### PR TITLE
fix(transform): preserve static values across runtime hazards

### DIFF
--- a/.changeset/static-processor-interpolation-exports.md
+++ b/.changeset/static-processor-interpolation-exports.md
@@ -2,4 +2,4 @@
 '@wyw-in-js/transform': patch
 ---
 
-Preserve static export resolution after safe processor-managed template interpolations.
+Preserve static values and styled runtime callbacks when unrelated runtime calls are present in the same module.

--- a/.changeset/static-processor-interpolation-exports.md
+++ b/.changeset/static-processor-interpolation-exports.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Preserve static export resolution after safe processor-managed template interpolations.

--- a/.changeset/static-processor-interpolation-exports.md
+++ b/.changeset/static-processor-interpolation-exports.md
@@ -2,4 +2,4 @@
 '@wyw-in-js/transform': patch
 ---
 
-Preserve static values and styled runtime callbacks when unrelated runtime calls or deferred function bodies are present in the same module.
+Preserve static values and processor replacements when runtime-only component code is removed during evaluation. Separate evaltime and runtime processor paths so removed code cannot poison static analysis, and reuse their shared analysis across both phases.

--- a/.changeset/static-processor-interpolation-exports.md
+++ b/.changeset/static-processor-interpolation-exports.md
@@ -2,4 +2,4 @@
 '@wyw-in-js/transform': patch
 ---
 
-Preserve static values and styled runtime callbacks when unrelated runtime calls are present in the same module.
+Preserve static values and styled runtime callbacks when unrelated runtime calls or deferred function bodies are present in the same module.

--- a/packages/transform/src/__tests__/oxc-collect-runtime.test.ts
+++ b/packages/transform/src/__tests__/oxc-collect-runtime.test.ts
@@ -19,6 +19,8 @@ import type {
   SyncScenarioForAction,
 } from '../transform/types';
 import { collectOxcRuntime } from '../utils/collectOxcRuntime';
+import { EventEmitter } from '../utils/EventEmitter';
+import { runOxcPreevalStage } from '../utils/oxcPreevalStage';
 
 const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
 const filename = join(__dirname, 'source.js');
@@ -74,6 +76,99 @@ const getHandlers = <TMode extends 'async' | 'sync'>(
 });
 
 describe('collectOxcRuntime', () => {
+  it('reports the runtime collect phase breakdown', () => {
+    const methods: string[] = [];
+    const eventEmitter = new EventEmitter(
+      (labels, type) => {
+        if (type === 'finish' && typeof labels.method === 'string') {
+          methods.push(labels.method);
+        }
+      },
+      () => 0,
+      () => {}
+    );
+
+    collectOxcRuntime(
+      dedent`
+        import { css } from 'test-css-processor';
+        export const className = css\`color: red;\`;
+      `,
+      filename,
+      __dirname,
+      { ...createOptions(), eventEmitter },
+      new Map()
+    );
+
+    expect(methods).toEqual(
+      expect.arrayContaining([
+        'transform:collect:applyProcessors',
+        'transform:collect:normalize',
+        'transform:collect:processorRuntime',
+        'transform:collect:sourceMap',
+      ])
+    );
+  });
+
+  it('reuses preeval analysis for runtime-only processors', () => {
+    const code = dedent`
+      import { css } from 'test-css-processor';
+      import { jsx as _jsx } from 'react/jsx-runtime';
+
+      const color = 'red';
+      export function Component() {
+        const className = css\`
+          color: ${'${color}'};
+        \`;
+
+        return _jsx('div', { className });
+      }
+    `;
+    const options = createOptions();
+    const preeval = runOxcPreevalStage(
+      code,
+      { filename, root: __dirname },
+      options
+    );
+    const direct = collectOxcRuntime(
+      code,
+      filename,
+      __dirname,
+      options,
+      preeval.staticValueCache
+    );
+    const methods: string[] = [];
+    const eventEmitter = new EventEmitter(
+      (labels, type) => {
+        if (type === 'finish' && typeof labels.method === 'string') {
+          methods.push(labels.method);
+        }
+      },
+      () => 0,
+      () => {}
+    );
+    const reused = collectOxcRuntime(
+      code,
+      filename,
+      __dirname,
+      { ...options, eventEmitter },
+      preeval.staticValueCache,
+      undefined,
+      preeval.runtimeProcessorPlan
+    );
+
+    expect(preeval.runtimeProcessorPlan).toBeDefined();
+    expect(reused.code).toBe(direct.code);
+    expect(reused.metadata?.processors).toHaveLength(1);
+    expect(methods).not.toEqual(
+      expect.arrayContaining([
+        'transform:collect:applyProcessors:deps',
+        'transform:collect:applyProcessors:imports',
+        'transform:collect:applyProcessors:usages',
+        'transform:collect:applyProcessors:usedNames',
+      ])
+    );
+  });
+
   it('builds processors and applies runtime replacement with evaluated values', () => {
     const result = collectOxcRuntime(
       dedent`

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -229,6 +229,45 @@ describe('runOxcPreevalStage', () => {
     expect(result.code).not.toContain('__wywPreval = { _exp: _exp }');
   });
 
+  it('ignores mutation hazards from component code removed before evaluation', () => {
+    const source = `
+      import { css } from 'test-package';
+      import { observer } from 'mobx-react-lite';
+      import * as tokens from './tokens';
+      import { jsx as _jsx } from 'react/jsx-runtime';
+
+      const Component = observer(() =>
+        _jsx('div', { children: tokens.runtime })
+      );
+
+      export const a = css\`
+        color: ${'${tokens.color}'};
+      \`;
+    `;
+    const enabled = runOxcPreevalStage(source, fileContext, options);
+    const disabled = runOxcPreevalStage(source, fileContext, {
+      ...options,
+      features: {
+        dangerousCodeRemover: false,
+      },
+    });
+
+    expect(enabled.staticValueCandidates).toEqual([
+      expect.objectContaining({
+        imports: [
+          expect.objectContaining({
+            imported: 'color',
+            source: './tokens',
+          }),
+        ],
+        source: expect.stringContaining('_wyw_static_tokens_color'),
+      }),
+    ]);
+    expect(disabled.staticValueCandidates).toEqual([
+      expect.objectContaining({ imports: [] }),
+    ]);
+  });
+
   it('still applies preeval syntax rewrites when no processors are present', () => {
     const result = runOxcPreevalStage(
       `

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -267,6 +267,39 @@ describe('runOxcPreevalStage', () => {
     });
   });
 
+  it('keeps processors in removed components runtime-only', () => {
+    const result = runOxcPreevalStage(
+      `
+        import { css } from 'test-package';
+        import { jsx as _jsx } from 'react/jsx-runtime';
+
+        const color = 'red';
+        export function Component() {
+          const className = css\`
+            color: ${'${color}'};
+          \`;
+
+          return _jsx('div', { className });
+        }
+      `,
+      fileContext,
+      options
+    );
+    const [processor] = result.metadata?.processors ?? [];
+    let evaltimeReplacementCalled = false;
+
+    expect(processor).toBeDefined();
+    processor!.doEvaltimeReplacement = () => {
+      evaltimeReplacementCalled = true;
+    };
+
+    result.finalizeEvaltimeReplacements?.(result.staticValueCache);
+
+    expect(evaltimeReplacementCalled).toBe(false);
+    expect(result.staticValueCache.get('_exp')).toBe('red');
+    expect(result.code).toContain('function Component() { return null; }');
+  });
+
   it('still applies preeval syntax rewrites when no processors are present', () => {
     const result = runOxcPreevalStage(
       `
@@ -298,7 +331,7 @@ describe('runOxcPreevalStage', () => {
       () => {}
     );
 
-    runOxcPreevalStage(
+    const result = runOxcPreevalStage(
       `
         import { css } from 'test-package';
         const href = window.location.href;
@@ -316,6 +349,7 @@ describe('runOxcPreevalStage', () => {
         eventEmitter,
       }
     );
+    result.finalizeEvaltimeReplacements?.(result.staticValueCache);
 
     expect(methods).toEqual(
       expect.arrayContaining([
@@ -333,6 +367,11 @@ describe('runOxcPreevalStage', () => {
         'transform:preeval:requireFallback',
       ])
     );
+    expect(
+      methods.filter(
+        (method) => method === 'transform:preeval:removeDangerousCode'
+      )
+    ).toHaveLength(1);
   });
 
   it('feeds Oxc shaker with __wywPreval-only prepared code', () => {

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -90,6 +90,12 @@ describe('runOxcPreevalStage', () => {
     );
 
     expect(result.staticValueCache.get('_exp')).toBe('red');
+    expect(result.staticPlanFacts).toEqual({
+      importedNeeds: [],
+      staticValueCount: 1,
+      unresolvedCount: 0,
+      usageCount: 1,
+    });
     expect(result.code).toContain('export const __wywPreval = {};');
     expect(result.code).not.toContain('__wywPreval = { _exp: _exp }');
   });

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -229,7 +229,7 @@ describe('runOxcPreevalStage', () => {
     expect(result.code).not.toContain('__wywPreval = { _exp: _exp }');
   });
 
-  it('ignores mutation hazards from component code removed before evaluation', () => {
+  it('ignores deferred component hazards before dangerous code removal', () => {
     const source = `
       import { css } from 'test-package';
       import { observer } from 'mobx-react-lite';
@@ -252,20 +252,19 @@ describe('runOxcPreevalStage', () => {
       },
     });
 
-    expect(enabled.staticValueCandidates).toEqual([
-      expect.objectContaining({
-        imports: [
-          expect.objectContaining({
-            imported: 'color',
-            source: './tokens',
-          }),
-        ],
-        source: expect.stringContaining('_wyw_static_tokens_color'),
-      }),
-    ]);
-    expect(disabled.staticValueCandidates).toEqual([
-      expect.objectContaining({ imports: [] }),
-    ]);
+    [enabled, disabled].forEach((result) => {
+      expect(result.staticValueCandidates).toEqual([
+        expect.objectContaining({
+          imports: [
+            expect.objectContaining({
+              imported: 'color',
+              source: './tokens',
+            }),
+          ],
+          source: expect.stringContaining('_wyw_static_tokens_color'),
+        }),
+      ]);
+    });
   });
 
   it('still applies preeval syntax rewrites when no processors are present', () => {

--- a/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 import { stripTypesAndJsxWithOxc } from '../utils/oxcEmit';
+import { removeDangerousCodeWithOxc } from '../utils/dangerousCodeRemoval';
 import {
   addRequireFallbackWithOxc,
-  removeDangerousCodeWithOxc,
   replaceImportMetaEnvWithOxc,
   rewriteDynamicImportsWithOxc,
 } from '../utils/oxcPreevalTransforms';

--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -160,7 +160,9 @@ describe('design-system chain repro for static eval strategy', () => {
         export const space = {
           s0: 0,
           s6: 6,
+          s10: 10,
           s12: 12,
+          s16: 16,
         } as const;
       `
     );
@@ -531,6 +533,107 @@ describe('design-system chain repro for static eval strategy', () => {
       expect(result.cssText).toContain('padding-left:24px');
       expect(result.cssText).toContain('margin-top:36px');
       expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines a cross-file scalar derived from a token re-exported by the design-system barrel', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-board-card-repro-'));
+    const dsDir = join(root, 'design-system');
+    const boardCellDir = join(root, 'board-cell');
+    const boardCardDir = join(root, 'board-card');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const boardCellFile = join(boardCellDir, 'styles.ts');
+    const entryFile = join(boardCardDir, 'styles.ts');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    require('fs').mkdirSync(boardCellDir, { recursive: true });
+    require('fs').mkdirSync(boardCardDir, { recursive: true });
+    const { barrelFile } = writeBarrelChain(root);
+
+    writeFileSync(
+      boardCellFile,
+      dedent`
+        import { space } from '@fibery/ui-kit/src/design-system';
+        import { css } from 'test-css-processor';
+
+        export const galleryModeStyle = css\`
+          gap: ${'${space.s16}'}px;
+        \`;
+
+        export const CARDS_GAP = space.s10;
+
+        export const style = css\`
+          display: flex;
+          gap: ${'${CARDS_GAP}'}px;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { CARDS_GAP } from '../board-cell/styles';
+
+        export const className = css\`
+          padding-top: ${'${CARDS_GAP / 2}'}px;
+          padding-right: ${'${CARDS_GAP / 2}'}px;
+          padding-bottom: ${'${CARDS_GAP / 2}'}px;
+          padding-left: ${'${CARDS_GAP / 2}'}px;
+        \`;
+      `
+    );
+
+    const resolver = async (what: string, importer: string) => {
+      if (what === 'test-css-processor') {
+        return processorFile;
+      }
+      if (what === '@fibery/ui-kit/src/design-system') {
+        return barrelFile;
+      }
+      if (what.startsWith('.')) {
+        const base = resolve(dirname(importer), what);
+        for (const ext of ['.ts', '.tsx', '.js']) {
+          const candidate = `${base}${ext}`;
+          if (existsSync(candidate) && statSync(candidate).isFile()) {
+            return candidate;
+          }
+        }
+        return base;
+      }
+      return null;
+    };
+
+    try {
+      const result = await transform(
+        {
+          cache,
+          eventEmitter: perf.eventEmitter,
+          options: {
+            filename: entryFile,
+            root,
+            pluginOptions: {
+              configFile: false,
+              eval: { strategy: 'static' },
+              tagResolver: (source, tag) =>
+                source === 'test-css-processor' && tag === 'css'
+                  ? processorFile
+                  : null,
+            },
+          },
+        },
+        readFileSync(entryFile, 'utf8'),
+        resolver
+      );
+
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+      expect(
+        result.cssText.match(/padding-(?:top|right|bottom|left):5px/g)
+      ).toHaveLength(4);
+      expect(result.code).not.toContain('CARDS_GAP');
+      expect(result.code).not.toContain('../board-cell/styles');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -938,6 +938,56 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('resolves a namespace member after removing component-only hazards', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const observerFile = join(root, 'observer.js');
+    const depFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      observerFile,
+      dedent`
+        export const observer = (component) => component;
+      `
+    );
+    writeFileSync(
+      depFile,
+      dedent`
+        export const runtime = 'runtime';
+        export const smallFontSize = { color: 'red' };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { observer } from './observer.js';
+        import * as tokens from './tokens.js';
+        import { jsx as _jsx } from 'react/jsx-runtime';
+
+        const Component = observer(() =>
+          _jsx('div', { children: tokens.runtime })
+        );
+
+        export const className = css\`
+          ${'${tokens.smallFontSize}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache, undefined, {
+        eval: { strategy: 'static' },
+      });
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(depFile);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines imported static values by default', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
@@ -3648,7 +3698,12 @@ describe('transform static import value inlining', () => {
     writeFileSync(
       buttonFile,
       dedent`
-        export const Button = () => null;
+        const Button = (props) => {
+          const kind = props.kind;
+          return kind ? null : null;
+        };
+
+        export { Button };
       `
     );
     writeFileSync(
@@ -3662,12 +3717,17 @@ describe('transform static import value inlining', () => {
           color: red;
         \`;
 
+        const Collapse = styled.button\`
+          transform: rotate(${"${props => (props.collapsed ? '-90deg' : '0deg')}"});
+        \`;
+
         const Clickable = css\`
           cursor: pointer;
         \`;
 
         export const Styles = {
           CloseButton,
+          Collapse,
           Clickable,
         };
       `

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -6061,4 +6061,37 @@ describe('transform static import value inlining', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('extracts runtime processors from components removed from evaltime', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-component-'));
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { jsx as _jsx } from 'react/jsx-runtime';
+
+        const color = 'red';
+        export function Component() {
+          const className = css\`
+            color: ${'${color}'};
+          \`;
+
+          return _jsx('div', { className });
+        }
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.code).toContain('function Component()');
+      expect(result.code).not.toContain('test-css-processor');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/__tests__/transform.static-runtime-hazards.test.ts
+++ b/packages/transform/src/__tests__/transform.static-runtime-hazards.test.ts
@@ -1,0 +1,245 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+
+const cssProcessorFile = join(
+  __dirname,
+  '__fixtures__',
+  'test-css-processor.js'
+);
+const styledProcessorFile = join(
+  __dirname,
+  '__fixtures__',
+  'test-styled-processor.js'
+);
+
+const resolver = async (what: string, importer: string) => {
+  if (what === 'test-css-processor') {
+    return cssProcessorFile;
+  }
+  if (what === 'test-styled-processor') {
+    return styledProcessorFile;
+  }
+  if (!what.startsWith('.')) {
+    return null;
+  }
+
+  const base = resolve(dirname(importer), what);
+  for (const extension of ['', '.ts', '.tsx', '.js']) {
+    const candidate = `${base}${extension}`;
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return base;
+};
+
+const runStatic = (root: string, entryFile: string) =>
+  transform(
+    {
+      cache: new TransformCacheCollection(),
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          eval: { strategy: 'static' },
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return cssProcessorFile;
+            }
+            if (source === 'test-styled-processor' && tag === 'styled') {
+              return styledProcessorFile;
+            }
+            return null;
+          },
+        },
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    resolver
+  );
+
+describe('static strategy runtime hazard regressions', () => {
+  it('resolves an imported member after an unrelated runtime call', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-runtime-call-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      dedent`
+        export const tokens = {
+          first: 'red',
+          second: 'blue',
+        } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import runtime from 'runtime-only';
+        import { tokens } from './tokens';
+
+        export function render() {
+          const first = css\`
+            color: ${'${tokens.first}'};
+          \`;
+          runtime(first);
+          return css\`
+            color: ${'${tokens.second}'};
+          \`;
+        }
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('color:blue');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an import in a binary expression after a runtime wrapper', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-binary-call-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      `export const tokens = { gap: 8 } as const;`
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import runtime from 'runtime-only';
+        import { tokens } from './tokens';
+
+        const width = 32;
+
+        export const first = css\`
+          gap: ${'${tokens.gap}'}px;
+        \`;
+
+        export const component = runtime(function Component(props) {
+          return runtime(first, props.className);
+        });
+
+        export const second = css\`
+          width: ${'${width + tokens.gap}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('gap:8px');
+      expect(result.cssText).toContain('width:40px');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a static export after a derived value helper call', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-helper-call-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      dedent`
+        export const tokens = {
+          accent: 'purple',
+          border: 'gray',
+        } as const;
+      `
+    );
+    writeFileSync(
+      join(root, 'effects.ts'),
+      dedent`
+        import { tokens } from './tokens';
+
+        function withAlpha(value, alpha) {
+          return value + ' ' + Math.round(alpha * 100) + '%';
+        }
+
+        export const accentWithAlpha = withAlpha(tokens.accent, 0.7);
+        export const effects = {
+          border: '1px solid ' + tokens.border,
+        } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { effects } from './effects';
+
+        export const className = css\`
+          border: ${'${effects.border}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('border:1px solid gray');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps transitive styled callbacks as runtime values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-callback-repro-'));
+    const entryFile = join(root, 'entry.js');
+
+    writeFileSync(
+      join(root, 'colors.js'),
+      `export const colors = { active: 'green', idle: 'gray' };`
+    );
+    writeFileSync(join(root, 'layout.js'), `export const layout = { gap: 2 };`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { colors } from './colors.js';
+        import { layout } from './layout.js';
+
+        const resolveColor = (active) =>
+          active ? colors.active : colors.idle;
+        const getColor = (props) => resolveColor(props.active);
+        const getBackground = (props) => resolveColor(!props.active);
+
+        export const Root = styled.div\`
+          padding: ${'${layout.gap}'}px;
+          color: ${'${getColor}'};
+          background: ${'${getBackground}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('padding:2px');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-runtime-hazards.test.ts
+++ b/packages/transform/src/__tests__/transform.static-runtime-hazards.test.ts
@@ -280,6 +280,91 @@ describe('static strategy runtime hazard regressions', () => {
     }
   });
 
+  it('ignores same-import reads inside runtime-only function bodies', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-same-import-runtime-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      dedent`
+        export const tokens = {
+          runtimeLabel: 'runtime',
+          gap: 8,
+        } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import runtime from 'runtime-only';
+        import { tokens } from './tokens';
+
+        export function render() {
+          return runtime(tokens.runtimeLabel);
+        }
+
+        export const className = css\`
+          gap: ${'${tokens.gap}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('gap:8px');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores read-only captures passed to a runtime-only top-level wrapper', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-wrapper-capture-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      dedent`
+        export const colors = {
+          runtime: 'red',
+          static: 'blue',
+        } as const;
+        export const layout = { gap: 8 } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import memoize from 'runtime-only';
+        import { colors, layout } from './tokens';
+
+        const getRuntimeStyle = memoize(() => ({
+          color: colors.runtime,
+        }));
+
+        export function render() {
+          return getRuntimeStyle();
+        }
+
+        export const className = css\`
+          color: ${'${colors.static}'};
+          gap: ${'${layout.gap}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('color:blue');
+      expect(result.cssText).toContain('gap:8px');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps transitive styled callbacks as runtime values', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-callback-repro-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-runtime-hazards.test.ts
+++ b/packages/transform/src/__tests__/transform.static-runtime-hazards.test.ts
@@ -205,6 +205,81 @@ describe('static strategy runtime hazard regressions', () => {
     }
   });
 
+  it('resolves a sibling import after a statically pure helper call', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-sibling-call-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      dedent`
+        export const runtimeLabel = 'runtime';
+        export const tokens = { gap: 8 } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { runtimeLabel, tokens } from './tokens';
+
+        function getRuntimeLabel() {
+          return runtimeLabel;
+        }
+
+        getRuntimeLabel();
+
+        export const className = css\`
+          gap: ${'${tokens.gap}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('gap:8px');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores sibling-import escapes inside runtime-only function bodies', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-sibling-runtime-repro-'));
+    const entryFile = join(root, 'entry.ts');
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      dedent`
+        export const runtimeLabel = 'runtime';
+        export const tokens = { gap: 8 } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import runtime from 'runtime-only';
+        import { runtimeLabel, tokens } from './tokens';
+
+        export function render() {
+          return runtime(runtimeLabel);
+        }
+
+        export const className = css\`
+          gap: ${'${tokens.gap}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runStatic(root, entryFile);
+
+      expect(result.cssText).toContain('gap:8px');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps transitive styled callbacks as runtime values', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-callback-repro-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -6,7 +6,10 @@ import type {
 
 import type { Services } from './types';
 import type { WYWTransformMetadata } from '../utils/TransformMetadata';
-import type { StaticPlanFacts } from '../utils/applyOxcProcessors/types';
+import type {
+  OxcProcessorAnalysisPlan,
+  StaticPlanFacts,
+} from '../utils/applyOxcProcessors/types';
 
 export type ParsedAst = unknown;
 
@@ -42,6 +45,7 @@ export interface IPreevalResult {
   ) => void;
   metadata: WYWTransformMetadata | null;
   processorClassNames?: Record<string, string>;
+  runtimeProcessorPlan?: OxcProcessorAnalysisPlan;
   staticImportLocals?: string[];
   staticSideEffectImportLocals?: string[];
   staticDependencies?: string[];

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -6,6 +6,7 @@ import type {
 
 import type { Services } from './types';
 import type { WYWTransformMetadata } from '../utils/TransformMetadata';
+import type { StaticPlanFacts } from '../utils/applyOxcProcessors/types';
 
 export type ParsedAst = unknown;
 
@@ -45,6 +46,7 @@ export interface IPreevalResult {
   staticSideEffectImportLocals?: string[];
   staticDependencies?: string[];
   staticNullWYWMetaExtendsHelpers?: string[];
+  staticPlanFacts?: StaticPlanFacts;
   staticValuesApplied?: boolean;
   staticValueCache?: Map<string, unknown>;
   runtimeOnlyStaticValueNames?: string[];

--- a/packages/transform/src/transform/generators/__tests__/transform.static-plan-debug.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/transform.static-plan-debug.test.ts
@@ -27,7 +27,7 @@ describe('emitCurrentStaticPlanDebug', () => {
     expect(entrypointRead).toBe(false);
   });
 
-  it('builds and emits the plan for a legacy listener', () => {
+  it('emits cached attribution without reparsing the source', () => {
     const events: Record<string, unknown>[] = [];
     const eventEmitter = new EventEmitter(
       (labels, type) => {
@@ -38,12 +38,26 @@ describe('emitCurrentStaticPlanDebug', () => {
       () => 0,
       () => {}
     );
-    const code = `export const color = 'red';`;
     const action = {
       entrypoint: {
-        getPreevalResult: () => ({ ast: null, code, metadata: null }),
+        getPreevalResult: () => ({
+          ast: null,
+          code: '',
+          dependencyNames: ['_exp2'],
+          metadata: null,
+          staticDependencies: ['./runtime.css'],
+          staticPlanFacts: {
+            importedNeeds: [{ name: 'color', source: './tokens' }],
+            staticValueCount: 1,
+            unresolvedCount: 1,
+            usageCount: 2,
+          },
+          staticValueCache: new Map([['_exp', 'red']]),
+        }),
         loadedAndParsed: {
-          code,
+          get code(): never {
+            throw new Error('source should not be reparsed');
+          },
           evalConfig: { filename },
           evaluator: () => {},
         },
@@ -55,10 +69,25 @@ describe('emitCurrentStaticPlanDebug', () => {
       },
     } as unknown as ITransformAction;
 
-    emitCurrentStaticPlanDebug(action, null);
+    emitCurrentStaticPlanDebug(
+      action,
+      new Map([
+        ['./runtime.css', ['side-effect']],
+        ['./runtime.js', ['default']],
+      ])
+    );
 
     expect(events).toEqual([
-      expect.objectContaining({ filename, type: 'staticPlan' }),
+      expect.objectContaining({
+        filename,
+        needCount: 2,
+        needRequestCount: 2,
+        runtimeDependencyCount: 2,
+        staticValueCount: 1,
+        type: 'staticPlan',
+        unresolvedCount: 1,
+        usageCount: 2,
+      }),
     ]);
   });
 });

--- a/packages/transform/src/transform/generators/collect.ts
+++ b/packages/transform/src/transform/generators/collect.ts
@@ -32,6 +32,7 @@ export function* collect(
     options.root ?? process.cwd(),
     {
       ...options.pluginOptions,
+      eventEmitter: this.services.eventEmitter,
       preserveSideEffectImportOrderLocals: new Set(
         preevalResult?.staticImportLocals ?? []
       ),
@@ -40,7 +41,8 @@ export function* collect(
       ),
     },
     prevalPayload.values,
-    options.inputSourceMap
+    options.inputSourceMap,
+    preevalResult?.runtimeProcessorPlan
   );
 
   return {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/exportResolver.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/exportResolver.ts
@@ -496,7 +496,8 @@ export function* resolveStaticExport(
       start: target.expression.start,
     },
     env,
-    getStaticBindings(action)
+    getStaticBindings(action),
+    sourcePreevalForExpression?.processorManagedExpressionSpans
   );
   if (!isOxcStaticSerializableValue(value)) {
     const metadataResult = yield* resolveProcessorStaticExport(

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/processorStaticExport.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/processorStaticExport.ts
@@ -3,6 +3,7 @@
 import type { Program } from 'oxc-parser';
 
 import {
+  createOxcStaticCallableValue,
   evaluateOxcStaticExpression,
   evaluateOxcStaticExpressionAt,
   isOxcStaticSerializableValue,
@@ -17,7 +18,10 @@ import {
   parseProgram,
 } from './environment';
 import { findExportTarget } from './exportTargets';
-import { collectOpaqueRuntimeImportProof } from './opaqueRuntime';
+import {
+  collectOpaqueRuntimeImportProof,
+  resolveImportAsOpaqueRuntime,
+} from './opaqueRuntime';
 import {
   mergeStaticObjectAssignAliases,
   objectAssignAliasExpressionsForTarget,
@@ -27,6 +31,7 @@ import {
 import { prepareProcessorTarget } from './processorTarget';
 import {
   collectProcessorImportLocals,
+  collectWYWMetaExtendsHelperNames,
   isKnownProcessorClassValue,
   isProcessorClassValue,
   isSelectorOnlyProcessorValue,
@@ -36,7 +41,11 @@ import {
   type StaticProcessorInstance,
 } from './processorStaticModel';
 import { bindStaticResolvedValue } from './staticExpression';
-import type { StaticExportResolverContext, StaticExportResult } from './types';
+import type {
+  OpaqueRuntimeImportProof,
+  StaticExportResolverContext,
+  StaticExportResult,
+} from './types';
 
 type StaticMetadataPreevalResult = NonNullable<
   ReturnType<typeof getStaticMetadataPreevalResult>
@@ -76,16 +85,58 @@ function* resolvePreevalStaticValueCandidates(
   preevalResult: StaticMetadataPreevalResult,
   stack: Set<string>,
   memo: Map<string, StaticExportResult | null>,
-  resolvers: StaticExportResolverContext
+  resolvers: StaticExportResolverContext,
+  opaqueRuntimeBaseHelpers: ReadonlySet<string> = new Set()
 ): SyncScenarioFor<StaticCandidateResolution> {
   const dependencies = new Set<string>();
   const sideEffectDependencies = new Set<string>();
   const staticValueCache =
     preevalResult.staticValueCache ?? new Map<string, unknown>();
+  const opaqueRuntimeMemo = new Map<string, OpaqueRuntimeImportProof | null>();
 
   for (const candidate of preevalResult.staticValueCandidates ?? []) {
     if (staticValueCache.has(candidate.name)) {
       continue;
+    }
+
+    if (
+      opaqueRuntimeBaseHelpers.has(candidate.name) &&
+      candidate.imports.length > 0
+    ) {
+      const opaqueDependencies = new Set<string>();
+      let resolvedOpaqueRuntimeBase = true;
+      for (const binding of candidate.imports) {
+        const proof = yield* resolveImportAsOpaqueRuntime(
+          action,
+          filename,
+          binding,
+          new Set(),
+          opaqueRuntimeMemo
+        );
+        if (!proof) {
+          resolvedOpaqueRuntimeBase = false;
+          break;
+        }
+
+        proof.dependencies.forEach((dependency) =>
+          opaqueDependencies.add(dependency)
+        );
+      }
+
+      if (resolvedOpaqueRuntimeBase) {
+        staticValueCache.set(candidate.name, null);
+        opaqueDependencies.forEach((dependency) =>
+          dependencies.add(dependency)
+        );
+        debugStaticResolve(action, {
+          candidate: candidate.name,
+          filename,
+          phase: 'candidate',
+          reason: 'opaque-runtime-component',
+          status: 'resolved',
+        });
+        continue;
+      }
     }
 
     const env = new Map<string, unknown>();
@@ -201,6 +252,26 @@ export function* resolveProcessorStaticExport(
     resolvers
   );
   preevalResult.finalizeEvaltimeReplacements?.(preevalResult.staticValueCache);
+
+  const opaqueRuntimeBaseHelpers = collectWYWMetaExtendsHelperNames(
+    parseProgram(preevalResult.baseCode, filename)
+  );
+  const finalizedCandidateResolution =
+    yield* resolvePreevalStaticValueCandidates(
+      action,
+      filename,
+      preevalResult,
+      stack,
+      memo,
+      resolvers,
+      opaqueRuntimeBaseHelpers
+    );
+  finalizedCandidateResolution.dependencies.forEach((dependency) =>
+    staticCandidateResolution.dependencies.add(dependency)
+  );
+  finalizedCandidateResolution.sideEffectDependencies.forEach((dependency) =>
+    staticCandidateResolution.sideEffectDependencies.add(dependency)
+  );
 
   if (!preevalResult.metadata) {
     debugStaticResolve(action, {
@@ -348,6 +419,15 @@ export function* resolveProcessorStaticExport(
       sideEffectDependencies.add(dependency)
     );
   }
+
+  opaqueRuntimeBaseHelpers.forEach((name) => {
+    if (preevalResult.staticValueCache?.has(name)) {
+      env.set(
+        name,
+        createOxcStaticCallableValue(preevalResult.staticValueCache.get(name))
+      );
+    }
+  });
 
   const value =
     preparedTarget.evaluationCode && preparedTarget.evaluationSpan

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -152,6 +152,7 @@ const ensureOxcPreevalResult = (
       evalCode: result.code,
       metadata: result.metadata,
       processorClassNames: result.processorClassNames,
+      runtimeProcessorPlan: result.runtimeProcessorPlan,
       staticImportLocals: [],
       staticSideEffectImportLocals: [],
       staticDependencies: result.staticDependencies,

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -17,7 +17,7 @@ import type {
 } from '../types';
 
 import {
-  buildStaticPlan,
+  buildStaticPlanAttribution,
   emitStaticPlanDebug,
 } from '../static-plan/buildStaticPlan';
 import { rewriteOptimizedOxcBarrelImports } from './rewriteOxcBarrelImports';
@@ -79,21 +79,23 @@ export const emitCurrentStaticPlanDebug = (
   }
 
   const preevalResult = action.entrypoint.getPreevalResult();
-  if (!preevalResult) {
+  if (!preevalResult?.staticPlanFacts) {
     return;
   }
 
   const filename =
     loadedAndParsed.evalConfig.filename ?? action.entrypoint.name;
-  const plan = buildStaticPlan({
-    code: loadedAndParsed.code,
+  const attribution = buildStaticPlanAttribution({
     filename,
-    options: action.services.options.pluginOptions,
     preparedImports: imports,
     preevalResult,
+    staticPlanFacts: preevalResult.staticPlanFacts,
   });
 
-  emitStaticPlanDebug(action.services.eventEmitter, plan);
+  emitStaticPlanDebug(action.services.eventEmitter, {
+    attribution,
+    filename,
+  });
 };
 
 type PrepareCodeOptions = {
@@ -153,6 +155,7 @@ const ensureOxcPreevalResult = (
       staticImportLocals: [],
       staticSideEffectImportLocals: [],
       staticDependencies: result.staticDependencies,
+      staticPlanFacts: result.staticPlanFacts,
       staticValuesApplied: false,
       staticValueCache: result.staticValueCache,
       staticValueCandidates: result.staticValueCandidates,

--- a/packages/transform/src/transform/static-plan/__tests__/buildStaticPlan.test.ts
+++ b/packages/transform/src/transform/static-plan/__tests__/buildStaticPlan.test.ts
@@ -2,7 +2,11 @@
 import type { ProcessorStaticValue } from '@wyw-in-js/processor-utils';
 
 import { EventEmitter } from '../../../utils/EventEmitter';
-import { buildStaticPlan, emitStaticPlanDebug } from '../buildStaticPlan';
+import {
+  buildStaticPlan,
+  buildStaticPlanAttribution,
+  emitStaticPlanDebug,
+} from '../buildStaticPlan';
 import type { StaticEnv } from '../types';
 
 const filename = '/project/src/entry.tsx';
@@ -25,6 +29,45 @@ const cssTemplateSemantics = {
 };
 
 describe('buildStaticPlan', () => {
+  it('combines cached plan facts with settled static state', () => {
+    const attribution = buildStaticPlanAttribution({
+      filename,
+      preparedImports: new Map([
+        ['./runtime.css', ['side-effect']],
+        ['./runtime.js', ['default']],
+      ]),
+      preevalResult: {
+        dependencyNames: [
+          'resolved',
+          'runtimeOnly',
+          'unresolved',
+          'unresolved',
+        ],
+        runtimeOnlyStaticValueNames: ['runtimeOnly'],
+        staticDependencies: ['./runtime.css'],
+        staticValueCache: new Map([['resolved', 'red']]),
+      },
+      staticPlanFacts: {
+        importedNeeds: [
+          { name: 'color', source: './tokens' },
+          { name: 'color', source: './tokens' },
+        ],
+        staticValueCount: 1,
+        unresolvedCount: 1,
+        usageCount: 2,
+      },
+    });
+
+    expect(attribution).toEqual({
+      needCount: 2,
+      needRequestCount: 2,
+      runtimeDependencyCount: 2,
+      staticValueCount: 1,
+      unresolvedCount: 1,
+      usageCount: 2,
+    });
+  });
+
   it('ignores imports that do not resolve to a processor implementation', () => {
     // Helper modules (e.g. a preeval runtime) import plain functions and call
     // them with values derived from function parameters. Those imports must

--- a/packages/transform/src/transform/static-plan/buildStaticPlan.ts
+++ b/packages/transform/src/transform/static-plan/buildStaticPlan.ts
@@ -61,6 +61,19 @@ export type BuildStaticPlanInput = {
   staticBindings?: StaticBindings;
 };
 
+export type BuildStaticPlanAttributionInput = {
+  filename: string;
+  preparedImports?: Map<string, string[]> | null;
+  preevalResult: Pick<
+    IPreevalResult,
+    | 'dependencyNames'
+    | 'runtimeOnlyStaticValueNames'
+    | 'staticDependencies'
+    | 'staticValueCache'
+  >;
+  staticPlanFacts: NonNullable<IPreevalResult['staticPlanFacts']>;
+};
+
 const PLAN_ONLY_PROCESSOR =
   class StaticPlanOnlyProcessor {} as unknown as DefinedProcessor[0];
 
@@ -321,9 +334,45 @@ export const buildStaticPlan = ({
   };
 };
 
+export const buildStaticPlanAttribution = ({
+  filename,
+  preparedImports,
+  preevalResult,
+  staticPlanFacts,
+}: BuildStaticPlanAttributionInput): StaticPlan['attribution'] => {
+  const importedNeeds: StaticNeed[] = staticPlanFacts.importedNeeds.map(
+    ({ name, source }) => ({
+      importer: filename,
+      kind: 'export',
+      name,
+      reason: 'processor-static-interpolation',
+      source,
+    })
+  );
+  const evalNeeds = resolveUnmetStaticNeeds({
+    filename,
+    resolvedNames: new Set(preevalResult.staticValueCache?.keys() ?? []),
+    runtimeOnlyNames: new Set(preevalResult.runtimeOnlyStaticValueNames ?? []),
+    unresolvedNames: preevalResult.dependencyNames ?? [],
+  });
+  const needs = dedupeNeeds([...importedNeeds, ...evalNeeds]);
+
+  return {
+    needCount: needs.length,
+    needRequestCount: planStaticNeedRequests(needs).length,
+    runtimeDependencyCount: collectRuntimeDependencies(
+      preparedImports,
+      preevalResult
+    ).size,
+    staticValueCount: staticPlanFacts.staticValueCount,
+    unresolvedCount: staticPlanFacts.unresolvedCount,
+    usageCount: staticPlanFacts.usageCount,
+  };
+};
+
 export const emitStaticPlanDebug = (
   eventEmitter: EventEmitter,
-  plan: StaticPlan
+  plan: Pick<StaticPlan, 'attribution' | 'filename'>
 ): void => {
   if (!eventEmitter.hasEventListener('staticPlan')) {
     return;

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -4,6 +4,7 @@ import dedent from 'dedent';
 import {
   collectOxcExpressionDependencies,
   collectOxcTemplateDependencies,
+  evaluateOxcStaticExpressionAt,
 } from '../collectOxcTemplateDependencies';
 import {
   analyzeProgram,
@@ -762,6 +763,68 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     expect(result.staticValues).toEqual([]);
     expect(result.staticValueCandidates).toHaveLength(1);
     expect(result.staticValueCandidates[0]?.source).toContain('=> width');
+  });
+
+  it('evaluates a later imported member after a processor-managed scalar interpolation', () => {
+    const code = dedent`
+      import { source } from './tokens';
+
+      processor\`${'${source.height}'}\`;
+      source.width;
+    `;
+    const processorStart = code.indexOf('processor`');
+    const processorEnd = code.indexOf('`;', processorStart) + 1;
+    const expressionStart = code.lastIndexOf('source.width');
+
+    expect(
+      evaluateOxcStaticExpressionAt(
+        code,
+        filename,
+        {
+          end: expressionStart + 'source.width'.length,
+          start: expressionStart,
+        },
+        new Map([['source', { height: 16, width: 304 }]]),
+        undefined,
+        [
+          {
+            end: processorEnd,
+            start: processorStart,
+          },
+        ]
+      )
+    ).toBe(304);
+  });
+
+  it('keeps a nested call hazardous while evaluating after a processor-managed interpolation', () => {
+    const code = dedent`
+      import { mutate, source } from './tokens';
+
+      processor\`${'${mutate(source)}'}\`;
+      source.width;
+    `;
+    const processorStart = code.indexOf('processor`');
+    const processorEnd = code.indexOf('`;', processorStart) + 1;
+    const expressionStart = code.lastIndexOf('source.width');
+
+    expect(
+      evaluateOxcStaticExpressionAt(
+        code,
+        filename,
+        {
+          end: expressionStart + 'source.width'.length,
+          start: expressionStart,
+        },
+        new Map([['source', { width: 304 }]]),
+        undefined,
+        [
+          {
+            end: processorEnd,
+            start: processorStart,
+          },
+        ]
+      )
+    ).toBeUndefined();
   });
 
   it('preserves a nested call hazard seed inside a processor-managed interpolation', () => {

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -651,29 +651,79 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     ['a bare unresolved identifier', 'const alias = current;'],
     ['an identifier-free member root', 'const alias = ({}).current;'],
     ['a this member root', 'const alias = this.current;'],
-    [
-      'a super member root',
+  ])('treats %s as unproven alias provenance', (_description, declaration) => {
+    expectWidthFallback(dedent`
+        import { source } from './tokens';
+
+        ${declaration}
+        alias.width = 400;
+        const { width } = source;
+        const template = tag\`${'${width}'}\`;
+      `);
+  });
+
+  it('does not execute uncalled class method provenance', () => {
+    const result = collectOxcTemplateDependencies(
       dedent`
+        import { source } from './tokens';
+
         class Holder extends Base {
           mutate() {
             const alias = super.current;
             alias.width = 400;
           }
         }
-      `,
-    ],
-  ])('treats %s as unproven alias provenance', (_description, declaration) => {
-    const mutation = declaration.includes('class Holder')
-      ? ''
-      : 'alias.width = 400;';
-    expectWidthFallback(dedent`
-        import { source } from './tokens';
-
-        ${declaration}
-        ${mutation}
         const { width } = source;
         const template = tag\`${'${width}'}\`;
-      `);
+      `,
+      filename,
+      true
+    );
+
+    expect(result.staticValueCandidates).toEqual([
+      expect.objectContaining({
+        imports: [
+          {
+            imported: 'source',
+            local: 'source',
+            source: './tokens',
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it('publishes unproven provenance when its function is called', () => {
+    expectWidthFallback(dedent`
+      import { source } from './tokens';
+
+      function mutate() {
+        const alias = registry.source;
+        alias.width = 400;
+      }
+      mutate();
+      const { width } = source;
+      const template = tag\`${'${width}'}\`;
+    `);
+  });
+
+  it('treats parent-container effects as possible before deferred reads', () => {
+    const result = collectOxcTemplateDependencies(
+      dedent`
+        import { source } from './tokens';
+
+        function render() {
+          return tag\`${'${source.width}'}\`;
+        }
+        mutate(source);
+        render();
+      `,
+      filename,
+      true
+    );
+
+    expect(result.staticValueCandidates).toEqual([]);
+    expect(result.dependencyNames).toEqual(['source']);
   });
 
   it.each(['holder.alias', 'holder[0]'])(

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -796,6 +796,91 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     ).toBe(304);
   });
 
+  it('does not propagate a processor result escape back to its interpolation', () => {
+    const code = dedent`
+      import runtime from 'runtime-only';
+      import { source } from './tokens';
+
+      const className = processor\`${'${source.height}'}\`;
+      runtime(className);
+      source.width;
+    `;
+    const processorStart = code.indexOf('processor`');
+    const processorEnd = code.indexOf('`;', processorStart) + 1;
+    const expressionStart = code.lastIndexOf('source.width');
+
+    expect(
+      evaluateOxcStaticExpressionAt(
+        code,
+        filename,
+        {
+          end: expressionStart + 'source.width'.length,
+          start: expressionStart,
+        },
+        new Map([['source', { height: 16, width: 304 }]]),
+        undefined,
+        [
+          {
+            end: processorEnd,
+            start: processorStart,
+          },
+        ]
+      )
+    ).toBe(304);
+  });
+
+  it('uses resolved scalar imports to prove a local helper call pure', () => {
+    const code = dedent`
+      import { tokens } from './tokens';
+
+      function withAlpha(value, alpha) {
+        return value + ' ' + Math.round(alpha * 100) + '%';
+      }
+
+      withAlpha(tokens.accent, 0.7);
+      tokens.border;
+    `;
+    const expressionStart = code.lastIndexOf('tokens.border');
+
+    expect(
+      evaluateOxcStaticExpressionAt(
+        code,
+        filename,
+        {
+          end: expressionStart + 'tokens.border'.length,
+          start: expressionStart,
+        },
+        new Map([['tokens', { accent: 'purple', border: 'gray' }]])
+      )
+    ).toBe('gray');
+  });
+
+  it('classifies a referenced local function without evaluating its body', () => {
+    const code = dedent`
+      const resolve = (props) => runtime(props.value);
+      const callback = (props) => resolve(props);
+      processor\`${'${callback}'}\`;
+    `;
+    const processorStart = code.indexOf('processor`');
+    const templateStart = processorStart + 'processor'.length;
+    const processorEnd = code.indexOf('`;', processorStart) + 1;
+    const result = collectOxcTemplateDependencies(
+      code,
+      filename,
+      true,
+      [{ end: processorEnd, start: templateStart }],
+      undefined,
+      [{ end: processorEnd, start: processorStart }]
+    );
+
+    expect(result.staticValueCandidates).toEqual([
+      expect.objectContaining({
+        imports: [],
+        source: '(props) => resolve(props)',
+      }),
+    ]);
+  });
+
   it('keeps a nested call hazardous while evaluating after a processor-managed interpolation', () => {
     const code = dedent`
       import { mutate, source } from './tokens';

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -730,6 +730,18 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     }
   );
 
+  it('propagates a sibling-import escape from a synchronous IIFE', () => {
+    expectLastWidthTemplateFallback(dedent`
+      import { alias, source } from './tokens';
+
+      (function mutateImmediately() {
+        mutate(alias);
+      })();
+      const { width } = source;
+      const template = tag\`${'${width}'}\`;
+    `);
+  });
+
   it('ignores interpolation provenance inside a processor-managed tag', () => {
     const code = dedent`
       import { alias, source } from './tokens';

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -4,6 +4,7 @@ import type { ExpressionValue, StrictOptions } from '@wyw-in-js/shared';
 import { collectOxcProcessorImportsFromProgram } from '../collectOxcExportsAndImports';
 import { collectOxcExpressionDependencies } from '../collectOxcTemplateDependencies';
 import type { OxcStaticValue } from '../collectOxcTemplateDependencies';
+import type { DangerousCodePlan } from '../dangerousCodeRemoval';
 import {
   collectOxcExpressionDependenciesForEvalFallback,
   OxcSnapshotWriteUnsupportedError,
@@ -11,7 +12,7 @@ import {
 import { EventEmitter } from '../EventEmitter';
 import type { AddedImport } from '../oxcAstService';
 import { isOxcNode } from '../oxc/ast';
-import { applyOxcReplacements } from '../oxc/replacements';
+import { applyOxcReplacementLayers } from '../oxc/replacements';
 import {
   buildOxcCodeFrameError,
   createOxcLocationLookup,
@@ -64,11 +65,10 @@ export const applyOxcProcessors = (
     | 'staticBindings'
     | 'tagResolver'
   > & {
+    createEvaltimeCodePlan?: (
+      processorSpans: Array<{ end: number; start: number }>
+    ) => DangerousCodePlan;
     eventEmitter?: EventEmitter;
-    getMutationHazardIgnoreTreeSpans?: () => Array<{
-      end: number;
-      start: number;
-    }>;
     preserveSideEffectImportOrderLocals?: Set<string>;
     preserveSideEffectImportLocals?: Set<string>;
   },
@@ -80,8 +80,24 @@ export const applyOxcProcessors = (
   const eventEmitter = options.eventEmitter ?? EventEmitter.dummy;
   const collectStaticExpressionValues =
     shouldCollectStaticExpressionValues(options);
-  let workingCode = code;
-  let program = parseOxc(workingCode, filename);
+  const workingCode = code;
+  const program = parseOxc(workingCode, filename);
+  let evaltimeCodePlan: DangerousCodePlan | null = null;
+  const getEvaltimeCodePlan = (
+    processorSpans: Array<{ end: number; start: number }> = []
+  ): DangerousCodePlan => {
+    evaltimeCodePlan ??= options.createEvaltimeCodePlan?.(processorSpans) ?? {
+      removedSpans: [],
+      replacements: [],
+      runtimeOnlyProcessorSpans: [],
+    };
+
+    return evaltimeCodePlan;
+  };
+  const buildUnprocessedCode = () =>
+    applyOxcReplacementLayers(workingCode, [
+      getEvaltimeCodePlan().replacements,
+    ]);
   const definedProcessors = new Map<string, DefinedProcessor>();
   const removableImportLocals = new Set<string>();
   const removableExpressionRefs = new Set<string>();
@@ -134,7 +150,7 @@ export const applyOxcProcessors = (
 
   if (definedProcessors.size === 0) {
     return {
-      code: workingCode,
+      code: buildUnprocessedCode(),
       processorManagedExpressionSpans: [],
       processorClassNamesByLocal: new Map(),
       processors: [],
@@ -143,13 +159,13 @@ export const applyOxcProcessors = (
     };
   }
 
-  let processorUsages = eventEmitter.perf(
+  const processorUsages = eventEmitter.perf(
     'transform:preeval:processTemplate:usages',
     () => collectProcessorUsages(program, definedProcessors)
   );
   if (processorUsages.length === 0) {
     return {
-      code: workingCode,
+      code: buildUnprocessedCode(),
       processorManagedExpressionSpans: [],
       processorClassNamesByLocal: new Map(),
       processors: [],
@@ -165,8 +181,11 @@ export const applyOxcProcessors = (
     end: usage.target.end,
     start: usage.target.start,
   }));
-  const mutationHazardIgnoreTreeSpans =
-    options.getMutationHazardIgnoreTreeSpans?.() ?? [];
+  const {
+    removedSpans: evaltimeRemovedSpans,
+    replacements: evaltimeCodeReplacements,
+    runtimeOnlyProcessorSpans,
+  } = getEvaltimeCodePlan(processorManagedExpressionSpans);
   const extractDependencies = () => {
     try {
       return collectOxcExpressionDependencies(
@@ -176,7 +195,7 @@ export const applyOxcProcessors = (
         targetExpressionSpans,
         options.staticBindings,
         processorManagedExpressionSpans,
-        mutationHazardIgnoreTreeSpans
+        evaltimeRemovedSpans
       );
     } catch (error) {
       if (!(error instanceof OxcSnapshotWriteUnsupportedError)) {
@@ -188,7 +207,7 @@ export const applyOxcProcessors = (
         filename,
         targetExpressionSpans,
         processorManagedExpressionSpans,
-        mutationHazardIgnoreTreeSpans
+        evaltimeRemovedSpans
       );
     }
   };
@@ -202,21 +221,10 @@ export const applyOxcProcessors = (
           code: workingCode,
           dependencyNames: [],
           expressionValues: [],
+          replacements: [],
           staticValueCandidates: [],
           staticValues: [],
         };
-
-  if (extracted.code !== workingCode) {
-    workingCode = extracted.code;
-    program = eventEmitter.perf(
-      'transform:preeval:processTemplate:reparse',
-      () => parseOxc(workingCode, filename)
-    );
-    processorUsages = eventEmitter.perf(
-      'transform:preeval:processTemplate:usages',
-      () => collectProcessorUsages(program, definedProcessors)
-    );
-  }
 
   const templateExpressionValues = extracted.expressionValues.map(
     (value) =>
@@ -270,6 +278,11 @@ export const applyOxcProcessors = (
         workingCode,
         loc,
         idx,
+        !runtimeOnlyProcessorSpans.some(
+          (span) =>
+            span.start <= usage.replacementTarget.start &&
+            span.end >= usage.replacementTarget.end
+        ),
         isTagReferenced(program, usage.ancestors),
         usedNames,
         replacements
@@ -329,7 +342,7 @@ export const applyOxcProcessors = (
 
       processors.push(processor);
       createdProcessors.push(created);
-      if (!deferProcessorCallbacks) {
+      if (!deferProcessorCallbacks && created.evaltimeLive) {
         callback(processor);
         addedImports.push(...astService.getAddedImports());
       }
@@ -387,7 +400,11 @@ export const applyOxcProcessors = (
   const currentSameFileProcessorStaticValues =
     collectCurrentSameFileProcessorStaticValues();
 
-  const replacedCode = applyOxcReplacements(workingCode, replacements);
+  const replacedCode = applyOxcReplacementLayers(workingCode, [
+    replacements,
+    evaltimeCodeReplacements,
+    extracted.replacements,
+  ]);
   const metadataExtendsHelperNames =
     collectWYWMetaExtendsHelperNames(replacedCode);
   const staticValueCandidates = extracted.staticValueCandidates.filter(
@@ -398,7 +415,11 @@ export const applyOxcProcessors = (
   let callbacksApplied = !deferProcessorCallbacks;
 
   const buildCode = (): string => {
-    const nextReplacedCode = applyOxcReplacements(workingCode, replacements);
+    const nextReplacedCode = applyOxcReplacementLayers(workingCode, [
+      replacements,
+      evaltimeCodeReplacements,
+      extracted.replacements,
+    ]);
     const codeWithAddedImports = insertAddedImports(
       nextReplacedCode,
       filename,
@@ -455,7 +476,11 @@ export const applyOxcProcessors = (
       staticValues.byLocal
     );
     result.staticValues = [...extracted.staticValues, ...staticValues.values];
-    createdProcessors.forEach(({ astService, processor }) => {
+    createdProcessors.forEach(({ astService, evaltimeLive, processor }) => {
+      if (!evaltimeLive) {
+        return;
+      }
+
       callback(processor);
       addedImports.push(...astService.getAddedImports());
     });

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -51,6 +51,7 @@ import type {
   ApplyOxcProcessorsResult,
   CreatedProcessor,
   DefinedProcessor,
+  OxcProcessorAnalysisPlan,
   ProcessorUsage,
   Replacement,
   SameFileProcessorObject,
@@ -112,19 +113,28 @@ export const applyOxcProcessors = (
       processorSpans: Array<{ end: number; start: number }>
     ) => DangerousCodePlan;
     eventEmitter?: EventEmitter;
+    perfPrefix?: string;
     preserveSideEffectImportOrderLocals?: Set<string>;
     preserveSideEffectImportLocals?: Set<string>;
   },
   callback: (processor: BaseProcessor) => void,
   cleanupUnused = false,
-  deferProcessorCallbacks = false
+  deferProcessorCallbacks = false,
+  runtimeProcessorPlan?: OxcProcessorAnalysisPlan
 ): ApplyOxcProcessorsResult => {
   const filename = fileContext.filename ?? 'unknown.js';
   const eventEmitter = options.eventEmitter ?? EventEmitter.dummy;
+  const perfPrefix = options.perfPrefix ?? 'transform:preeval:processTemplate';
+  const perfLabel = (suffix: string): string => `${perfPrefix}:${suffix}`;
   const collectStaticExpressionValues =
     shouldCollectStaticExpressionValues(options);
   const workingCode = code;
-  const program = parseOxc(workingCode, filename);
+  const reusablePlan =
+    runtimeProcessorPlan?.code === workingCode &&
+    runtimeProcessorPlan.filename === filename
+      ? runtimeProcessorPlan
+      : undefined;
+  const program = reusablePlan?.program ?? parseOxc(workingCode, filename);
   let evaltimeCodePlan: DangerousCodePlan | null = null;
   const getEvaltimeCodePlan = (
     processorSpans: Array<{ end: number; start: number }> = []
@@ -142,18 +152,18 @@ export const applyOxcProcessors = (
       getEvaltimeCodePlan().replacements,
     ]);
   const definedProcessors = new Map<string, DefinedProcessor>();
-  const removableImportLocals = new Set<string>();
+  const removableImportLocals = new Set(
+    reusablePlan?.removableImportLocals ?? []
+  );
   const removableExpressionRefs = new Set<string>();
 
-  eventEmitter.perf('transform:preeval:processTemplate:imports', () => {
-    const imports = eventEmitter.perf(
-      'transform:preeval:processTemplate:imports:analysis',
-      () => collectOxcProcessorImportsFromProgram(program, workingCode)
-    );
+  if (!reusablePlan) {
+    eventEmitter.perf(perfLabel('imports'), () => {
+      const imports = eventEmitter.perf(perfLabel('imports:analysis'), () =>
+        collectOxcProcessorImportsFromProgram(program, workingCode)
+      );
 
-    eventEmitter.perf(
-      'transform:preeval:processTemplate:imports:lookup',
-      () => {
+      eventEmitter.perf(perfLabel('imports:lookup'), () => {
         imports.forEach((item) => {
           const localName = item.local.name ?? item.local.code;
           if (item.imported === 'side-effect' || !localName) {
@@ -187,11 +197,11 @@ export const applyOxcProcessors = (
             }
           }
         });
-      }
-    );
-  });
+      });
+    });
+  }
 
-  if (definedProcessors.size === 0) {
+  if (!reusablePlan && definedProcessors.size === 0) {
     return {
       code: buildUnprocessedCode(),
       processorManagedExpressionSpans: [],
@@ -203,10 +213,11 @@ export const applyOxcProcessors = (
     };
   }
 
-  const processorUsages = eventEmitter.perf(
-    'transform:preeval:processTemplate:usages',
-    () => collectProcessorUsages(program, definedProcessors)
-  );
+  const processorUsages =
+    reusablePlan?.processorUsages ??
+    eventEmitter.perf(perfLabel('usages'), () =>
+      collectProcessorUsages(program, definedProcessors)
+    );
   if (processorUsages.length === 0) {
     return {
       code: buildUnprocessedCode(),
@@ -258,10 +269,9 @@ export const applyOxcProcessors = (
   };
 
   const extracted =
-    targetExpressionSpans.length > 0
-      ? eventEmitter.perf('transform:preeval:processTemplate:deps', () =>
-          extractDependencies()
-        )
+    reusablePlan?.extracted ??
+    (targetExpressionSpans.length > 0
+      ? eventEmitter.perf(perfLabel('deps'), () => extractDependencies())
       : {
           code: workingCode,
           dependencyNames: [],
@@ -269,7 +279,7 @@ export const applyOxcProcessors = (
           replacements: [],
           staticValueCandidates: [],
           staticValues: [],
-        };
+        });
 
   const templateExpressionValues = extracted.expressionValues.map(
     (value) =>
@@ -280,10 +290,9 @@ export const applyOxcProcessors = (
       }) as ExpressionValue
   );
   const loc = createOxcLocationLookup(workingCode);
-  const usedNames = eventEmitter.perf(
-    'transform:preeval:processTemplate:usedNames',
-    () => collectUsedNames(program)
-  );
+  const usedNames =
+    reusablePlan?.usedNames ??
+    eventEmitter.perf(perfLabel('usedNames'), () => collectUsedNames(program));
   const addedImports: AddedImport[] = [];
   const replacements: Replacement[] = [];
   const createdProcessors: CreatedProcessor[] = [];
@@ -297,8 +306,19 @@ export const applyOxcProcessors = (
   extracted.dependencyNames.forEach((name: string) =>
     removableImportLocals.add(name)
   );
+  const capturedRuntimeProcessorPlan = deferProcessorCallbacks
+    ? {
+        code: workingCode,
+        extracted,
+        filename,
+        processorUsages,
+        program,
+        removableImportLocals: new Set(removableImportLocals),
+        usedNames,
+      }
+    : undefined;
 
-  eventEmitter.perf('transform:preeval:processTemplate:processors', () => {
+  eventEmitter.perf(perfLabel('processors'), () => {
     processorUsages.forEach((usage, idx) => {
       const params = buildParams(
         usage,
@@ -472,7 +492,7 @@ export const applyOxcProcessors = (
     );
 
     return cleanupUnused
-      ? eventEmitter.perf('transform:preeval:processTemplate:cleanup', () =>
+      ? eventEmitter.perf(perfLabel('cleanup'), () =>
           removeUnusedAfterReplacement(
             codeWithAddedImports,
             filename,
@@ -492,6 +512,7 @@ export const applyOxcProcessors = (
     processorManagedExpressionSpans,
     processorClassNamesByLocal,
     processors,
+    runtimeProcessorPlan: capturedRuntimeProcessorPlan,
     staticPlanFacts: collectStaticPlanFacts(
       processorUsages,
       extracted.staticValueCandidates,

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -65,6 +65,10 @@ export const applyOxcProcessors = (
     | 'tagResolver'
   > & {
     eventEmitter?: EventEmitter;
+    getMutationHazardIgnoreTreeSpans?: () => Array<{
+      end: number;
+      start: number;
+    }>;
     preserveSideEffectImportOrderLocals?: Set<string>;
     preserveSideEffectImportLocals?: Set<string>;
   },
@@ -161,6 +165,8 @@ export const applyOxcProcessors = (
     end: usage.target.end,
     start: usage.target.start,
   }));
+  const mutationHazardIgnoreTreeSpans =
+    options.getMutationHazardIgnoreTreeSpans?.() ?? [];
   const extractDependencies = () => {
     try {
       return collectOxcExpressionDependencies(
@@ -169,7 +175,8 @@ export const applyOxcProcessors = (
         collectStaticExpressionValues,
         targetExpressionSpans,
         options.staticBindings,
-        processorManagedExpressionSpans
+        processorManagedExpressionSpans,
+        mutationHazardIgnoreTreeSpans
       );
     } catch (error) {
       if (!(error instanceof OxcSnapshotWriteUnsupportedError)) {
@@ -180,7 +187,8 @@ export const applyOxcProcessors = (
         workingCode,
         filename,
         targetExpressionSpans,
-        processorManagedExpressionSpans
+        processorManagedExpressionSpans,
+        mutationHazardIgnoreTreeSpans
       );
     }
   };

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -3,7 +3,10 @@ import type { ExpressionValue, StrictOptions } from '@wyw-in-js/shared';
 
 import { collectOxcProcessorImportsFromProgram } from '../collectOxcExportsAndImports';
 import { collectOxcExpressionDependencies } from '../collectOxcTemplateDependencies';
-import type { OxcStaticValue } from '../collectOxcTemplateDependencies';
+import type {
+  OxcStaticValue,
+  OxcStaticValueCandidate,
+} from '../collectOxcTemplateDependencies';
 import type { DangerousCodePlan } from '../dangerousCodeRemoval';
 import {
   collectOxcExpressionDependenciesForEvalFallback,
@@ -48,9 +51,49 @@ import type {
   ApplyOxcProcessorsResult,
   CreatedProcessor,
   DefinedProcessor,
+  ProcessorUsage,
   Replacement,
   SameFileProcessorObject,
+  StaticPlanFacts,
 } from './types';
+
+const EMPTY_STATIC_PLAN_FACTS: StaticPlanFacts = {
+  importedNeeds: [],
+  staticValueCount: 0,
+  unresolvedCount: 0,
+  usageCount: 0,
+};
+
+const collectStaticPlanFacts = (
+  usages: ProcessorUsage[],
+  staticValueCandidates: OxcStaticValueCandidate[],
+  staticValues: OxcStaticValue[]
+): StaticPlanFacts => {
+  const staticValueNames = new Set(staticValues.map(({ name }) => name));
+  const unresolvedNames = new Set<string>();
+  const importedNeeds: StaticPlanFacts['importedNeeds'] = [];
+
+  staticValueCandidates.forEach((candidate) => {
+    if (candidate.imports.length === 0) {
+      return;
+    }
+
+    if (!staticValueNames.has(candidate.name)) {
+      unresolvedNames.add(candidate.name);
+    }
+
+    candidate.imports.forEach(({ imported: name, source }) => {
+      importedNeeds.push({ name, source });
+    });
+  });
+
+  return {
+    importedNeeds,
+    staticValueCount: staticValueNames.size,
+    unresolvedCount: unresolvedNames.size,
+    usageCount: usages.length,
+  };
+};
 
 export const applyOxcProcessors = (
   code: string,
@@ -154,6 +197,7 @@ export const applyOxcProcessors = (
       processorManagedExpressionSpans: [],
       processorClassNamesByLocal: new Map(),
       processors: [],
+      staticPlanFacts: EMPTY_STATIC_PLAN_FACTS,
       staticValueCandidates: [],
       staticValues: [],
     };
@@ -169,6 +213,7 @@ export const applyOxcProcessors = (
       processorManagedExpressionSpans: [],
       processorClassNamesByLocal: new Map(),
       processors: [],
+      staticPlanFacts: EMPTY_STATIC_PLAN_FACTS,
       staticValueCandidates: [],
       staticValues: [],
     };
@@ -447,6 +492,11 @@ export const applyOxcProcessors = (
     processorManagedExpressionSpans,
     processorClassNamesByLocal,
     processors,
+    staticPlanFacts: collectStaticPlanFacts(
+      processorUsages,
+      extracted.staticValueCandidates,
+      extracted.staticValues
+    ),
     staticValueCandidates: addCandidateInlineConstants(
       staticValueCandidates,
       currentSameFileProcessorStaticValues.byLocal

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -131,6 +131,7 @@ export const applyOxcProcessors = (
   if (definedProcessors.size === 0) {
     return {
       code: workingCode,
+      processorManagedExpressionSpans: [],
       processorClassNamesByLocal: new Map(),
       processors: [],
       staticValueCandidates: [],
@@ -145,6 +146,7 @@ export const applyOxcProcessors = (
   if (processorUsages.length === 0) {
     return {
       code: workingCode,
+      processorManagedExpressionSpans: [],
       processorClassNamesByLocal: new Map(),
       processors: [],
       staticValueCandidates: [],
@@ -413,6 +415,7 @@ export const applyOxcProcessors = (
 
   const result: ApplyOxcProcessorsResult = {
     code: buildCode(),
+    processorManagedExpressionSpans,
     processorClassNamesByLocal,
     processors,
     staticValueCandidates: addCandidateInlineConstants(

--- a/packages/transform/src/utils/applyOxcProcessors/processorFactory.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/processorFactory.ts
@@ -46,6 +46,7 @@ export const createProcessor = (
   code: string,
   loc: LocationLookup,
   idx: number,
+  evaltimeLive: boolean,
   isReferenced: boolean,
   usedNames: Set<string>,
   replacements: Replacement[]
@@ -125,6 +126,7 @@ export const createProcessor = (
 
     return {
       astService,
+      evaltimeLive,
       processor,
     };
   } catch (e) {

--- a/packages/transform/src/utils/applyOxcProcessors/types.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/types.ts
@@ -24,6 +24,13 @@ export type DefinedProcessor = [
 
 export type Replacement = OxcValueReplacement;
 
+export type StaticPlanFacts = {
+  importedNeeds: Array<{ name: string; source: string }>;
+  staticValueCount: number;
+  unresolvedCount: number;
+  usageCount: number;
+};
+
 export type ApplyOxcProcessorsResult = {
   code: string;
   finalizeProcessorCallbacks?: (
@@ -35,6 +42,7 @@ export type ApplyOxcProcessorsResult = {
   // the runtime value of the binding IS this string.
   processorClassNamesByLocal: Map<string, string>;
   processors: BaseProcessor[];
+  staticPlanFacts: StaticPlanFacts;
   staticValueCandidates: OxcStaticValueCandidate[];
   staticValues: OxcStaticValue[];
 };

--- a/packages/transform/src/utils/applyOxcProcessors/types.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/types.ts
@@ -73,6 +73,7 @@ export type ExpressionSpan = {
 
 export type CreatedProcessor = {
   astService: OxcAstService;
+  evaltimeLive: boolean;
   processor: BaseProcessor;
 };
 

--- a/packages/transform/src/utils/applyOxcProcessors/types.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/types.ts
@@ -3,6 +3,7 @@ import type {
   CallExpression,
   Expression,
   Node,
+  Program,
   TaggedTemplateExpression,
 } from 'oxc-parser';
 
@@ -10,6 +11,7 @@ import type {
   OxcStaticValue,
   OxcStaticValueCandidate,
 } from '../collectOxcTemplateDependencies';
+import type { TemplateExtractionResult } from '../collectOxcTemplateDependencies/types';
 import type { OxcAstService } from '../oxcAstService';
 import type { OxcValueReplacement } from '../oxc/replacements';
 import type { OxcLocationLookup } from '../oxc/sourceLocations';
@@ -31,6 +33,16 @@ export type StaticPlanFacts = {
   usageCount: number;
 };
 
+export type OxcProcessorAnalysisPlan = {
+  code: string;
+  extracted: TemplateExtractionResult;
+  filename: string;
+  processorUsages: ProcessorUsage[];
+  program: Program;
+  removableImportLocals: Set<string>;
+  usedNames: Set<string>;
+};
+
 export type ApplyOxcProcessorsResult = {
   code: string;
   finalizeProcessorCallbacks?: (
@@ -42,6 +54,7 @@ export type ApplyOxcProcessorsResult = {
   // the runtime value of the binding IS this string.
   processorClassNamesByLocal: Map<string, string>;
   processors: BaseProcessor[];
+  runtimeProcessorPlan?: OxcProcessorAnalysisPlan;
   staticPlanFacts: StaticPlanFacts;
   staticValueCandidates: OxcStaticValueCandidate[];
   staticValues: OxcStaticValue[];

--- a/packages/transform/src/utils/applyOxcProcessors/types.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/types.ts
@@ -29,6 +29,7 @@ export type ApplyOxcProcessorsResult = {
   finalizeProcessorCallbacks?: (
     staticValueCache?: Map<string, unknown>
   ) => ApplyOxcProcessorsResult;
+  processorManagedExpressionSpans: ExpressionSpan[];
   // Selector-only processor class names (css`...`-style). Safe to use as
   // a class-name fallback in cross-file static-export resolution because
   // the runtime value of the binding IS this string.

--- a/packages/transform/src/utils/collectOxcRuntime.ts
+++ b/packages/transform/src/utils/collectOxcRuntime.ts
@@ -1,7 +1,9 @@
 import type { ValueCache } from '@wyw-in-js/processor-utils';
 import type { RawSourceMap } from 'source-map';
 
+import { EventEmitter } from './EventEmitter';
 import { applyOxcProcessors } from './applyOxcProcessors';
+import type { OxcProcessorAnalysisPlan } from './applyOxcProcessors/types';
 import { normalizeRuntimeCode } from './collectOxcRuntime/normalizeRuntimeCode';
 import { createComposedRuntimeSourceMap } from './collectOxcRuntime/sourceMap';
 import type {
@@ -15,27 +17,43 @@ export const collectOxcRuntime = (
   root: string,
   options: OxcCollectOptions,
   values: ValueCache,
-  inputSourceMap?: RawSourceMap
+  inputSourceMap?: RawSourceMap,
+  runtimeProcessorPlan?: OxcProcessorAnalysisPlan
 ): OxcCollectResult => {
-  const result = applyOxcProcessors(
-    code,
-    {
-      filename,
-      root,
-    },
-    options,
-    (processor) => {
-      processor.build(values);
-      processor.doRuntimeReplacement();
-    },
-    true
+  const { eventEmitter = EventEmitter.dummy, ...processorOptions } = options;
+  const result = eventEmitter.perf('transform:collect:applyProcessors', () =>
+    applyOxcProcessors(
+      code,
+      {
+        filename,
+        root,
+      },
+      {
+        ...processorOptions,
+        eventEmitter,
+        perfPrefix: 'transform:collect:applyProcessors',
+      },
+      (processor) => {
+        eventEmitter.perf('transform:collect:processorRuntime', () => {
+          processor.build(values);
+          processor.doRuntimeReplacement();
+        });
+      },
+      true,
+      false,
+      runtimeProcessorPlan
+    )
   );
-  const normalizedCode = normalizeRuntimeCode(result.code, filename);
-  const map = createComposedRuntimeSourceMap(
-    normalizedCode,
-    code,
-    filename,
-    inputSourceMap
+  const normalizedCode = eventEmitter.perf('transform:collect:normalize', () =>
+    normalizeRuntimeCode(result.code, filename)
+  );
+  const map = eventEmitter.perf('transform:collect:sourceMap', () =>
+    createComposedRuntimeSourceMap(
+      normalizedCode,
+      code,
+      filename,
+      inputSourceMap
+    )
   );
 
   if (result.processors.length === 0) {

--- a/packages/transform/src/utils/collectOxcRuntime/types.ts
+++ b/packages/transform/src/utils/collectOxcRuntime/types.ts
@@ -1,6 +1,7 @@
 import type { StrictOptions } from '@wyw-in-js/shared';
 import type { RawSourceMap } from 'source-map';
 
+import type { EventEmitter } from '../EventEmitter';
 import type { WYWTransformMetadata } from '../TransformMetadata';
 
 export type OxcCollectOptions = Pick<
@@ -13,6 +14,7 @@ export type OxcCollectOptions = Pick<
   | 'tagResolver'
   | 'variableNameConfig'
 > & {
+  eventEmitter?: EventEmitter;
   preserveSideEffectImportOrderLocals?: Set<string>;
   preserveSideEffectImportLocals?: Set<string>;
 };

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/__tests__/mutationPropagation.test.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/__tests__/mutationPropagation.test.ts
@@ -9,7 +9,10 @@ import {
   toMutationBindingKey,
   unknownAliasMutationBinding,
 } from '../scopeAnalysis';
-import { getExecutionVisibleMutationTimeline } from '../mutationExecution';
+import {
+  getExecutionVisibleMutationTimeline,
+  someExecutionAncestorEffect,
+} from '../mutationExecution';
 
 const filename = '/mutation-propagation.ts';
 
@@ -319,6 +322,24 @@ describe('indexed mutation propagation', () => {
 
     expect(labels(code, analysis, 'source')).toEqual([]);
     expect(labels(code, analysis, 'sibling')).toEqual([]);
+  });
+
+  it('keeps post-interpolation effects behind their deferred child reads', () => {
+    const code = [
+      'import { source } from "./tokens";',
+      'tag`${[source, () => source.value]}`;',
+    ].join('\n');
+    const analysis = analyze(code);
+    const targetStart = code.lastIndexOf('source.value');
+
+    expect(
+      someExecutionAncestorEffect(
+        analysis.bindingIndex,
+        timeline(analysis, 'source'),
+        targetStart,
+        () => true
+      )
+    ).toBe(false);
   });
 
   it('preserves shallow-copy directionality in both rest-link directions', () => {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/__tests__/mutationPropagation.test.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/__tests__/mutationPropagation.test.ts
@@ -205,6 +205,19 @@ describe('indexed mutation propagation', () => {
     ]);
   });
 
+  it('keeps function-valued declarator links dormant until invocation', () => {
+    const code = [
+      'const source = {};',
+      'const captures = () => source;',
+      'source.value = 1;',
+      'captures();',
+    ].join('\n');
+    const analysis = analyze(code);
+
+    expect(labels(code, analysis, 'source')).toEqual(['captures()']);
+    expect(labels(code, analysis, 'captures')).toEqual(['captures()']);
+  });
+
   it('preserves shallow-copy directionality in both rest-link directions', () => {
     const code = [
       'const source = { nested: {} };',

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/__tests__/mutationPropagation.test.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/__tests__/mutationPropagation.test.ts
@@ -5,8 +5,11 @@ import {
   analyzeProgram,
   getRootMutationHazards,
   parseOxc,
+  resolveBindingAt,
+  toMutationBindingKey,
   unknownAliasMutationBinding,
 } from '../scopeAnalysis';
+import { getExecutionVisibleMutationTimeline } from '../mutationExecution';
 
 const filename = '/mutation-propagation.ts';
 
@@ -30,6 +33,18 @@ const labels = (
   getRootMutationHazards(analysis.rootMutationHazardsByBinding, binding).map(
     (node) => code.slice(node.start, node.end)
   );
+
+const visibleLabels = (
+  code: string,
+  analysis: ProgramAnalysis,
+  binding: string,
+  targetStart = code.length
+): string[] =>
+  getExecutionVisibleMutationTimeline(
+    analysis.bindingIndex,
+    timeline(analysis, binding),
+    targetStart
+  ).byStart.map((node) => code.slice(node.start, node.end));
 
 describe('indexed mutation propagation', () => {
   it('promotes a late weak hazard to sibling-capable and wakes its import group', () => {
@@ -216,6 +231,94 @@ describe('indexed mutation propagation', () => {
 
     expect(labels(code, analysis, 'source')).toEqual(['captures()']);
     expect(labels(code, analysis, 'captures')).toEqual(['captures()']);
+  });
+
+  it('publishes dormant function effects at the invocation site', () => {
+    const code = [
+      'import { source, sibling } from "./tokens";',
+      'function render() { mutate(source); }',
+      'render();',
+    ].join('\n');
+    const analysis = analyze(code);
+
+    expect(visibleLabels(code, analysis, 'source')).toEqual(['render()']);
+    expect(visibleLabels(code, analysis, 'sibling')).toEqual(['render()']);
+  });
+
+  it('does not publish invocation summaries into function locals', () => {
+    const code = [
+      'function run() {',
+      '  const local = {};',
+      '  mutate(local);',
+      '}',
+      'run();',
+    ].join('\n');
+    const analysis = analyze(code);
+    const referenceStart = code.indexOf('local);');
+    const binding = resolveBindingAt(
+      { bindingIndex: analysis.bindingIndex },
+      'local',
+      referenceStart
+    );
+
+    expect(binding).toBeDefined();
+    expect(labels(code, analysis, toMutationBindingKey(binding!))).toEqual([
+      'mutate(local)',
+    ]);
+  });
+
+  it('keeps dormant alias effects inside their execution container', () => {
+    const code = [
+      'import { source, sibling } from "./tokens";',
+      'function dormant() {',
+      '  const alias = source;',
+      '  mutate(alias);',
+      '}',
+      'const value = source.width;',
+    ].join('\n');
+    const analysis = analyze(code);
+
+    expect(labels(code, analysis, 'source')).toContain('mutate(alias)');
+    expect(visibleLabels(code, analysis, 'source')).toEqual([]);
+    expect(visibleLabels(code, analysis, 'sibling')).toEqual([]);
+  });
+
+  it('publishes invoked unproven alias effects at the call site', () => {
+    const code = [
+      'function mutate() {',
+      '  const alias = registry.source;',
+      '  alias.width = 400;',
+      '}',
+      'mutate();',
+    ].join('\n');
+    const analysis = analyze(code);
+
+    expect(visibleLabels(code, analysis, unknownAliasMutationBinding)).toEqual([
+      'mutate()',
+    ]);
+  });
+
+  it.each([
+    [
+      'inline callback',
+      [
+        'import { source, sibling } from "./tokens";',
+        'wrap(() => source.value);',
+      ].join('\n'),
+    ],
+    [
+      'named callback',
+      [
+        'import { source, sibling } from "./tokens";',
+        'function callback() { return source.value; }',
+        'wrap(callback);',
+      ].join('\n'),
+    ],
+  ])('does not execute captures when passing a %s', (_name, code) => {
+    const analysis = analyze(code);
+
+    expect(labels(code, analysis, 'source')).toEqual([]);
+    expect(labels(code, analysis, 'sibling')).toEqual([]);
   });
 
   it('preserves shallow-copy directionality in both rest-link directions', () => {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
@@ -687,6 +687,7 @@ const extractExpressions = (
       code,
       dependencyNames: [],
       expressionValues: [],
+      replacements: [],
       staticValueCandidates: [],
       staticValues: [],
     };
@@ -820,6 +821,7 @@ const extractExpressions = (
     code: applyOxcReplacements(code, ctx.replacements),
     dependencyNames: [...ctx.dependencyNames],
     expressionValues: ctx.expressionValues,
+    replacements: ctx.replacements,
     staticValueCandidates: ctx.staticValueCandidates,
     staticValues: ctx.staticValues,
   };

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
@@ -915,7 +915,8 @@ export const collectOxcExpressionDependencies = (
   evaluate = false,
   targetExpressionSpans?: ExpressionSpan[],
   staticBindings?: StaticBindings,
-  processorManagedExpressionSpans: ExpressionSpan[] = []
+  processorManagedExpressionSpans: ExpressionSpan[] = [],
+  removedExpressionSpans: ExpressionSpan[] = []
 ): TemplateExtractionResult => {
   const program = parseOxc(code, filename);
   const analysis = analyzeProgram(program, {
@@ -924,6 +925,7 @@ export const collectOxcExpressionDependencies = (
     mutationHazardIgnoreLookup: createSpanLookup(
       processorManagedExpressionSpans
     ),
+    mutationHazardIgnoreTreeLookup: createSpanLookup(removedExpressionSpans),
   });
 
   return extractExpressions(
@@ -942,7 +944,8 @@ export const collectOxcExpressionDependenciesForEvalFallback = (
   code: string,
   filename: string,
   targetExpressionSpans?: ExpressionSpan[],
-  processorManagedExpressionSpans: ExpressionSpan[] = []
+  processorManagedExpressionSpans: ExpressionSpan[] = [],
+  removedExpressionSpans: ExpressionSpan[] = []
 ): TemplateExtractionResult => {
   const program = parseOxc(code, filename);
   const analysis = analyzeProgram(program, {
@@ -951,6 +954,7 @@ export const collectOxcExpressionDependenciesForEvalFallback = (
     mutationHazardIgnoreLookup: createSpanLookup(
       processorManagedExpressionSpans
     ),
+    mutationHazardIgnoreTreeLookup: createSpanLookup(removedExpressionSpans),
   });
   const extracted = extractExpressions(
     code,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
@@ -827,7 +827,6 @@ const extractExpressions = (
 
 export const isOxcStaticSerializableValue = (value: unknown): boolean =>
   isStaticSerializableValue(value);
-
 export const evaluateOxcStaticExpressionAt = (
   code: string,
   filename: string,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
@@ -833,12 +833,16 @@ export const evaluateOxcStaticExpressionAt = (
   filename: string,
   expressionSpan: ExpressionSpan,
   env: Map<string, unknown> = new Map(),
-  staticBindings?: StaticBindings
+  staticBindings?: StaticBindings,
+  processorManagedExpressionSpans: ExpressionSpan[] = []
 ): unknown | undefined => {
   const program = parseOxc(code, filename);
   const analysis = analyzeProgram(program, {
     collectTargetExpressions: true,
     expressionSpanLookup: createSpanLookup([expressionSpan]),
+    mutationHazardIgnoreLookup: createSpanLookup(
+      processorManagedExpressionSpans
+    ),
   });
   const [expression] = analysis.targetExpressions;
   if (!expression) {
@@ -857,7 +861,9 @@ export const evaluateOxcStaticExpressionAt = (
     hoistedDeclarations: new Map(),
     hoistedDeclarationsByInsertionPoint: new Map(),
     loc: createOxcLocationLookup(code),
-    processorManagedExpressionSpans: new Set(),
+    processorManagedExpressionSpans: new Set(
+      processorManagedExpressionSpans.map(expressionSpanKey)
+    ),
     program,
     replacements: [],
     rootMutationHazardsByBinding: analysis.rootMutationHazardsByBinding,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -15,7 +15,6 @@ import {
 } from '../oxc/assignmentTargets';
 import { getOxcNodeChildren } from '../oxc/ast';
 import { collectOxcPatternBindingNames } from '../oxc/patterns';
-import { getOxcSyntacticPropertyKey } from '../oxc/projections';
 import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
 import {
   findResolvedReferences as getReferences,
@@ -26,6 +25,21 @@ import {
   getMutationTimeline,
   sealMutationTimelineMap,
 } from './mutationTimeline';
+import {
+  collectInvocationTargetKeys,
+  collectMutationReferenceKeys,
+  collectRootMutations,
+  collectThrownExpressions,
+  containsUnprovenAliasSource,
+  createDeferredReferencePolicyCollector,
+  findContainingClass,
+  getExecutionOwner,
+  isImmediatelyInvokedFunction,
+  publishDeferredUnknownAliasSources,
+  registerExecutionFunction,
+  registerExecutionNode,
+  type MutationAliasLink,
+} from './mutationExecution';
 import { visitOxcScopes } from './scopeTraversal';
 import type {
   Binding,
@@ -158,77 +172,6 @@ const collectRestContainerBindingNames = (
   return names;
 };
 
-const collectRootMutations = (
-  program: Program
-): Map<string, Array<AssignmentExpression | UpdateExpression>> => {
-  const mutations = new Map<
-    string,
-    Array<AssignmentExpression | UpdateExpression>
-  >();
-
-  const getRootMutationTarget = (
-    node: Node
-  ): { binding: string; path: Array<string | number> } | null => {
-    if (node.type === 'Identifier') {
-      return {
-        binding: node.name,
-        path: [],
-      };
-    }
-
-    if (node.type !== 'MemberExpression') {
-      return null;
-    }
-
-    const parent = getRootMutationTarget(node.object);
-    if (!parent) {
-      return null;
-    }
-
-    const key = getOxcSyntacticPropertyKey(node.property, node.computed);
-    if (key === null) {
-      return null;
-    }
-
-    return {
-      binding: parent.binding,
-      path: [...parent.path, key],
-    };
-  };
-
-  program.body.forEach((statement) => {
-    if (statement.type !== 'ExpressionStatement') {
-      return;
-    }
-
-    const { expression } = statement;
-    if (expression.type === 'AssignmentExpression') {
-      const target = getRootMutationTarget(expression.left);
-      if (expression.operator !== '=' || !target || target.path.length === 0) {
-        return;
-      }
-
-      const bucket = mutations.get(target.binding) ?? [];
-      bucket.push(expression);
-      mutations.set(target.binding, bucket);
-      return;
-    }
-
-    if (expression.type === 'UpdateExpression') {
-      const target = getRootMutationTarget(expression.argument);
-      if (!target || target.path.length === 0) {
-        return;
-      }
-
-      const bucket = mutations.get(target.binding) ?? [];
-      bucket.push(expression);
-      mutations.set(target.binding, bucket);
-    }
-  });
-
-  return mutations;
-};
-
 export const unknownAliasMutationBinding =
   '\0wyw-static-unknown-alias-mutation';
 
@@ -245,118 +188,6 @@ export const getRootMutationHazards = (
   hazards: ReadonlyMap<string, MutationTimeline<Node>>,
   binding: string
 ): readonly Node[] => getMutationTimeline(hazards, binding).byStart;
-
-const containsOpaqueAliasConstruct = (
-  node: Node,
-  bindingIndex: BindingIndex,
-  ignoredTreeNodes: ReadonlySet<Node>,
-  ignoredReferenceStarts: ReadonlySet<number>
-): boolean => {
-  if (ignoredTreeNodes.has(node)) {
-    return false;
-  }
-
-  return (
-    node.type === 'CallExpression' ||
-    node.type === 'NewExpression' ||
-    node.type === 'TaggedTemplateExpression' ||
-    node.type === 'ImportExpression' ||
-    node.type === 'ThisExpression' ||
-    node.type === 'Super' ||
-    (node.type === 'MemberExpression' &&
-      getReferences(node, bindingIndex).every((reference) =>
-        ignoredReferenceStarts.has(reference.start)
-      )) ||
-    getOxcNodeChildren(node).some((child) =>
-      containsOpaqueAliasConstruct(
-        child,
-        bindingIndex,
-        ignoredTreeNodes,
-        ignoredReferenceStarts
-      )
-    )
-  );
-};
-
-const containsUnprovenAliasSource = (
-  node: Node,
-  bindingIndex: BindingIndex,
-  ignoredTreeNodes: ReadonlySet<Node>,
-  ignoredReferenceStarts: ReadonlySet<number>
-): boolean =>
-  !ignoredTreeNodes.has(node) &&
-  (getReferences(node, bindingIndex).some(
-    (reference) =>
-      !ignoredReferenceStarts.has(reference.start) && reference.binding === null
-  ) ||
-    containsOpaqueAliasConstruct(
-      node,
-      bindingIndex,
-      ignoredTreeNodes,
-      ignoredReferenceStarts
-    ));
-
-const collectThrownExpressions = (
-  node: Node,
-  ignoredTreeNodes: ReadonlySet<Node>,
-  expressions: Expression[] = []
-): Expression[] => {
-  if (ignoredTreeNodes.has(node)) {
-    return expressions;
-  }
-
-  if (
-    node.type === 'FunctionDeclaration' ||
-    node.type === 'FunctionExpression' ||
-    node.type === 'ArrowFunctionExpression'
-  ) {
-    return expressions;
-  }
-
-  if (node.type === 'ThrowStatement') {
-    expressions.push(node.argument);
-    return expressions;
-  }
-
-  getOxcNodeChildren(node).forEach((child) =>
-    collectThrownExpressions(child, ignoredTreeNodes, expressions)
-  );
-  return expressions;
-};
-
-const isImmediatelyInvokedFunction = (
-  functionNode: Node,
-  ancestors: readonly Node[]
-): boolean => {
-  let child = functionNode;
-  for (let index = ancestors.length - 1; index >= 0; index -= 1) {
-    const ancestor = ancestors[index]!;
-    if (
-      ancestor.type === 'ParenthesizedExpression' &&
-      ancestor.expression === child
-    ) {
-      child = ancestor;
-      continue;
-    }
-    if (
-      ancestor.type === 'SequenceExpression' &&
-      ancestor.expressions[ancestor.expressions.length - 1] === child
-    ) {
-      child = ancestor;
-      continue;
-    }
-
-    return (
-      ((ancestor.type === 'CallExpression' ||
-        ancestor.type === 'NewExpression') &&
-        ancestor.callee === child) ||
-      (ancestor.type === 'TaggedTemplateExpression' && ancestor.tag === child)
-    );
-  }
-
-  return false;
-};
-
 const collectRootMutationHazards = (
   program: Program,
   mutations: Map<string, Array<AssignmentExpression | UpdateExpression>>,
@@ -410,17 +241,31 @@ const collectRootMutationHazards = (
     }
   });
 
-  const collectReferenceKeys = (node: Node): string[] => [
-    ...new Set(
-      getReferences(node, bindingIndex)
-        .filter(
-          (reference) => !ignoredHazardTreeReferenceStarts.has(reference.start)
-        )
-        .map(({ binding, name }) =>
-          binding ? toMutationBindingKey(binding) : name
-        )
-    ),
-  ];
+  const toReferenceKey = (binding: Binding | null, name: string): string =>
+    binding ? toMutationBindingKey(binding) : name;
+  const collectReferenceKeys = (node: Node): string[] =>
+    collectMutationReferenceKeys(
+      node,
+      bindingIndex,
+      [ignoredHazardTreeReferenceStarts],
+      toReferenceKey
+    );
+
+  const collectDeferredReferencePolicy =
+    createDeferredReferencePolicyCollector(bindingIndex);
+  const collectEagerReferenceKeys = (
+    node: Node,
+    includeBinding: (binding: Binding | null) => boolean = () => true
+  ): string[] => {
+    const { ignoredStarts } = collectDeferredReferencePolicy(node);
+    return collectMutationReferenceKeys(
+      node,
+      bindingIndex,
+      [ignoredHazardTreeReferenceStarts, ignoredStarts],
+      toReferenceKey,
+      includeBinding
+    );
+  };
 
   const processorManagedAliasReferenceStarts = new Set<number>();
   ignoredHazardNodes.forEach((node) => {
@@ -431,19 +276,25 @@ const collectRootMutationHazards = (
       processorManagedAliasReferenceStarts.add(start)
     );
   });
-  const collectAliasReferenceKeys = (node: Node): string[] => [
-    ...new Set(
-      getReferences(node, bindingIndex)
-        .filter(
-          (reference) =>
-            !processorManagedAliasReferenceStarts.has(reference.start) &&
-            !ignoredHazardTreeReferenceStarts.has(reference.start)
-        )
-        .map(({ binding, name }) =>
-          binding ? toMutationBindingKey(binding) : name
-        )
-    ),
-  ];
+  const collectAliasReferenceKeys = (
+    node: Node,
+    includeBinding: (binding: Binding | null) => boolean = () => true
+  ): string[] =>
+    collectMutationReferenceKeys(
+      node,
+      bindingIndex,
+      [processorManagedAliasReferenceStarts, ignoredHazardTreeReferenceStarts],
+      toReferenceKey,
+      includeBinding
+    );
+  const collectCapturedAliasReferenceKeys = (node: Node): string[] =>
+    collectAliasReferenceKeys(
+      node,
+      (binding) =>
+        !binding ||
+        binding.declaredAt < node.start ||
+        node.end <= binding.declaredAt
+    );
 
   const containsUnprovenAlias = (node: Node): boolean =>
     containsUnprovenAliasSource(
@@ -452,6 +303,18 @@ const collectRootMutationHazards = (
       ignoredHazardTreeNodes,
       ignoredHazardTreeReferenceStarts
     );
+  const containsEagerUnprovenAlias = (node: Node): boolean => {
+    const { ignoredRoots, ignoredStarts } =
+      collectDeferredReferencePolicy(node);
+    return containsUnprovenAliasSource(
+      node,
+      bindingIndex,
+      ignoredHazardTreeNodes,
+      ignoredHazardTreeReferenceStarts,
+      ignoredRoots,
+      ignoredStarts
+    );
+  };
 
   const shallowCopyChangeCanAffectBindings = (
     bindings: readonly string[],
@@ -551,60 +414,73 @@ const collectRootMutationHazards = (
     hazard: Node,
     canAffectSiblingImport = false
   ): void => {
-    collectReferenceKeys(node).forEach((key) => {
+    collectEagerReferenceKeys(node).forEach((key) => {
       addHazard(key, hazard, canAffectSiblingImport);
     });
   };
 
   const addUnknownAliasHazard = (node: Node, hazard: Node): void => {
-    if (containsUnprovenAlias(node)) {
+    if (containsEagerUnprovenAlias(node)) {
       addHazard(unknownAliasMutationBinding, hazard);
     }
   };
 
+  const deferredFunctionsWithUnknownAlias = new Set<Node>();
+  const containingClassByDeferredFunction = new Map<Node, Node>();
   visitOxcScopes(program, null, (node, scope, _parent, ancestors) => {
+    const executionOwner = scope.deferredFunctionNode ?? null;
+    registerExecutionNode(bindingIndex, node, executionOwner);
     if (
       isOxcFunctionLike(node) &&
       !isImmediatelyInvokedFunction(node, ancestors)
     ) {
+      registerExecutionFunction(bindingIndex, node, executionOwner);
+      const containingClass = findContainingClass(ancestors);
+      if (containingClass) {
+        containingClassByDeferredFunction.set(node, containingClass);
+      }
       // Scope state is intentionally inherited by scopes created below it.
       // eslint-disable-next-line no-param-reassign
-      scope.deferredFunction = true;
+      scope.deferredFunctionNode = node;
     }
 
     if (!isEffectiveMutationHazardSeed(node, ignoredHazardNodes)) {
       return;
     }
 
-    // A dormant function body is not executed while the module's static
-    // exports are collected. Keep its direct binding hazard, but do not let
-    // that hazard poison sibling exports from the same imported module. If
-    // the function is invoked, its function alias link below promotes the
-    // captured bindings from the invocation site instead.
-    const canAffectSiblingImport = scope.deferredFunction !== true;
+    const deferredFunction = scope.deferredFunctionNode;
+    const addExecutionUnknownAliasHazard = (
+      referenceNode: Node,
+      hazard: Node
+    ): void => {
+      if (deferredFunction && containsEagerUnprovenAlias(referenceNode)) {
+        deferredFunctionsWithUnknownAlias.add(deferredFunction);
+      }
+      addUnknownAliasHazard(referenceNode, hazard);
+    };
 
     if (node.type === 'AssignmentExpression') {
       // The RHS can similarly create an alias even when the LHS write itself
       // is one of the simple statically modeled root mutations.
       addReferences(node.right, node);
       if (!modeledMutations.has(node)) {
-        addReferences(node.left, node, canAffectSiblingImport);
-        addUnknownAliasHazard(node.left, node);
+        addReferences(node.left, node, true);
+        addExecutionUnknownAliasHazard(node.left, node);
       }
       return;
     }
 
     if (node.type === 'UpdateExpression') {
       if (!modeledMutations.has(node)) {
-        addReferences(node.argument, node, canAffectSiblingImport);
-        addUnknownAliasHazard(node.argument, node);
+        addReferences(node.argument, node, true);
+        addExecutionUnknownAliasHazard(node.argument, node);
       }
       return;
     }
 
     if (node.type === 'UnaryExpression' && node.operator === 'delete') {
-      addReferences(node.argument, node, canAffectSiblingImport);
-      addUnknownAliasHazard(node.argument, node);
+      addReferences(node.argument, node, true);
+      addExecutionUnknownAliasHazard(node.argument, node);
       return;
     }
 
@@ -612,21 +488,21 @@ const collectRootMutationHazards = (
       // Any object passed to unknown code, or used as a method receiver, can
       // be mutated. Pure calls are intentionally rejected here rather than
       // risking a stale static snapshot.
-      addReferences(node.callee, node, canAffectSiblingImport);
-      addUnknownAliasHazard(node.callee, node);
+      // Starting at the invocation keeps an inline IIFE body eager while the
+      // deferred-reference policy still skips callback arguments.
+      addReferences(node, node, true);
+      addExecutionUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
-        addReferences(argument, node, canAffectSiblingImport);
-        addUnknownAliasHazard(argument, node);
+        addExecutionUnknownAliasHazard(argument, node);
       });
       return;
     }
 
     if (node.type === 'NewExpression') {
-      addReferences(node.callee, node, canAffectSiblingImport);
-      addUnknownAliasHazard(node.callee, node);
+      addReferences(node, node, true);
+      addExecutionUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
-        addReferences(argument, node, canAffectSiblingImport);
-        addUnknownAliasHazard(argument, node);
+        addExecutionUnknownAliasHazard(argument, node);
       });
       return;
     }
@@ -636,8 +512,8 @@ const collectRootMutationHazards = (
       // hazard lets known static processor calls remain classifiable, while a
       // direct/aliased tag still represents an opaque invocation.
       if (node.tag.type !== 'CallExpression') {
-        addReferences(node.tag, node, canAffectSiblingImport);
-        addUnknownAliasHazard(node.tag, node);
+        addReferences(node.tag, node, true);
+        addExecutionUnknownAliasHazard(node.tag, node);
       }
       node.quasi.expressions.forEach((expression) => {
         // The escape occurs when the tag is invoked, after interpolation
@@ -645,21 +521,13 @@ const collectRootMutationHazards = (
         // interpolation from invalidating its own pre-call snapshot, while
         // later destructuring still observes an opaque (non-call-classified)
         // escape.
-        addReferences(expression, node.quasi, canAffectSiblingImport);
-        addUnknownAliasHazard(expression, node.quasi);
+        addReferences(expression, node.quasi, true);
+        addExecutionUnknownAliasHazard(expression, node.quasi);
       });
     }
   });
 
-  const aliasLinks: Array<{
-    declaredAt: number;
-    sourceChangeCanAffectTargets?: (change: Node) => boolean;
-    sourceChangesAffectTargets?: boolean;
-    sources: string[];
-    targetChangeCanAffectSources?: (change: Node) => boolean;
-    targets: string[];
-    unprovenResult: boolean;
-  }> = [];
+  const aliasLinks: MutationAliasLink[] = [];
   visitOxcScopes(program, null, (node, scope, parent) => {
     if (ignoredHazardTreeNodes.has(node)) {
       return;
@@ -680,10 +548,11 @@ const collectRootMutationHazards = (
       ];
       aliasLinks.push({
         declaredAt: node.param.end,
+        executionOwner: getExecutionOwner(bindingIndex, node),
         sources: [
           ...new Set(
             sourceExpressions.flatMap((expression) =>
-              collectAliasReferenceKeys(expression)
+              collectCapturedAliasReferenceKeys(expression)
             )
           ),
         ],
@@ -712,10 +581,11 @@ const collectRootMutationHazards = (
           ];
           aliasLinks.push({
             declaredAt: node.right.end,
+            executionOwner: getExecutionOwner(bindingIndex, node),
             sources: [
               ...new Set(
                 sourceExpressions.flatMap((expression) =>
-                  collectAliasReferenceKeys(expression)
+                  collectCapturedAliasReferenceKeys(expression)
                 )
               ),
             ],
@@ -733,10 +603,11 @@ const collectRootMutationHazards = (
         ];
         aliasLinks.push({
           declaredAt: node.right.end,
+          executionOwner: getExecutionOwner(bindingIndex, node),
           sources: [
             ...new Set(
               sourceExpressions.flatMap((expression) =>
-                collectAliasReferenceKeys(expression)
+                collectCapturedAliasReferenceKeys(expression)
               )
             ),
           ],
@@ -748,14 +619,20 @@ const collectRootMutationHazards = (
     }
 
     if (node.type === 'FunctionDeclaration' && node.id) {
+      const sources = collectCapturedAliasReferenceKeys(node);
+      if (deferredFunctionsWithUnknownAlias.has(node)) {
+        sources.push(unknownAliasMutationBinding);
+      }
       aliasLinks.push({
+        callableNode: node,
         declaredAt: scope.parent?.start ?? 0,
+        executionOwner: getExecutionOwner(bindingIndex, node),
         sourceChangesAffectTargets: false,
-        sources: collectAliasReferenceKeys(node),
-        targetChangeCanAffectSources: (change) =>
-          change.type === 'CallExpression' ||
-          change.type === 'NewExpression' ||
-          change.type === 'TaggedTemplateExpression',
+        sources: [...new Set(sources)],
+        targetChangeCanAffectSources: (change, target) =>
+          collectInvocationTargetKeys(change, collectReferenceKeys).includes(
+            target
+          ),
         targets: collectDeclaredBindingKeys(
           [node.id.name],
           (binding) => binding.functionNode === node
@@ -777,10 +654,11 @@ const collectRootMutationHazards = (
 
         aliasLinks.push({
           declaredAt: param.end,
+          executionOwner: getExecutionOwner(bindingIndex, node),
           sources: [
             ...new Set(
               defaultExpressions.flatMap((expression) =>
-                collectAliasReferenceKeys(expression)
+                collectCapturedAliasReferenceKeys(expression)
               )
             ),
           ],
@@ -797,8 +675,10 @@ const collectRootMutationHazards = (
 
     if (node.type === 'ClassDeclaration' && node.id) {
       aliasLinks.push({
+        classNode: node,
         declaredAt: node.end,
-        sources: collectAliasReferenceKeys(node),
+        executionOwner: getExecutionOwner(bindingIndex, node),
+        sources: collectCapturedAliasReferenceKeys(node),
         targets: collectDeclaredBindingKeys(
           [node.id.name],
           (binding) =>
@@ -816,7 +696,8 @@ const collectRootMutationHazards = (
     if (node.type === 'AssignmentExpression') {
       aliasLinks.push({
         declaredAt: node.end,
-        sources: collectAliasReferenceKeys(node.right),
+        executionOwner: getExecutionOwner(bindingIndex, node),
+        sources: collectCapturedAliasReferenceKeys(node.right),
         targets: collectReferenceKeys(node.left),
         unprovenResult: containsUnprovenAlias(node.right),
       });
@@ -839,7 +720,7 @@ const collectRootMutationHazards = (
     const sources = [
       ...new Set(
         sourceExpressions.flatMap((expression) =>
-          collectAliasReferenceKeys(expression)
+          collectCapturedAliasReferenceKeys(expression)
         )
       ),
     ];
@@ -862,15 +743,29 @@ const collectRootMutationHazards = (
 
     if (directTargets.length > 0) {
       const isFunctionValue = !!node.init && isOxcFunctionLike(node.init);
+      const directSources =
+        isFunctionValue && node.init
+          ? collectCapturedAliasReferenceKeys(node.init)
+          : sources;
+      if (
+        isFunctionValue &&
+        node.init &&
+        deferredFunctionsWithUnknownAlias.has(node.init)
+      ) {
+        directSources.push(unknownAliasMutationBinding);
+      }
       aliasLinks.push({
+        callableNode: isFunctionValue ? node.init! : undefined,
         declaredAt: node.end,
+        executionOwner: getExecutionOwner(bindingIndex, node),
         sourceChangesAffectTargets: isFunctionValue ? false : undefined,
-        sources,
+        sources: [...new Set(directSources)],
         targetChangeCanAffectSources: isFunctionValue
-          ? (change) =>
-              change.type === 'CallExpression' ||
-              change.type === 'NewExpression' ||
-              change.type === 'TaggedTemplateExpression'
+          ? (change, target) =>
+              collectInvocationTargetKeys(
+                change,
+                collectReferenceKeys
+              ).includes(target)
           : undefined,
         targets: directTargets,
         unprovenResult: isFunctionValue ? false : unprovenResult,
@@ -879,6 +774,7 @@ const collectRootMutationHazards = (
     if (restTargets.length > 0) {
       aliasLinks.push({
         declaredAt: node.end,
+        executionOwner: getExecutionOwner(bindingIndex, node),
         sourceChangeCanAffectTargets: (change) =>
           shallowCopyChangeCanAffectBindings(sources, change),
         sources,
@@ -889,6 +785,13 @@ const collectRootMutationHazards = (
       });
     }
   });
+
+  publishDeferredUnknownAliasSources(
+    aliasLinks,
+    deferredFunctionsWithUnknownAlias,
+    containingClassByDeferredFunction,
+    unknownAliasMutationBinding
+  );
 
   // Propagation capability forms an absent < weak < strong lattice, while
   // published hazard membership is tracked separately from modeled mutation
@@ -997,7 +900,7 @@ const collectRootMutationHazards = (
         if (
           item.change.start < link.declaredAt ||
           (link.targetChangeCanAffectSources &&
-            !link.targetChangeCanAffectSources(item.change))
+            !link.targetChangeCanAffectSources(item.change, item.key))
         ) {
           continue;
         }

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -38,6 +38,7 @@ import {
   publishDeferredUnknownAliasSources,
   registerExecutionFunction,
   registerExecutionNode,
+  registerPostChildEvaluationEffect,
   type MutationAliasLink,
 } from './mutationExecution';
 import { visitOxcScopes } from './scopeTraversal';
@@ -515,12 +516,14 @@ const collectRootMutationHazards = (
         addReferences(node.tag, node, true);
         addExecutionUnknownAliasHazard(node.tag, node);
       }
+      registerPostChildEvaluationEffect(bindingIndex, node);
+      registerPostChildEvaluationEffect(bindingIndex, node.quasi);
       node.quasi.expressions.forEach((expression) => {
         // The escape occurs when the tag is invoked, after interpolation
-        // evaluation. Anchoring it on the quasi prevents a target
-        // interpolation from invalidating its own pre-call snapshot, while
-        // later destructuring still observes an opaque (non-call-classified)
-        // escape.
+        // evaluation. The explicit phase fence prevents execution-container
+        // ancestry from moving this effect before a deferred reference in its
+        // own interpolation, while later expressions still observe the
+        // opaque (non-call-classified) escape.
         addReferences(expression, node.quasi, true);
         addExecutionUnknownAliasHazard(expression, node.quasi);
       });

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -50,8 +50,16 @@ const markIgnoredMutationHazardTree = (
 export const registerMutationHazardNode = (
   node: Node,
   ignoreLookup: SpanLookup,
-  ignoredHazardNodes: Set<Node>
+  ignoreTreeLookup: SpanLookup,
+  ignoredHazardNodes: Set<Node>,
+  ignoredHazardTreeNodes: Set<Node>
 ): void => {
+  if (ignoreTreeLookup?.has(toSpanKey(node.start, node.end))) {
+    markIgnoredMutationHazardTree(node, ignoredHazardNodes);
+    markIgnoredMutationHazardTree(node, ignoredHazardTreeNodes);
+    return;
+  }
+
   if (!ignoreLookup?.has(toSpanKey(node.start, node.end))) {
     return;
   }
@@ -240,32 +248,63 @@ export const getRootMutationHazards = (
 
 const containsOpaqueAliasConstruct = (
   node: Node,
-  bindingIndex: BindingIndex
-): boolean =>
-  node.type === 'CallExpression' ||
-  node.type === 'NewExpression' ||
-  node.type === 'TaggedTemplateExpression' ||
-  node.type === 'ImportExpression' ||
-  node.type === 'ThisExpression' ||
-  node.type === 'Super' ||
-  (node.type === 'MemberExpression' &&
-    getReferences(node, bindingIndex).length === 0) ||
-  getOxcNodeChildren(node).some((child) =>
-    containsOpaqueAliasConstruct(child, bindingIndex)
+  bindingIndex: BindingIndex,
+  ignoredTreeNodes: ReadonlySet<Node>,
+  ignoredReferenceStarts: ReadonlySet<number>
+): boolean => {
+  if (ignoredTreeNodes.has(node)) {
+    return false;
+  }
+
+  return (
+    node.type === 'CallExpression' ||
+    node.type === 'NewExpression' ||
+    node.type === 'TaggedTemplateExpression' ||
+    node.type === 'ImportExpression' ||
+    node.type === 'ThisExpression' ||
+    node.type === 'Super' ||
+    (node.type === 'MemberExpression' &&
+      getReferences(node, bindingIndex).every((reference) =>
+        ignoredReferenceStarts.has(reference.start)
+      )) ||
+    getOxcNodeChildren(node).some((child) =>
+      containsOpaqueAliasConstruct(
+        child,
+        bindingIndex,
+        ignoredTreeNodes,
+        ignoredReferenceStarts
+      )
+    )
   );
+};
 
 const containsUnprovenAliasSource = (
   node: Node,
-  bindingIndex: BindingIndex
+  bindingIndex: BindingIndex,
+  ignoredTreeNodes: ReadonlySet<Node>,
+  ignoredReferenceStarts: ReadonlySet<number>
 ): boolean =>
-  getReferences(node, bindingIndex).some(
-    (reference) => reference.binding === null
-  ) || containsOpaqueAliasConstruct(node, bindingIndex);
+  !ignoredTreeNodes.has(node) &&
+  (getReferences(node, bindingIndex).some(
+    (reference) =>
+      !ignoredReferenceStarts.has(reference.start) && reference.binding === null
+  ) ||
+    containsOpaqueAliasConstruct(
+      node,
+      bindingIndex,
+      ignoredTreeNodes,
+      ignoredReferenceStarts
+    ));
 
 const collectThrownExpressions = (
   node: Node,
+  ignoredTreeNodes: ReadonlySet<Node>,
   expressions: Expression[] = []
 ): Expression[] => {
+  if (ignoredTreeNodes.has(node)) {
+    return expressions;
+  }
+
   if (
     node.type === 'FunctionDeclaration' ||
     node.type === 'FunctionExpression' ||
@@ -280,7 +319,7 @@ const collectThrownExpressions = (
   }
 
   getOxcNodeChildren(node).forEach((child) =>
-    collectThrownExpressions(child, expressions)
+    collectThrownExpressions(child, ignoredTreeNodes, expressions)
   );
   return expressions;
 };
@@ -289,7 +328,8 @@ const collectRootMutationHazards = (
   program: Program,
   mutations: Map<string, Array<AssignmentExpression | UpdateExpression>>,
   bindingIndex: BindingIndex,
-  ignoredHazardNodes: ReadonlySet<Node>
+  ignoredHazardNodes: ReadonlySet<Node>,
+  ignoredHazardTreeNodes: ReadonlySet<Node>
 ): Map<string, Node[]> => {
   const { bindingsByName } = bindingIndex;
   const hazards = new Map<string, Node[]>();
@@ -330,11 +370,22 @@ const collectRootMutationHazards = (
   ): Binding | undefined =>
     resolveBindingInIndex(bindingIndex, name, referenceStart);
 
+  const ignoredHazardTreeReferenceStarts = new Set<number>();
+  ignoredHazardTreeNodes.forEach((node) => {
+    if (node.type === 'Identifier') {
+      ignoredHazardTreeReferenceStarts.add(node.start);
+    }
+  });
+
   const collectReferenceKeys = (node: Node): string[] => [
     ...new Set(
-      getReferences(node, bindingIndex).map(({ binding, name }) =>
-        binding ? toMutationBindingKey(binding) : name
-      )
+      getReferences(node, bindingIndex)
+        .filter(
+          (reference) => !ignoredHazardTreeReferenceStarts.has(reference.start)
+        )
+        .map(({ binding, name }) =>
+          binding ? toMutationBindingKey(binding) : name
+        )
     ),
   ];
 
@@ -352,7 +403,8 @@ const collectRootMutationHazards = (
       getReferences(node, bindingIndex)
         .filter(
           (reference) =>
-            !processorManagedAliasReferenceStarts.has(reference.start)
+            !processorManagedAliasReferenceStarts.has(reference.start) &&
+            !ignoredHazardTreeReferenceStarts.has(reference.start)
         )
         .map(({ binding, name }) =>
           binding ? toMutationBindingKey(binding) : name
@@ -361,7 +413,12 @@ const collectRootMutationHazards = (
   ];
 
   const containsUnprovenAlias = (node: Node): boolean =>
-    containsUnprovenAliasSource(node, bindingIndex);
+    containsUnprovenAliasSource(
+      node,
+      bindingIndex,
+      ignoredHazardTreeNodes,
+      ignoredHazardTreeReferenceStarts
+    );
 
   const shallowCopyChangeCanAffectBindings = (
     bindings: readonly string[],
@@ -555,12 +612,19 @@ const collectRootMutationHazards = (
     unprovenResult: boolean;
   }> = [];
   visitOxcScopes(program, null, (node, scope, parent) => {
+    if (ignoredHazardTreeNodes.has(node)) {
+      return;
+    }
+
     if (
       node.type === 'CatchClause' &&
       node.param &&
       parent?.type === 'TryStatement'
     ) {
-      const thrownExpressions = collectThrownExpressions(parent.block);
+      const thrownExpressions = collectThrownExpressions(
+        parent.block,
+        ignoredHazardTreeNodes
+      );
       const sourceExpressions = [
         ...thrownExpressions,
         ...collectPatternDefaultExpressions(node.param),
@@ -957,6 +1021,7 @@ export const collectProgramMutationAnalysis = (
   program: Program,
   bindingIndex: BindingIndex,
   ignoredMutationHazardNodes: ReadonlySet<Node>,
+  ignoredMutationHazardTreeNodes: ReadonlySet<Node>,
   hasEffectiveMutationHazardSeed: boolean
 ): Pick<
   ProgramAnalysis,
@@ -970,7 +1035,8 @@ export const collectProgramMutationAnalysis = (
           program,
           rootMutationsByBinding,
           bindingIndex,
-          ignoredMutationHazardNodes
+          ignoredMutationHazardNodes,
+          ignoredMutationHazardTreeNodes
         );
 
   return {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -324,6 +324,39 @@ const collectThrownExpressions = (
   return expressions;
 };
 
+const isImmediatelyInvokedFunction = (
+  functionNode: Node,
+  ancestors: readonly Node[]
+): boolean => {
+  let child = functionNode;
+  for (let index = ancestors.length - 1; index >= 0; index -= 1) {
+    const ancestor = ancestors[index]!;
+    if (
+      ancestor.type === 'ParenthesizedExpression' &&
+      ancestor.expression === child
+    ) {
+      child = ancestor;
+      continue;
+    }
+    if (
+      ancestor.type === 'SequenceExpression' &&
+      ancestor.expressions[ancestor.expressions.length - 1] === child
+    ) {
+      child = ancestor;
+      continue;
+    }
+
+    return (
+      ((ancestor.type === 'CallExpression' ||
+        ancestor.type === 'NewExpression') &&
+        ancestor.callee === child) ||
+      (ancestor.type === 'TaggedTemplateExpression' && ancestor.tag === child)
+    );
+  }
+
+  return false;
+};
+
 const collectRootMutationHazards = (
   program: Program,
   mutations: Map<string, Array<AssignmentExpression | UpdateExpression>>,
@@ -529,17 +562,33 @@ const collectRootMutationHazards = (
     }
   };
 
-  visitOxcScopes(program, null, (node) => {
+  visitOxcScopes(program, null, (node, scope, _parent, ancestors) => {
+    if (
+      isOxcFunctionLike(node) &&
+      !isImmediatelyInvokedFunction(node, ancestors)
+    ) {
+      // Scope state is intentionally inherited by scopes created below it.
+      // eslint-disable-next-line no-param-reassign
+      scope.deferredFunction = true;
+    }
+
     if (!isEffectiveMutationHazardSeed(node, ignoredHazardNodes)) {
       return;
     }
+
+    // A dormant function body is not executed while the module's static
+    // exports are collected. Keep its direct binding hazard, but do not let
+    // that hazard poison sibling exports from the same imported module. If
+    // the function is invoked, its function alias link below promotes the
+    // captured bindings from the invocation site instead.
+    const canAffectSiblingImport = scope.deferredFunction !== true;
 
     if (node.type === 'AssignmentExpression') {
       // The RHS can similarly create an alias even when the LHS write itself
       // is one of the simple statically modeled root mutations.
       addReferences(node.right, node);
       if (!modeledMutations.has(node)) {
-        addReferences(node.left, node, true);
+        addReferences(node.left, node, canAffectSiblingImport);
         addUnknownAliasHazard(node.left, node);
       }
       return;
@@ -547,14 +596,14 @@ const collectRootMutationHazards = (
 
     if (node.type === 'UpdateExpression') {
       if (!modeledMutations.has(node)) {
-        addReferences(node.argument, node, true);
+        addReferences(node.argument, node, canAffectSiblingImport);
         addUnknownAliasHazard(node.argument, node);
       }
       return;
     }
 
     if (node.type === 'UnaryExpression' && node.operator === 'delete') {
-      addReferences(node.argument, node, true);
+      addReferences(node.argument, node, canAffectSiblingImport);
       addUnknownAliasHazard(node.argument, node);
       return;
     }
@@ -563,20 +612,20 @@ const collectRootMutationHazards = (
       // Any object passed to unknown code, or used as a method receiver, can
       // be mutated. Pure calls are intentionally rejected here rather than
       // risking a stale static snapshot.
-      addReferences(node.callee, node, true);
+      addReferences(node.callee, node, canAffectSiblingImport);
       addUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
-        addReferences(argument, node, true);
+        addReferences(argument, node, canAffectSiblingImport);
         addUnknownAliasHazard(argument, node);
       });
       return;
     }
 
     if (node.type === 'NewExpression') {
-      addReferences(node.callee, node, true);
+      addReferences(node.callee, node, canAffectSiblingImport);
       addUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
-        addReferences(argument, node, true);
+        addReferences(argument, node, canAffectSiblingImport);
         addUnknownAliasHazard(argument, node);
       });
       return;
@@ -587,7 +636,7 @@ const collectRootMutationHazards = (
       // hazard lets known static processor calls remain classifiable, while a
       // direct/aliased tag still represents an opaque invocation.
       if (node.tag.type !== 'CallExpression') {
-        addReferences(node.tag, node, true);
+        addReferences(node.tag, node, canAffectSiblingImport);
         addUnknownAliasHazard(node.tag, node);
       }
       node.quasi.expressions.forEach((expression) => {
@@ -596,7 +645,7 @@ const collectRootMutationHazards = (
         // interpolation from invalidating its own pre-call snapshot, while
         // later destructuring still observes an opaque (non-call-classified)
         // escape.
-        addReferences(expression, node.quasi, true);
+        addReferences(expression, node.quasi, canAffectSiblingImport);
         addUnknownAliasHazard(expression, node.quasi);
       });
     }

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -16,6 +16,7 @@ import {
 import { getOxcNodeChildren } from '../oxc/ast';
 import { collectOxcPatternBindingNames } from '../oxc/patterns';
 import { getOxcSyntacticPropertyKey } from '../oxc/projections';
+import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
 import {
   findResolvedReferences as getReferences,
   resolveBindingInIndex,
@@ -337,6 +338,28 @@ const collectRootMutationHazards = (
     ),
   ];
 
+  const processorManagedAliasReferenceStarts = new Set<number>();
+  ignoredHazardNodes.forEach((node) => {
+    if (node.type !== 'TaggedTemplateExpression') {
+      return;
+    }
+    getReferences(node, bindingIndex).forEach(({ start }) =>
+      processorManagedAliasReferenceStarts.add(start)
+    );
+  });
+  const collectAliasReferenceKeys = (node: Node): string[] => [
+    ...new Set(
+      getReferences(node, bindingIndex)
+        .filter(
+          (reference) =>
+            !processorManagedAliasReferenceStarts.has(reference.start)
+        )
+        .map(({ binding, name }) =>
+          binding ? toMutationBindingKey(binding) : name
+        )
+    ),
+  ];
+
   const containsUnprovenAlias = (node: Node): boolean =>
     containsUnprovenAliasSource(node, bindingIndex);
 
@@ -547,7 +570,7 @@ const collectRootMutationHazards = (
         sources: [
           ...new Set(
             sourceExpressions.flatMap((expression) =>
-              collectReferenceKeys(expression)
+              collectAliasReferenceKeys(expression)
             )
           ),
         ],
@@ -579,7 +602,7 @@ const collectRootMutationHazards = (
             sources: [
               ...new Set(
                 sourceExpressions.flatMap((expression) =>
-                  collectReferenceKeys(expression)
+                  collectAliasReferenceKeys(expression)
                 )
               ),
             ],
@@ -600,7 +623,7 @@ const collectRootMutationHazards = (
           sources: [
             ...new Set(
               sourceExpressions.flatMap((expression) =>
-                collectReferenceKeys(expression)
+                collectAliasReferenceKeys(expression)
               )
             ),
           ],
@@ -615,7 +638,7 @@ const collectRootMutationHazards = (
       aliasLinks.push({
         declaredAt: scope.parent?.start ?? 0,
         sourceChangesAffectTargets: false,
-        sources: collectReferenceKeys(node),
+        sources: collectAliasReferenceKeys(node),
         targetChangeCanAffectSources: (change) =>
           change.type === 'CallExpression' ||
           change.type === 'NewExpression' ||
@@ -644,7 +667,7 @@ const collectRootMutationHazards = (
           sources: [
             ...new Set(
               defaultExpressions.flatMap((expression) =>
-                collectReferenceKeys(expression)
+                collectAliasReferenceKeys(expression)
               )
             ),
           ],
@@ -662,7 +685,7 @@ const collectRootMutationHazards = (
     if (node.type === 'ClassDeclaration' && node.id) {
       aliasLinks.push({
         declaredAt: node.end,
-        sources: collectReferenceKeys(node),
+        sources: collectAliasReferenceKeys(node),
         targets: collectDeclaredBindingKeys(
           [node.id.name],
           (binding) =>
@@ -680,7 +703,7 @@ const collectRootMutationHazards = (
     if (node.type === 'AssignmentExpression') {
       aliasLinks.push({
         declaredAt: node.end,
-        sources: collectReferenceKeys(node.right),
+        sources: collectAliasReferenceKeys(node.right),
         targets: collectReferenceKeys(node.left),
         unprovenResult: containsUnprovenAlias(node.right),
       });
@@ -703,7 +726,7 @@ const collectRootMutationHazards = (
     const sources = [
       ...new Set(
         sourceExpressions.flatMap((expression) =>
-          collectReferenceKeys(expression)
+          collectAliasReferenceKeys(expression)
         )
       ),
     ];
@@ -725,11 +748,19 @@ const collectRootMutationHazards = (
     const unprovenResult = sourceExpressions.some(containsUnprovenAlias);
 
     if (directTargets.length > 0) {
+      const isFunctionValue = !!node.init && isOxcFunctionLike(node.init);
       aliasLinks.push({
         declaredAt: node.end,
+        sourceChangesAffectTargets: isFunctionValue ? false : undefined,
         sources,
+        targetChangeCanAffectSources: isFunctionValue
+          ? (change) =>
+              change.type === 'CallExpression' ||
+              change.type === 'NewExpression' ||
+              change.type === 'TaggedTemplateExpression'
+          : undefined,
         targets: directTargets,
-        unprovenResult,
+        unprovenResult: isFunctionValue ? false : unprovenResult,
       });
     }
     if (restTargets.length > 0) {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
@@ -40,6 +40,7 @@ type ExecutionIndex = {
   >;
   readonly ownerByStart: Map<number, ExecutionOwner>;
   readonly parentByFunction: Map<Node, ExecutionOwner>;
+  readonly postChildEvaluationEffects: WeakSet<Node>;
 };
 
 const executionIndexes = new WeakMap<BindingIndex, ExecutionIndex>();
@@ -54,6 +55,7 @@ const getExecutionIndex = (bindingIndex: BindingIndex): ExecutionIndex => {
     filteredTimelines: new WeakMap(),
     ownerByStart: new Map(),
     parentByFunction: new Map(),
+    postChildEvaluationEffects: new WeakSet(),
   };
   executionIndexes.set(bindingIndex, created);
   return created;
@@ -76,6 +78,13 @@ export const registerExecutionNode = (
   if (!ownerByStart.has(node.start)) {
     ownerByStart.set(node.start, owner);
   }
+};
+
+export const registerPostChildEvaluationEffect = (
+  bindingIndex: BindingIndex,
+  node: Node
+): void => {
+  getExecutionIndex(bindingIndex).postChildEvaluationEffects.add(node);
 };
 
 export const getExecutionOwner = (
@@ -159,6 +168,11 @@ export const someExecutionAncestorEffect = (
     const effectOwner = index.ownerByStart.get(effect.start) ?? null;
     return (
       effectOwner !== targetOwner &&
+      !(
+        index.postChildEvaluationEffects.has(effect) &&
+        effect.start <= targetStart &&
+        targetStart < effect.end
+      ) &&
       isExecutionOwnerVisible(
         effectOwner,
         targetOwner,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
@@ -1,0 +1,530 @@
+/* eslint-disable no-restricted-syntax,no-continue */
+
+import type {
+  AssignmentExpression,
+  Expression,
+  Node,
+  Program,
+  UpdateExpression,
+} from 'oxc-parser';
+
+import { getOxcNodeChildren } from '../oxc/ast';
+import { getOxcSyntacticPropertyKey } from '../oxc/projections';
+import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
+import { findResolvedReferences as getReferences } from './bindingResolution';
+import {
+  emptyMutationTimeline,
+  sealMutationTimeline,
+} from './mutationTimeline';
+import type { Binding, BindingIndex, MutationTimeline } from './types';
+
+type ExecutionOwner = Node | null;
+
+export type MutationAliasLink = {
+  callableNode?: Node;
+  classNode?: Node;
+  declaredAt: number;
+  executionOwner?: Node | null;
+  sourceChangeCanAffectTargets?: (change: Node) => boolean;
+  sourceChangesAffectTargets?: boolean;
+  sources: string[];
+  targetChangeCanAffectSources?: (change: Node, target: string) => boolean;
+  targets: string[];
+  unprovenResult: boolean;
+};
+
+type ExecutionIndex = {
+  readonly filteredTimelines: WeakMap<
+    MutationTimeline<Node>,
+    Map<ExecutionOwner, MutationTimeline<Node>>
+  >;
+  readonly ownerByStart: Map<number, ExecutionOwner>;
+  readonly parentByFunction: Map<Node, ExecutionOwner>;
+};
+
+const executionIndexes = new WeakMap<BindingIndex, ExecutionIndex>();
+
+const getExecutionIndex = (bindingIndex: BindingIndex): ExecutionIndex => {
+  const existing = executionIndexes.get(bindingIndex);
+  if (existing) {
+    return existing;
+  }
+
+  const created: ExecutionIndex = {
+    filteredTimelines: new WeakMap(),
+    ownerByStart: new Map(),
+    parentByFunction: new Map(),
+  };
+  executionIndexes.set(bindingIndex, created);
+  return created;
+};
+
+export const registerExecutionFunction = (
+  bindingIndex: BindingIndex,
+  node: Node,
+  parent: ExecutionOwner
+): void => {
+  getExecutionIndex(bindingIndex).parentByFunction.set(node, parent);
+};
+
+export const registerExecutionNode = (
+  bindingIndex: BindingIndex,
+  node: Node,
+  owner: ExecutionOwner
+): void => {
+  const { ownerByStart } = getExecutionIndex(bindingIndex);
+  if (!ownerByStart.has(node.start)) {
+    ownerByStart.set(node.start, owner);
+  }
+};
+
+export const getExecutionOwner = (
+  bindingIndex: BindingIndex,
+  node: Node
+): ExecutionOwner =>
+  executionIndexes.get(bindingIndex)?.ownerByStart.get(node.start) ?? null;
+
+const isExecutionOwnerVisible = (
+  effectOwner: ExecutionOwner,
+  targetOwner: ExecutionOwner,
+  parentByFunction: ReadonlyMap<Node, ExecutionOwner>
+): boolean => {
+  if (effectOwner === null) {
+    return true;
+  }
+
+  let current = targetOwner;
+  while (current) {
+    if (current === effectOwner) {
+      return true;
+    }
+    current = parentByFunction.get(current) ?? null;
+  }
+  return false;
+};
+
+export const getExecutionVisibleMutationTimeline = (
+  bindingIndex: BindingIndex,
+  timeline: MutationTimeline<Node>,
+  targetStart: number
+): MutationTimeline<Node> => {
+  if (timeline.byStart.length === 0) {
+    return emptyMutationTimeline;
+  }
+
+  const index = executionIndexes.get(bindingIndex);
+  if (!index) {
+    return timeline;
+  }
+
+  const targetOwner = index.ownerByStart.get(targetStart) ?? null;
+  let timelinesByOwner = index.filteredTimelines.get(timeline);
+  if (!timelinesByOwner) {
+    timelinesByOwner = new Map();
+    index.filteredTimelines.set(timeline, timelinesByOwner);
+  }
+  const cached = timelinesByOwner.get(targetOwner);
+  if (cached) {
+    return cached;
+  }
+
+  const visible = timeline.byStart.filter((effect) =>
+    isExecutionOwnerVisible(
+      index.ownerByStart.get(effect.start) ?? null,
+      targetOwner,
+      index.parentByFunction
+    )
+  );
+  const result =
+    visible.length === timeline.byStart.length
+      ? timeline
+      : sealMutationTimeline(visible);
+  timelinesByOwner.set(targetOwner, result);
+  return result;
+};
+
+export const someExecutionAncestorEffect = (
+  bindingIndex: BindingIndex,
+  timeline: MutationTimeline<Node>,
+  targetStart: number,
+  predicate: (effect: Node) => boolean
+): boolean => {
+  const index = executionIndexes.get(bindingIndex);
+  const targetOwner = index?.ownerByStart.get(targetStart) ?? null;
+  if (!index || !targetOwner) {
+    return false;
+  }
+
+  return timeline.byStart.some((effect) => {
+    const effectOwner = index.ownerByStart.get(effect.start) ?? null;
+    return (
+      effectOwner !== targetOwner &&
+      isExecutionOwnerVisible(
+        effectOwner,
+        targetOwner,
+        index.parentByFunction
+      ) &&
+      predicate(effect)
+    );
+  });
+};
+
+export const findContainingClass = (ancestors: readonly Node[]): Node | null =>
+  [...ancestors]
+    .reverse()
+    .find(
+      (ancestor) =>
+        ancestor.type === 'ClassDeclaration' ||
+        ancestor.type === 'ClassExpression'
+    ) ?? null;
+
+export const publishDeferredUnknownAliasSources = (
+  aliasLinks: MutationAliasLink[],
+  deferredFunctions: Set<Node>,
+  containingClassByFunction: ReadonlyMap<Node, Node>,
+  unknownAliasKey: string
+): void => {
+  aliasLinks.forEach((link) => {
+    if (link.unprovenResult && link.executionOwner) {
+      deferredFunctions.add(link.executionOwner);
+    }
+  });
+  const deferredClasses = new Set(
+    [...deferredFunctions]
+      .map((node) => containingClassByFunction.get(node))
+      .filter((node): node is Node => !!node)
+  );
+  aliasLinks.forEach((link) => {
+    if (
+      (link.callableNode && deferredFunctions.has(link.callableNode)) ||
+      (link.classNode && deferredClasses.has(link.classNode))
+    ) {
+      if (!link.sources.includes(unknownAliasKey)) {
+        link.sources.push(unknownAliasKey);
+      }
+    }
+  });
+};
+
+export type DeferredReferencePolicy = {
+  ignoredRoots: ReadonlySet<Node>;
+  ignoredStarts: ReadonlySet<number>;
+};
+
+export const collectMutationReferenceKeys = (
+  node: Node,
+  bindingIndex: BindingIndex,
+  ignoredStarts: readonly ReadonlySet<number>[],
+  toKey: (binding: Binding | null, name: string) => string,
+  includeBinding: (binding: Binding | null) => boolean = () => true
+): string[] => [
+  ...new Set(
+    getReferences(node, bindingIndex)
+      .filter(
+        (reference) =>
+          ignoredStarts.every((starts) => !starts.has(reference.start)) &&
+          includeBinding(reference.binding)
+      )
+      .map(({ binding, name }) => toKey(binding, name))
+  ),
+];
+
+export const collectRootMutations = (
+  program: Program
+): Map<string, Array<AssignmentExpression | UpdateExpression>> => {
+  const mutations = new Map<
+    string,
+    Array<AssignmentExpression | UpdateExpression>
+  >();
+
+  const getRootMutationTarget = (
+    node: Node
+  ): { binding: string; path: Array<string | number> } | null => {
+    if (node.type === 'Identifier') {
+      return { binding: node.name, path: [] };
+    }
+    if (node.type !== 'MemberExpression') {
+      return null;
+    }
+
+    const parent = getRootMutationTarget(node.object);
+    const key = getOxcSyntacticPropertyKey(node.property, node.computed);
+    return !parent || key === null
+      ? null
+      : { binding: parent.binding, path: [...parent.path, key] };
+  };
+
+  program.body.forEach((statement) => {
+    if (statement.type !== 'ExpressionStatement') {
+      return;
+    }
+
+    const { expression } = statement;
+    if (expression.type === 'AssignmentExpression') {
+      const target = getRootMutationTarget(expression.left);
+      if (expression.operator !== '=' || !target || target.path.length === 0) {
+        return;
+      }
+
+      const bucket = mutations.get(target.binding) ?? [];
+      bucket.push(expression);
+      mutations.set(target.binding, bucket);
+      return;
+    }
+
+    if (expression.type === 'UpdateExpression') {
+      const target = getRootMutationTarget(expression.argument);
+      if (!target || target.path.length === 0) {
+        return;
+      }
+
+      const bucket = mutations.get(target.binding) ?? [];
+      bucket.push(expression);
+      mutations.set(target.binding, bucket);
+    }
+  });
+
+  return mutations;
+};
+
+const containsOpaqueAliasConstruct = (
+  node: Node,
+  bindingIndex: BindingIndex,
+  ignoredTreeNodes: ReadonlySet<Node>,
+  ignoredReferenceStarts: ReadonlySet<number>,
+  ignoredSubtreeRoots?: ReadonlySet<Node>,
+  ignoredExtraReferenceStarts?: ReadonlySet<number>
+): boolean => {
+  if (ignoredTreeNodes.has(node) || ignoredSubtreeRoots?.has(node)) {
+    return false;
+  }
+
+  return (
+    node.type === 'CallExpression' ||
+    node.type === 'NewExpression' ||
+    node.type === 'TaggedTemplateExpression' ||
+    node.type === 'ImportExpression' ||
+    node.type === 'ThisExpression' ||
+    node.type === 'Super' ||
+    (node.type === 'MemberExpression' &&
+      getReferences(node, bindingIndex).every(
+        (reference) =>
+          ignoredReferenceStarts.has(reference.start) ||
+          ignoredExtraReferenceStarts?.has(reference.start)
+      )) ||
+    getOxcNodeChildren(node).some((child) =>
+      containsOpaqueAliasConstruct(
+        child,
+        bindingIndex,
+        ignoredTreeNodes,
+        ignoredReferenceStarts,
+        ignoredSubtreeRoots,
+        ignoredExtraReferenceStarts
+      )
+    )
+  );
+};
+
+export const containsUnprovenAliasSource = (
+  node: Node,
+  bindingIndex: BindingIndex,
+  ignoredTreeNodes: ReadonlySet<Node>,
+  ignoredReferenceStarts: ReadonlySet<number>,
+  ignoredSubtreeRoots?: ReadonlySet<Node>,
+  ignoredExtraReferenceStarts?: ReadonlySet<number>
+): boolean =>
+  !ignoredTreeNodes.has(node) &&
+  !ignoredSubtreeRoots?.has(node) &&
+  (getReferences(node, bindingIndex).some(
+    (reference) =>
+      !ignoredReferenceStarts.has(reference.start) &&
+      !ignoredExtraReferenceStarts?.has(reference.start) &&
+      reference.binding === null
+  ) ||
+    containsOpaqueAliasConstruct(
+      node,
+      bindingIndex,
+      ignoredTreeNodes,
+      ignoredReferenceStarts,
+      ignoredSubtreeRoots,
+      ignoredExtraReferenceStarts
+    ));
+
+export const collectThrownExpressions = (
+  node: Node,
+  ignoredTreeNodes: ReadonlySet<Node>,
+  expressions: Expression[] = []
+): Expression[] => {
+  if (ignoredTreeNodes.has(node)) {
+    return expressions;
+  }
+
+  if (isOxcFunctionLike(node)) {
+    return expressions;
+  }
+
+  if (node.type === 'ThrowStatement') {
+    expressions.push(node.argument);
+    return expressions;
+  }
+
+  getOxcNodeChildren(node).forEach((child) =>
+    collectThrownExpressions(child, ignoredTreeNodes, expressions)
+  );
+  return expressions;
+};
+
+export const isImmediatelyInvokedFunction = (
+  functionNode: Node,
+  ancestors: readonly Node[]
+): boolean => {
+  let child = functionNode;
+  for (let index = ancestors.length - 1; index >= 0; index -= 1) {
+    const ancestor = ancestors[index]!;
+    if (
+      ancestor.type === 'ParenthesizedExpression' &&
+      ancestor.expression === child
+    ) {
+      child = ancestor;
+      continue;
+    }
+    if (
+      ancestor.type === 'SequenceExpression' &&
+      ancestor.expressions[ancestor.expressions.length - 1] === child
+    ) {
+      child = ancestor;
+      continue;
+    }
+    if (
+      ancestor.type === 'ConditionalExpression' &&
+      (ancestor.consequent === child || ancestor.alternate === child)
+    ) {
+      child = ancestor;
+      continue;
+    }
+    if (
+      ancestor.type === 'LogicalExpression' &&
+      (ancestor.left === child || ancestor.right === child)
+    ) {
+      child = ancestor;
+      continue;
+    }
+    if (ancestor.type === 'AssignmentExpression' && ancestor.right === child) {
+      child = ancestor;
+      continue;
+    }
+
+    return (
+      ((ancestor.type === 'CallExpression' ||
+        ancestor.type === 'NewExpression') &&
+        ancestor.callee === child) ||
+      (ancestor.type === 'TaggedTemplateExpression' && ancestor.tag === child)
+    );
+  }
+
+  return false;
+};
+
+export const createDeferredReferencePolicyCollector = (
+  bindingIndex: BindingIndex
+): ((node: Node) => DeferredReferencePolicy) => {
+  const cache = new WeakMap<Node, DeferredReferencePolicy>();
+  return (node: Node): DeferredReferencePolicy => {
+    const cached = cache.get(node);
+    if (cached) {
+      return cached;
+    }
+
+    const ignoredRoots = new Set<Node>();
+    const ignoredStarts = new Set<number>();
+    const ancestors: Node[] = [];
+    const visit = (current: Node): void => {
+      if (
+        isOxcFunctionLike(current) &&
+        !isImmediatelyInvokedFunction(current, ancestors)
+      ) {
+        ignoredRoots.add(current);
+        getReferences(current, bindingIndex).forEach(({ start }) =>
+          ignoredStarts.add(start)
+        );
+        return;
+      }
+
+      ancestors.push(current);
+      getOxcNodeChildren(current).forEach(visit);
+      ancestors.pop();
+    };
+    visit(node);
+
+    const policy = { ignoredRoots, ignoredStarts };
+    cache.set(node, policy);
+    return policy;
+  };
+};
+
+export const collectInvocationTargetKeys = (
+  change: Node,
+  collectReferenceKeys: (node: Node) => readonly string[]
+): string[] => {
+  let invocationTarget: Node | null = null;
+  if (change.type === 'CallExpression' || change.type === 'NewExpression') {
+    invocationTarget = change.callee;
+  } else if (change.type === 'TaggedTemplateExpression') {
+    invocationTarget = change.tag;
+  }
+  if (!invocationTarget) {
+    return [];
+  }
+
+  const keys = new Set<string>();
+  const collect = (target: Node): void => {
+    if (
+      target.type === 'ParenthesizedExpression' ||
+      target.type === 'TSAsExpression' ||
+      target.type === 'TSInstantiationExpression' ||
+      target.type === 'TSNonNullExpression' ||
+      target.type === 'TSSatisfiesExpression' ||
+      target.type === 'TSTypeAssertion' ||
+      target.type === 'ChainExpression'
+    ) {
+      collect(target.expression);
+      return;
+    }
+    if (target.type === 'SequenceExpression') {
+      const last = target.expressions[target.expressions.length - 1];
+      if (last) {
+        collect(last);
+      }
+      return;
+    }
+    if (target.type === 'ConditionalExpression') {
+      collect(target.consequent);
+      collect(target.alternate);
+      return;
+    }
+    if (target.type === 'LogicalExpression') {
+      collect(target.left);
+      collect(target.right);
+      return;
+    }
+    if (target.type === 'AssignmentExpression') {
+      collect(target.right);
+      return;
+    }
+    if (target.type === 'Identifier') {
+      collectReferenceKeys(target).forEach((key) => keys.add(key));
+      return;
+    }
+    if (target.type === 'MemberExpression') {
+      const property = getOxcSyntacticPropertyKey(
+        target.property,
+        target.computed
+      );
+      if (property === 'call' || property === 'apply') {
+        collect(target.object);
+      }
+    }
+  };
+  collect(invocationTarget);
+  return [...keys];
+};

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/scopeAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/scopeAnalysis.ts
@@ -190,6 +190,7 @@ type AnalyzeProgramOptions = {
   collectTemplateLiterals?: boolean;
   expressionSpanLookup?: SpanLookup;
   mutationHazardIgnoreLookup?: SpanLookup;
+  mutationHazardIgnoreTreeLookup?: SpanLookup;
   templateSpanLookup?: SpanLookup;
 };
 
@@ -198,6 +199,7 @@ type NormalizedAnalyzeProgramOptions = {
   collectTemplateLiterals: boolean;
   expressionSpanLookup: SpanLookup;
   mutationHazardIgnoreLookup: SpanLookup;
+  mutationHazardIgnoreTreeLookup: SpanLookup;
   templateSpanLookup: SpanLookup;
 };
 
@@ -211,6 +213,7 @@ type RequestAnalysis = Pick<
 > & {
   hasEffectiveMutationHazardSeed: boolean;
   ignoredMutationHazardNodes: Set<Node>;
+  ignoredMutationHazardTreeNodes: Set<Node>;
 };
 
 const programScopeFacts = new WeakMap<Program, ProgramScopeFacts>();
@@ -236,6 +239,7 @@ const normalizeAnalyzeProgramOptions = ({
   collectTemplateLiterals = false,
   expressionSpanLookup,
   mutationHazardIgnoreLookup,
+  mutationHazardIgnoreTreeLookup,
   templateSpanLookup,
 }: AnalyzeProgramOptions): NormalizedAnalyzeProgramOptions => {
   const normalizedExpressionSpanLookup =
@@ -250,6 +254,9 @@ const normalizeAnalyzeProgramOptions = ({
       ? normalizedExpressionSpanLookup
       : null,
     mutationHazardIgnoreLookup: normalizeSpanLookup(mutationHazardIgnoreLookup),
+    mutationHazardIgnoreTreeLookup: normalizeSpanLookup(
+      mutationHazardIgnoreTreeLookup
+    ),
     templateSpanLookup: collectTemplateLiterals
       ? templateSpanLookup ?? null
       : null,
@@ -264,6 +271,7 @@ const programAnalysisCacheKey = ({
   collectTemplateLiterals,
   expressionSpanLookup,
   mutationHazardIgnoreLookup,
+  mutationHazardIgnoreTreeLookup,
   templateSpanLookup,
 }: NormalizedAnalyzeProgramOptions): string =>
   JSON.stringify([
@@ -271,6 +279,7 @@ const programAnalysisCacheKey = ({
     collectTemplateLiterals ? '1' : '0',
     sortedSpanLookup(expressionSpanLookup),
     sortedSpanLookup(mutationHazardIgnoreLookup),
+    sortedSpanLookup(mutationHazardIgnoreTreeLookup),
     sortedSpanLookup(templateSpanLookup),
   ]);
 
@@ -321,6 +330,7 @@ const createRequestAnalysis = ({
   collectTemplateLiterals,
   expressionSpanLookup,
   mutationHazardIgnoreLookup,
+  mutationHazardIgnoreTreeLookup,
   templateSpanLookup,
 }: NormalizedAnalyzeProgramOptions): {
   collect: (node: Node, ancestors: Node[]) => void;
@@ -329,6 +339,7 @@ const createRequestAnalysis = ({
   const result: RequestAnalysis = {
     hasEffectiveMutationHazardSeed: false,
     ignoredMutationHazardNodes: new Set(),
+    ignoredMutationHazardTreeNodes: new Set(),
     targetExpressions: [],
     templateLiterals: [],
   };
@@ -338,7 +349,17 @@ const createRequestAnalysis = ({
       registerMutationHazardNode(
         node,
         mutationHazardIgnoreLookup,
-        result.ignoredMutationHazardNodes
+        mutationHazardIgnoreTreeLookup,
+        result.ignoredMutationHazardNodes,
+        result.ignoredMutationHazardTreeNodes
+      );
+    } else if (mutationHazardIgnoreTreeLookup) {
+      registerMutationHazardNode(
+        node,
+        null,
+        mutationHazardIgnoreTreeLookup,
+        result.ignoredMutationHazardNodes,
+        result.ignoredMutationHazardTreeNodes
       );
     }
     result.hasEffectiveMutationHazardSeed ||= isEffectiveMutationHazardSeed(
@@ -576,14 +597,17 @@ export const analyzeProgram = (
     collectTemplateLiterals = false,
     expressionSpanLookup = null,
     mutationHazardIgnoreLookup = null,
+    mutationHazardIgnoreTreeLookup = null,
   } = normalizedOptions;
   const request = createRequestAnalysis(normalizedOptions);
   let scopeFacts = programScopeFacts.get(program);
-  const cachedDefaultMutationHazards = mutationHazardIgnoreLookup
-    ? undefined
-    : programDefaultMutationHazards.get(program);
+  const cachedDefaultMutationHazards =
+    mutationHazardIgnoreLookup || mutationHazardIgnoreTreeLookup
+      ? undefined
+      : programDefaultMutationHazards.get(program);
   const needsRequestTraversal =
     mutationHazardIgnoreLookup !== null ||
+    mutationHazardIgnoreTreeLookup !== null ||
     cachedDefaultMutationHazards === undefined ||
     collectTemplateLiterals ||
     (collectTargetExpressions && expressionSpanLookup !== null);
@@ -602,6 +626,7 @@ export const analyzeProgram = (
       program,
       scopeFacts.bindingIndex,
       request.result.ignoredMutationHazardNodes,
+      request.result.ignoredMutationHazardTreeNodes,
       request.result.hasEffectiveMutationHazardSeed
     );
     rootMutationHazardsByBinding =
@@ -610,7 +635,7 @@ export const analyzeProgram = (
     if (!programRootMutations.has(program)) {
       programRootMutations.set(program, rootMutationsByBinding);
     }
-    if (!mutationHazardIgnoreLookup) {
+    if (!mutationHazardIgnoreLookup && !mutationHazardIgnoreTreeLookup) {
       programDefaultMutationHazards.set(program, rootMutationHazardsByBinding);
     }
   }

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/scopeTraversal.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/scopeTraversal.ts
@@ -20,6 +20,7 @@ const createScope = (
   boundary: OxcLexicalScopeBoundary
 ): Scope => ({
   bindings: new Map(),
+  deferredFunction: parent?.deferredFunction ?? false,
   depth: parent ? parent.depth + 1 : 0,
   end: boundary.end,
   functionBoundary: boundary.functionBoundary,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/scopeTraversal.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/scopeTraversal.ts
@@ -20,7 +20,7 @@ const createScope = (
   boundary: OxcLexicalScopeBoundary
 ): Scope => ({
   bindings: new Map(),
-  deferredFunction: parent?.deferredFunction ?? false,
+  deferredFunctionNode: parent?.deferredFunctionNode,
   depth: parent ? parent.depth + 1 : 0,
   end: boundary.end,
   functionBoundary: boundary.functionBoundary,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/snapshotReplay.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/snapshotReplay.ts
@@ -15,11 +15,14 @@ import {
   forEachTimelineFullyContained,
   getMutationTimeline,
   resolveBindingAt,
-  someTimelineEndAtOrBefore,
   someTimelineStartBefore,
   toMutationBindingKey,
 } from './scopeAnalysis';
 import { isKnownPureStaticCall } from './staticEvaluator';
+import {
+  getHazardTimelineAt,
+  someHazardTimelineEndAtOrBefore,
+} from './staticEvaluationSafety';
 import type { Binding, ExpressionSpan, ExtractionContext } from './types';
 
 export const allocateHoistedBindingName = (
@@ -49,7 +52,8 @@ export const countPatternBindingNames = (pattern: Node): Map<string, number> =>
 export const hasDestructuringIntrinsicMutationBefore = (
   pattern: Node,
   referenceStart: number,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  targetStart = referenceStart
 ): boolean => {
   const intrinsicNames =
     pattern.type === 'ArrayPattern' ? ['Array', 'Object'] : ['Object', 'Array'];
@@ -64,9 +68,10 @@ export const hasDestructuringIntrinsicMutationBefore = (
         referenceStart,
         changesUnshadowedIntrinsic
       ) ||
-      someTimelineEndAtOrBefore(
-        getMutationTimeline(ctx.rootMutationHazardsByBinding, name),
+      someHazardTimelineEndAtOrBefore(
+        getHazardTimelineAt(name, targetStart, ctx),
         referenceStart,
+        ctx,
         changesUnshadowedIntrinsic
       )
     );
@@ -92,9 +97,10 @@ export const hasAnyBindingChange = (
   return (
     getMutationTimeline(ctx.rootMutationsByBinding, bindingKey).byStart.length >
       0 ||
-    getMutationTimeline(
-      ctx.rootMutationHazardsByBinding,
-      bindingKey
+    getHazardTimelineAt(
+      bindingKey,
+      ctx.currentExpressionStart,
+      ctx
     ).byStart.some((hazard) => isOpaqueDestructuringHazard(hazard, ctx))
   );
 };
@@ -303,7 +309,8 @@ const collectSnapshotStatements = (
     hasDestructuringIntrinsicMutationBefore(
       declarator.id,
       Number.POSITIVE_INFINITY,
-      ctx
+      ctx,
+      ctx.currentExpressionStart
     )
   ) {
     throw snapshotReplayError();
@@ -417,7 +424,7 @@ const collectSnapshotStatements = (
         includeChange
       );
       forEachTimelineFullyContained(
-        getMutationTimeline(ctx.rootMutationHazardsByBinding, dependencyKey),
+        getHazardTimelineAt(dependencyKey, ctx.currentExpressionStart, ctx),
         body.start,
         ctx.currentExpressionStart,
         (hazard) => {
@@ -479,9 +486,10 @@ const collectSnapshotStatements = (
         ctx.rootMutationsByBinding,
         toMutationBindingKey(dependency)
       ).byStart.length === 0 &&
-      getMutationTimeline(
-        ctx.rootMutationHazardsByBinding,
-        toMutationBindingKey(dependency)
+      getHazardTimelineAt(
+        toMutationBindingKey(dependency),
+        ctx.currentExpressionStart,
+        ctx
       ).byStart.every((hazard) => !isOpaqueDestructuringHazard(hazard, ctx))
     ) {
       return;

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/snapshotValueAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/snapshotValueAnalysis.ts
@@ -10,10 +10,13 @@ import {
   forEachTimelineStartBefore,
   getMutationTimeline,
   resolveBindingAt,
-  someTimelineStartBefore,
   toMutationBindingKey,
 } from './scopeAnalysis';
 import { evaluateStatic } from './staticEvaluator';
+import {
+  getHazardTimelineAt,
+  someHazardTimelineEndAtOrBefore,
+} from './staticEvaluationSafety';
 import { toOxcBindingIdentity } from './bindingIdentity';
 import type { Binding, ExtractionContext } from './types';
 
@@ -658,7 +661,7 @@ function inferSnapshotBindingKind(
   const bindingKey = toMutationBindingKey(binding);
   forEachMergedTimelineStartBefore(
     getMutationTimeline(ctx.rootMutationsByBinding, bindingKey),
-    getMutationTimeline(ctx.rootMutationHazardsByBinding, bindingKey),
+    getHazardTimelineAt(bindingKey, ctx.currentExpressionStart, ctx),
     ctx.currentExpressionStart,
     (hazard) =>
       hazard.type === 'AssignmentExpression' ||
@@ -689,9 +692,10 @@ function inferSnapshotBindingKind(
     }
   );
 
-  const hasOpaqueCallHazard = someTimelineStartBefore(
-    getMutationTimeline(ctx.rootMutationHazardsByBinding, bindingKey),
+  const hasOpaqueCallHazard = someHazardTimelineEndAtOrBefore(
+    getHazardTimelineAt(bindingKey, ctx.currentExpressionStart, ctx),
     ctx.currentExpressionStart,
+    ctx,
     (hazard) => {
       if (
         hazard.type === 'CallExpression' &&

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluationSafety.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluationSafety.ts
@@ -19,8 +19,11 @@ import {
 import { getOxcSyntacticPropertyKey } from '../oxc/projections';
 import { findResolvedReferences as getReferences } from './bindingResolution';
 import {
+  getExecutionVisibleMutationTimeline,
+  someExecutionAncestorEffect,
+} from './mutationExecution';
+import {
   getMutationTimeline,
-  hasTimelineEndAtOrBefore,
   someTimelineEndAtOrBefore,
   someTimelineStartBefore,
   unknownAliasMutationBinding,
@@ -134,9 +137,10 @@ const someIntrinsicChangeEndAtOrBefore = (
     end,
     predicate
   ) ||
-  someTimelineEndAtOrBefore(
-    getMutationTimeline(ctx.rootMutationHazardsByBinding, binding),
+  someHazardTimelineEndAtOrBefore(
+    getHazardTimelineAt(binding, end, ctx),
     end,
+    ctx,
     predicate
   );
 
@@ -145,12 +149,11 @@ export const hasRelevantIntrinsicMutationBefore = (
   end: number,
   ctx: ExtractionContext
 ): boolean => {
-  const unknownAliasChangesBefore = hasTimelineEndAtOrBefore(
-    getMutationTimeline(
-      ctx.rootMutationHazardsByBinding,
-      unknownAliasMutationBinding
-    ),
-    end
+  const unknownAliasChangesBefore = someHazardTimelineEndAtOrBefore(
+    getHazardTimelineAt(unknownAliasMutationBinding, end, ctx),
+    end,
+    ctx,
+    () => true
   );
 
   if (
@@ -178,12 +181,11 @@ export const hasArrayIterationMutationBefore = (
   end: number,
   ctx: ExtractionContext
 ): boolean =>
-  hasTimelineEndAtOrBefore(
-    getMutationTimeline(
-      ctx.rootMutationHazardsByBinding,
-      unknownAliasMutationBinding
-    ),
-    end
+  someHazardTimelineEndAtOrBefore(
+    getHazardTimelineAt(unknownAliasMutationBinding, end, ctx),
+    end,
+    ctx,
+    () => true
   ) ||
   someIntrinsicChangeEndAtOrBefore(
     'Object',
@@ -224,13 +226,39 @@ export const getBindingDirectTimeline = (
     toMutationBindingKey(binding)
   );
 
+export const getHazardTimelineAt = (
+  binding: string,
+  targetStart: number,
+  ctx: ExtractionContext
+): MutationTimeline<Node> =>
+  getExecutionVisibleMutationTimeline(
+    ctx.bindingIndex,
+    getMutationTimeline(ctx.rootMutationHazardsByBinding, binding),
+    targetStart
+  );
+
+export const someHazardTimelineEndAtOrBefore = (
+  timeline: MutationTimeline<Node>,
+  targetStart: number,
+  ctx: ExtractionContext,
+  predicate: (hazard: Node) => boolean
+): boolean =>
+  someTimelineEndAtOrBefore(timeline, targetStart, predicate) ||
+  someExecutionAncestorEffect(
+    ctx.bindingIndex,
+    timeline,
+    targetStart,
+    predicate
+  );
+
 export const getBindingHazardTimeline = (
   binding: Binding,
   ctx: ExtractionContext
-) =>
-  getMutationTimeline(
-    ctx.rootMutationHazardsByBinding,
-    toMutationBindingKey(binding)
+): MutationTimeline<Node> =>
+  getHazardTimelineAt(
+    toMutationBindingKey(binding),
+    ctx.currentExpressionStart,
+    ctx
   );
 
 const assignmentTargetContainsBinding = (
@@ -277,9 +305,10 @@ export const hasDirectBindingMutationBefore = (
     end,
     (mutation) => mutationDirectlyTargetsBinding(mutation, binding, ctx)
   ) ||
-  someTimelineEndAtOrBefore(
+  someHazardTimelineEndAtOrBefore(
     getBindingHazardTimeline(binding, ctx),
     end,
+    ctx,
     (mutation) => mutationDirectlyTargetsBinding(mutation, binding, ctx)
   );
 

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
@@ -60,7 +60,8 @@ const hasReferencedRootMutationBetween = (
   expression: Expression,
   start: number,
   end: number,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  env: EvalEnv
 ): boolean =>
   getReferences(expression, ctx.bindingIndex).some(({ binding }) => {
     if (!binding) {
@@ -77,14 +78,15 @@ const hasReferencedRootMutationBetween = (
         getBindingHazardTimeline(binding, ctx),
         start,
         end,
-        (hazard) => !isKnownPureStaticCall(hazard, ctx)
+        (hazard) => !isKnownPureStaticCall(hazard, ctx, env)
       )
     );
   });
 
 export const isKnownPureStaticCall = (
   node: Node,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  env?: EvalEnv
 ): boolean => {
   // Tagged templates are classified more precisely by the destructuring
   // projection gate. Treating them as ordinary binding mutations here would
@@ -124,7 +126,12 @@ export const isKnownPureStaticCall = (
     return false;
   }
 
-  return recursiveProof.run(node, ctx.staticCallProof, () => {
+  const proofEnv = env ?? new Map();
+  const proofState =
+    proofEnv.size === 0
+      ? ctx.staticCallProof
+      : recursiveProof.partial(ctx.staticCallProof);
+  return recursiveProof.run(node, proofState, () => {
     const proofCtx: ExtractionContext = {
       ...ctx,
       currentExpressionStart: node.start,
@@ -143,10 +150,12 @@ export const isKnownPureStaticCall = (
     const argumentsAreScalar = node.arguments.every(
       (argument) =>
         argument.type !== 'SpreadElement' &&
-        isScalar(evaluateStatic(argument, proofCtx))
+        isScalar(evaluateStatic(argument, proofCtx, proofEnv))
     );
 
-    return argumentsAreScalar && isScalar(evaluateStatic(node, proofCtx));
+    return (
+      argumentsAreScalar && isScalar(evaluateStatic(node, proofCtx, proofEnv))
+    );
   });
 };
 
@@ -154,7 +163,8 @@ const hasReferencedRootMutationHazardBefore = (
   expression: Expression,
   end: number,
   ctx: ExtractionContext,
-  ignoredHazard?: Node
+  ignoredHazard: Node | undefined,
+  env: EvalEnv
 ): boolean => {
   if (ctx.rootMutationHazardsByBinding.size === 0) {
     return false;
@@ -169,7 +179,7 @@ const hasReferencedRootMutationHazardBefore = (
       getBindingHazardTimeline(binding, ctx),
       end,
       (hazard) =>
-        !isKnownPureStaticCall(hazard, ctx) &&
+        !isKnownPureStaticCall(hazard, ctx, env) &&
         (!ignoredHazard ||
           hazard.start < ignoredHazard.start ||
           ignoredHazard.end < hazard.end)
@@ -181,19 +191,21 @@ const hasBindingMutationHazardBetween = (
   binding: Binding,
   start: number,
   end: number,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  env: EvalEnv
 ): boolean =>
   timeline.someTimelineFullyContained(
     getBindingHazardTimeline(binding, ctx),
     start,
     end,
-    (hazard) => !isKnownPureStaticCall(hazard, ctx)
+    (hazard) => !isKnownPureStaticCall(hazard, ctx, env)
   );
 
 const hasBindingMutationBefore = (
   binding: Binding,
   end: number,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  env: EvalEnv
 ): boolean =>
   timeline.hasTimelineStartBefore(
     getBindingDirectTimeline(binding, ctx),
@@ -202,7 +214,7 @@ const hasBindingMutationBefore = (
   timeline.someTimelineEndAtOrBefore(
     getBindingHazardTimeline(binding, ctx),
     end,
-    (hazard) => !isKnownPureStaticCall(hazard, ctx)
+    (hazard) => !isKnownPureStaticCall(hazard, ctx, env)
   );
 
 export const evaluateStatic = (
@@ -370,7 +382,7 @@ export const evaluateStatic = (
 
       if (
         binding?.importedFrom &&
-        hasBindingMutationBefore(binding, ctx.currentExpressionStart, ctx)
+        hasBindingMutationBefore(binding, ctx.currentExpressionStart, ctx, env)
       ) {
         return undefined;
       }
@@ -379,7 +391,9 @@ export const evaluateStatic = (
     }
 
     if (binding?.importedFrom) {
-      if (hasBindingMutationBefore(binding, ctx.currentExpressionStart, ctx)) {
+      if (
+        hasBindingMutationBefore(binding, ctx.currentExpressionStart, ctx, env)
+      ) {
         return undefined;
       }
 
@@ -430,7 +444,7 @@ export const evaluateStatic = (
           ctx,
           bindingMutations,
           bindingMutationHazards,
-          isKnownPureStaticCall
+          (hazard, proofCtx) => isKnownPureStaticCall(hazard, proofCtx, env)
         )
       : null;
     if (valueCacheKey && env.has(valueCacheKey)) {
@@ -450,7 +464,8 @@ export const evaluateStatic = (
             init,
             ctx.currentExpressionStart,
             ctx,
-            declarator
+            declarator,
+            env
           )
         ) {
           return undefined;
@@ -460,7 +475,13 @@ export const evaluateStatic = (
         if (
           binding.declarationKind !== 'const' ||
           expression.start < declarator.end ||
-          hasReferencedRootMutationHazardBefore(init, declarator.start, ctx)
+          hasReferencedRootMutationHazardBefore(
+            init,
+            declarator.start,
+            ctx,
+            undefined,
+            env
+          )
         ) {
           return undefined;
         }
@@ -484,7 +505,9 @@ export const evaluateStatic = (
               hasReferencedRootMutationHazardBefore(
                 runtimeExpression,
                 declarator.start,
-                ctx
+                ctx,
+                undefined,
+                env
               )
           )
         ) {
@@ -523,14 +546,16 @@ export const evaluateStatic = (
             init,
             declarator.end,
             ctx.currentExpressionStart,
-            ctx
+            ctx,
+            env
           ) ||
           patternRuntimeExpressions.some((runtimeExpression) =>
             hasReferencedRootMutationBetween(
               runtimeExpression,
               declarator.end,
               ctx.currentExpressionStart,
-              ctx
+              ctx,
+              env
             )
           );
         if (
@@ -541,7 +566,8 @@ export const evaluateStatic = (
               binding,
               declarator.end,
               ctx.currentExpressionStart,
-              ctx
+              ctx,
+              env
             ))
         ) {
           return undefined;
@@ -572,7 +598,8 @@ export const evaluateStatic = (
                 ctx,
                 undefined,
                 undefined,
-                isKnownPureStaticCall
+                (hazard, proofCtx) =>
+                  isKnownPureStaticCall(hazard, proofCtx, env)
               ),
               siblingValue
             );
@@ -595,7 +622,7 @@ export const evaluateStatic = (
       ctx.currentExpressionStart
     );
     const isUnreplayedPriorHazard = (hazard: Node): boolean =>
-      !isKnownPureStaticCall(hazard, ctx) &&
+      !isKnownPureStaticCall(hazard, ctx, env) &&
       !timeline.timelineStartBeforeIncludes(
         bindingMutations,
         ctx.currentExpressionStart,
@@ -972,6 +999,28 @@ export const evaluateStatic = (
     }
 
     if (expression.callee.type === 'MemberExpression') {
+      if (
+        !expression.callee.computed &&
+        expression.callee.object.type === 'Identifier' &&
+        expression.callee.object.name === 'Math' &&
+        !resolveBindingAt(
+          ctx,
+          expression.callee.object.name,
+          expression.callee.object.start
+        ) &&
+        expression.callee.property.type === 'Identifier' &&
+        expression.callee.property.name === 'round' &&
+        expression.arguments.length === 1
+      ) {
+        const [argument] = expression.arguments;
+        if (argument?.type !== 'SpreadElement') {
+          const value = evaluateStatic(argument, ctx, env, stack);
+          if (typeof value === 'number') {
+            return Math.round(value);
+          }
+        }
+      }
+
       const objectValue = evaluateStatic(
         expression.callee.object,
         ctx,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
@@ -6,10 +6,15 @@ import {
   collectOxcPatternBindingNames,
   collectOxcPatternRuntimeExpressions,
 } from '../oxc/patterns';
-import { getOxcNodeChildren } from '../oxc/ast';
 import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
-import { findResolvedReferences as getReferences } from './bindingResolution';
 import { lookupStaticBinding } from './staticBindings';
+import { isReadOnlyOpaqueFunction } from './staticFunctionPurity';
+import {
+  hasBindingMutationBefore,
+  hasBindingMutationHazardBetween,
+  hasReferencedRootMutationBetween,
+  hasReferencedRootMutationHazardBefore,
+} from './staticMutationChecks';
 import * as timeline from './mutationTimeline';
 import * as recursiveProof from './recursiveProof';
 import { resolveBindingAt } from './scopeAnalysis';
@@ -53,97 +58,9 @@ import {
   type EvalEnv,
   type EvaluationStack,
 } from './staticEvaluationRuntime';
-import type { Binding, ExtractionContext } from './types';
+import type { ExtractionContext } from './types';
 
 export { createOxcStaticCallableValue } from './staticEvaluationRuntime';
-
-const isDirectReadOnlyExpression = (node: Node): boolean => {
-  if (
-    node.type === 'TSAsExpression' ||
-    node.type === 'TSSatisfiesExpression' ||
-    node.type === 'TSNonNullExpression' ||
-    node.type === 'TSInstantiationExpression' ||
-    node.type === 'TSTypeAssertion' ||
-    node.type === 'ParenthesizedExpression'
-  ) {
-    return isDirectReadOnlyExpression(node.expression);
-  }
-
-  return node.type === 'Identifier' || node.type === 'Literal';
-};
-
-const readOnlyOpaqueFunctionCache = new WeakMap<Node, boolean>();
-
-const isReadOnlyOpaqueFunction = (node: Node): boolean => {
-  const cached = readOnlyOpaqueFunctionCache.get(node);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  if (!isOxcFunctionLike(node)) {
-    readOnlyOpaqueFunctionCache.set(node, false);
-    return false;
-  }
-
-  if (
-    node.params.some(
-      (param) => collectOxcPatternRuntimeExpressions(param).length > 0
-    )
-  ) {
-    readOnlyOpaqueFunctionCache.set(node, false);
-    return false;
-  }
-
-  const { body } = node;
-  if (!body) {
-    readOnlyOpaqueFunctionCache.set(node, false);
-    return false;
-  }
-  if (body.type !== 'BlockStatement') {
-    const result = isDirectReadOnlyExpression(body);
-    readOnlyOpaqueFunctionCache.set(node, result);
-    return result;
-  }
-
-  const result = getOxcNodeChildren(body).every(
-    (statement) =>
-      statement.type === 'EmptyStatement' ||
-      (statement.type === 'ExpressionStatement' &&
-        statement.expression.type === 'Literal' &&
-        typeof statement.expression.value === 'string') ||
-      (statement.type === 'ReturnStatement' &&
-        (!statement.argument || isDirectReadOnlyExpression(statement.argument)))
-  );
-  readOnlyOpaqueFunctionCache.set(node, result);
-  return result;
-};
-
-const hasReferencedRootMutationBetween = (
-  expression: Expression,
-  start: number,
-  end: number,
-  ctx: ExtractionContext,
-  env: EvalEnv
-): boolean =>
-  getReferences(expression, ctx.bindingIndex).some(({ binding }) => {
-    if (!binding) {
-      return false;
-    }
-
-    return (
-      timeline.hasTimelineStartInRange(
-        getBindingDirectTimeline(binding, ctx),
-        start,
-        end
-      ) ||
-      timeline.someTimelineFullyContained(
-        getBindingHazardTimeline(binding, ctx),
-        start,
-        end,
-        (hazard) => !isKnownPureStaticCall(hazard, ctx, env)
-      )
-    );
-  });
 
 export const isKnownPureStaticCall = (
   node: Node,
@@ -188,10 +105,8 @@ export const isKnownPureStaticCall = (
     return false;
   }
 
-  // A helper that only returns a direct binding/literal read cannot mutate
-  // unrelated state even when that binding is intentionally unavailable to
-  // the static evaluator. This distinction matters for sibling imports: an
-  // opaque return value is not the same thing as an impure invocation.
+  // An opaque return value is distinct from an impure invocation. A helper
+  // that only returns a direct read cannot mutate sibling imports.
   if (isReadOnlyOpaqueFunction(fn)) {
     return true;
   }
@@ -228,64 +143,6 @@ export const isKnownPureStaticCall = (
     );
   });
 };
-
-const hasReferencedRootMutationHazardBefore = (
-  expression: Expression,
-  end: number,
-  ctx: ExtractionContext,
-  ignoredHazard: Node | undefined,
-  env: EvalEnv
-): boolean => {
-  if (ctx.rootMutationHazardsByBinding.size === 0) {
-    return false;
-  }
-
-  return getReferences(expression, ctx.bindingIndex).some(({ binding }) => {
-    if (!binding) {
-      return false;
-    }
-
-    return timeline.someTimelineEndAtOrBefore(
-      getBindingHazardTimeline(binding, ctx),
-      end,
-      (hazard) =>
-        !isKnownPureStaticCall(hazard, ctx, env) &&
-        (!ignoredHazard ||
-          hazard.start < ignoredHazard.start ||
-          ignoredHazard.end < hazard.end)
-    );
-  });
-};
-
-const hasBindingMutationHazardBetween = (
-  binding: Binding,
-  start: number,
-  end: number,
-  ctx: ExtractionContext,
-  env: EvalEnv
-): boolean =>
-  timeline.someTimelineFullyContained(
-    getBindingHazardTimeline(binding, ctx),
-    start,
-    end,
-    (hazard) => !isKnownPureStaticCall(hazard, ctx, env)
-  );
-
-const hasBindingMutationBefore = (
-  binding: Binding,
-  end: number,
-  ctx: ExtractionContext,
-  env: EvalEnv
-): boolean =>
-  timeline.hasTimelineStartBefore(
-    getBindingDirectTimeline(binding, ctx),
-    end
-  ) ||
-  timeline.someTimelineEndAtOrBefore(
-    getBindingHazardTimeline(binding, ctx),
-    end,
-    (hazard) => !isKnownPureStaticCall(hazard, ctx, env)
-  );
 
 export const evaluateStatic = (
   expression: Expression,
@@ -452,7 +309,13 @@ export const evaluateStatic = (
 
       if (
         binding?.importedFrom &&
-        hasBindingMutationBefore(binding, ctx.currentExpressionStart, ctx, env)
+        hasBindingMutationBefore(
+          binding,
+          ctx.currentExpressionStart,
+          ctx,
+          env,
+          isKnownPureStaticCall
+        )
       ) {
         return undefined;
       }
@@ -462,7 +325,13 @@ export const evaluateStatic = (
 
     if (binding?.importedFrom) {
       if (
-        hasBindingMutationBefore(binding, ctx.currentExpressionStart, ctx, env)
+        hasBindingMutationBefore(
+          binding,
+          ctx.currentExpressionStart,
+          ctx,
+          env,
+          isKnownPureStaticCall
+        )
       ) {
         return undefined;
       }
@@ -535,7 +404,8 @@ export const evaluateStatic = (
             ctx.currentExpressionStart,
             ctx,
             declarator,
-            env
+            env,
+            isKnownPureStaticCall
           )
         ) {
           return undefined;
@@ -550,7 +420,8 @@ export const evaluateStatic = (
             declarator.start,
             ctx,
             undefined,
-            env
+            env,
+            isKnownPureStaticCall
           )
         ) {
           return undefined;
@@ -577,7 +448,8 @@ export const evaluateStatic = (
                 declarator.start,
                 ctx,
                 undefined,
-                env
+                env,
+                isKnownPureStaticCall
               )
           )
         ) {
@@ -617,7 +489,8 @@ export const evaluateStatic = (
             declarator.end,
             ctx.currentExpressionStart,
             ctx,
-            env
+            env,
+            isKnownPureStaticCall
           ) ||
           patternRuntimeExpressions.some((runtimeExpression) =>
             hasReferencedRootMutationBetween(
@@ -625,7 +498,8 @@ export const evaluateStatic = (
               declarator.end,
               ctx.currentExpressionStart,
               ctx,
-              env
+              env,
+              isKnownPureStaticCall
             )
           );
         if (
@@ -637,7 +511,8 @@ export const evaluateStatic = (
               declarator.end,
               ctx.currentExpressionStart,
               ctx,
-              env
+              env,
+              isKnownPureStaticCall
             ))
         ) {
           return undefined;

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
@@ -6,6 +6,7 @@ import {
   collectOxcPatternBindingNames,
   collectOxcPatternRuntimeExpressions,
 } from '../oxc/patterns';
+import { getOxcNodeChildren } from '../oxc/ast';
 import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
 import { findResolvedReferences as getReferences } from './bindingResolution';
 import { lookupStaticBinding } from './staticBindings';
@@ -55,6 +56,67 @@ import {
 import type { Binding, ExtractionContext } from './types';
 
 export { createOxcStaticCallableValue } from './staticEvaluationRuntime';
+
+const isDirectReadOnlyExpression = (node: Node): boolean => {
+  if (
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TSInstantiationExpression' ||
+    node.type === 'TSTypeAssertion' ||
+    node.type === 'ParenthesizedExpression'
+  ) {
+    return isDirectReadOnlyExpression(node.expression);
+  }
+
+  return node.type === 'Identifier' || node.type === 'Literal';
+};
+
+const readOnlyOpaqueFunctionCache = new WeakMap<Node, boolean>();
+
+const isReadOnlyOpaqueFunction = (node: Node): boolean => {
+  const cached = readOnlyOpaqueFunctionCache.get(node);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (!isOxcFunctionLike(node)) {
+    readOnlyOpaqueFunctionCache.set(node, false);
+    return false;
+  }
+
+  if (
+    node.params.some(
+      (param) => collectOxcPatternRuntimeExpressions(param).length > 0
+    )
+  ) {
+    readOnlyOpaqueFunctionCache.set(node, false);
+    return false;
+  }
+
+  const { body } = node;
+  if (!body) {
+    readOnlyOpaqueFunctionCache.set(node, false);
+    return false;
+  }
+  if (body.type !== 'BlockStatement') {
+    const result = isDirectReadOnlyExpression(body);
+    readOnlyOpaqueFunctionCache.set(node, result);
+    return result;
+  }
+
+  const result = getOxcNodeChildren(body).every(
+    (statement) =>
+      statement.type === 'EmptyStatement' ||
+      (statement.type === 'ExpressionStatement' &&
+        statement.expression.type === 'Literal' &&
+        typeof statement.expression.value === 'string') ||
+      (statement.type === 'ReturnStatement' &&
+        (!statement.argument || isDirectReadOnlyExpression(statement.argument)))
+  );
+  readOnlyOpaqueFunctionCache.set(node, result);
+  return result;
+};
 
 const hasReferencedRootMutationBetween = (
   expression: Expression,
@@ -124,6 +186,14 @@ export const isKnownPureStaticCall = (
     node.arguments.some((argument) => argument.type === 'SpreadElement')
   ) {
     return false;
+  }
+
+  // A helper that only returns a direct binding/literal read cannot mutate
+  // unrelated state even when that binding is intentionally unavailable to
+  // the static evaluator. This distinction matters for sibling imports: an
+  // opaque return value is not the same thing as an impure invocation.
+  if (isReadOnlyOpaqueFunction(fn)) {
+    return true;
   }
 
   const proofEnv = env ?? new Map();

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticFunctionPurity.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticFunctionPurity.ts
@@ -1,0 +1,66 @@
+import type { Node } from 'oxc-parser';
+
+import { getOxcNodeChildren } from '../oxc/ast';
+import { collectOxcPatternRuntimeExpressions } from '../oxc/patterns';
+import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
+
+const isDirectReadOnlyExpression = (node: Node): boolean => {
+  if (
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TSInstantiationExpression' ||
+    node.type === 'TSTypeAssertion' ||
+    node.type === 'ParenthesizedExpression'
+  ) {
+    return isDirectReadOnlyExpression(node.expression);
+  }
+
+  return node.type === 'Identifier' || node.type === 'Literal';
+};
+
+const readOnlyOpaqueFunctionCache = new WeakMap<Node, boolean>();
+
+export const isReadOnlyOpaqueFunction = (node: Node): boolean => {
+  const cached = readOnlyOpaqueFunctionCache.get(node);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (!isOxcFunctionLike(node)) {
+    readOnlyOpaqueFunctionCache.set(node, false);
+    return false;
+  }
+
+  if (
+    node.params.some(
+      (param) => collectOxcPatternRuntimeExpressions(param).length > 0
+    )
+  ) {
+    readOnlyOpaqueFunctionCache.set(node, false);
+    return false;
+  }
+
+  const { body } = node;
+  if (!body) {
+    readOnlyOpaqueFunctionCache.set(node, false);
+    return false;
+  }
+  if (body.type !== 'BlockStatement') {
+    const result = isDirectReadOnlyExpression(body);
+    readOnlyOpaqueFunctionCache.set(node, result);
+    return result;
+  }
+
+  const result = getOxcNodeChildren(body).every(
+    (statement) =>
+      statement.type === 'EmptyStatement' ||
+      (statement.type === 'ExpressionStatement' &&
+        statement.expression.type === 'Literal' &&
+        typeof statement.expression.value === 'string') ||
+      (statement.type === 'ReturnStatement' &&
+        (!statement.argument || isDirectReadOnlyExpression(statement.argument)))
+  );
+  readOnlyOpaqueFunctionCache.set(node, result);
+  return result;
+};

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticLocalPlanning.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticLocalPlanning.ts
@@ -20,7 +20,6 @@ import {
 import {
   getMutationTimeline,
   hasTimelineStartBefore,
-  someTimelineEndAtOrBefore,
   toMutationBindingKey,
   unknownAliasMutationBinding,
 } from './scopeAnalysis';
@@ -33,6 +32,10 @@ import {
   isOpaqueDestructuringHazard,
 } from './snapshotReplay';
 import { isKnownPureStaticCall } from './staticEvaluator';
+import {
+  getHazardTimelineAt,
+  someHazardTimelineEndAtOrBefore,
+} from './staticEvaluationSafety';
 import type {
   Binding,
   ExtractionContext,
@@ -131,9 +134,10 @@ export const hasReferencedRootMutationBefore = (
           getMutationTimeline(ctx.rootMutationsByBinding, dependencyKey),
           referenceStart
         ) ||
-        someTimelineEndAtOrBefore(
-          getMutationTimeline(ctx.rootMutationHazardsByBinding, dependencyKey),
+        someHazardTimelineEndAtOrBefore(
+          getHazardTimelineAt(dependencyKey, referenceStart, ctx),
           referenceStart,
+          ctx,
           (hazard) =>
             !isKnownPureStaticCall(hazard, ctx) &&
             (!ignoredHazard ||
@@ -155,9 +159,10 @@ export const hasBindingMutationBefore = (
       getMutationTimeline(ctx.rootMutationsByBinding, bindingKey),
       referenceStart
     ) ||
-    someTimelineEndAtOrBefore(
-      getMutationTimeline(ctx.rootMutationHazardsByBinding, bindingKey),
+    someHazardTimelineEndAtOrBefore(
+      getHazardTimelineAt(bindingKey, referenceStart, ctx),
       referenceStart,
+      ctx,
       (hazard) => !isKnownPureStaticCall(hazard, ctx)
     )
   );
@@ -168,9 +173,10 @@ export const hasOpaqueDestructuringHazardBefore = (
   referenceStart: number,
   ctx: ExtractionContext
 ): boolean =>
-  someTimelineEndAtOrBefore(
-    getMutationTimeline(ctx.rootMutationHazardsByBinding, bindingKey),
+  someHazardTimelineEndAtOrBefore(
+    getHazardTimelineAt(bindingKey, referenceStart, ctx),
     referenceStart,
+    ctx,
     (hazard) => isOpaqueDestructuringHazard(hazard, ctx)
   );
 
@@ -208,7 +214,8 @@ export const nestedDestructuringHasCallTimeUncertainty = (
     hasDestructuringIntrinsicMutationBefore(
       declarator.id,
       Number.POSITIVE_INFINITY,
-      ctx
+      ctx,
+      ctx.currentExpressionStart
     )
   ) {
     return true;
@@ -435,14 +442,18 @@ function collectStaticDestructuringProjection(
     ctx.rootMutationsByBinding,
     bindingKey
   );
-  const targetMutationHazards = getMutationTimeline(
-    ctx.rootMutationHazardsByBinding,
-    bindingKey
+  const targetMutationHazards = getHazardTimelineAt(
+    bindingKey,
+    referenceStart,
+    ctx
   );
   if (
     hasTimelineStartBefore(targetMutations, referenceStart) ||
-    someTimelineEndAtOrBefore(targetMutationHazards, referenceStart, (hazard) =>
-      isOpaqueDestructuringHazard(hazard, ctx)
+    someHazardTimelineEndAtOrBefore(
+      targetMutationHazards,
+      referenceStart,
+      ctx,
+      (hazard) => isOpaqueDestructuringHazard(hazard, ctx)
     )
   ) {
     return null;

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticLocalPlanning.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticLocalPlanning.ts
@@ -8,6 +8,7 @@ import {
   collectOxcPatternRuntimeExpressions,
   collectOxcPatternShorthandProperties,
 } from '../oxc/patterns';
+import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
 import { toOxcBindingIdentity } from './bindingIdentity';
 import { findResolvedReferences as getReferences } from './bindingResolution';
 import {
@@ -564,6 +565,14 @@ export function collectStaticBindingExpression(
   }
 
   const nextStack = [...stack, key];
+  if (isOxcFunctionLike(declarator.init)) {
+    return {
+      importedFrom: [],
+      imports: [],
+      source: ctx.code.slice(declarator.init.start, declarator.init.end),
+    };
+  }
+
   if (
     hasReferencedRootMutationBefore(
       declarator.init,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticMutationChecks.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticMutationChecks.ts
@@ -1,0 +1,113 @@
+import type { Expression, Node } from 'oxc-parser';
+
+import { findResolvedReferences as getReferences } from './bindingResolution';
+import { someExecutionAncestorEffect } from './mutationExecution';
+import * as timeline from './mutationTimeline';
+import {
+  getBindingDirectTimeline,
+  getBindingHazardTimeline,
+  someHazardTimelineEndAtOrBefore,
+} from './staticEvaluationSafety';
+import type { EvalEnv } from './staticEvaluationRuntime';
+import type { Binding, ExtractionContext } from './types';
+
+type StaticCallPurity = (
+  node: Node,
+  ctx: ExtractionContext,
+  env: EvalEnv
+) => boolean;
+
+export const hasReferencedRootMutationBetween = (
+  expression: Expression,
+  start: number,
+  end: number,
+  ctx: ExtractionContext,
+  env: EvalEnv,
+  isKnownPure: StaticCallPurity
+): boolean =>
+  getReferences(expression, ctx.bindingIndex).some(
+    ({ binding }) =>
+      !!binding &&
+      (timeline.hasTimelineStartInRange(
+        getBindingDirectTimeline(binding, ctx),
+        start,
+        end
+      ) ||
+        (() => {
+          const hazards = getBindingHazardTimeline(binding, ctx);
+          const isImpure = (hazard: Node) => !isKnownPure(hazard, ctx, env);
+          return (
+            timeline.someTimelineFullyContained(
+              hazards,
+              start,
+              end,
+              isImpure
+            ) ||
+            someExecutionAncestorEffect(
+              ctx.bindingIndex,
+              hazards,
+              end,
+              isImpure
+            )
+          );
+        })())
+  );
+
+export const hasReferencedRootMutationHazardBefore = (
+  expression: Expression,
+  end: number,
+  ctx: ExtractionContext,
+  ignoredHazard: Node | undefined,
+  env: EvalEnv,
+  isKnownPure: StaticCallPurity
+): boolean =>
+  ctx.rootMutationHazardsByBinding.size > 0 &&
+  getReferences(expression, ctx.bindingIndex).some(
+    ({ binding }) =>
+      !!binding &&
+      someHazardTimelineEndAtOrBefore(
+        getBindingHazardTimeline(binding, ctx),
+        end,
+        ctx,
+        (hazard) =>
+          !isKnownPure(hazard, ctx, env) &&
+          (!ignoredHazard ||
+            hazard.start < ignoredHazard.start ||
+            ignoredHazard.end < hazard.end)
+      )
+  );
+
+export const hasBindingMutationHazardBetween = (
+  binding: Binding,
+  start: number,
+  end: number,
+  ctx: ExtractionContext,
+  env: EvalEnv,
+  isKnownPure: StaticCallPurity
+): boolean =>
+  (() => {
+    const hazards = getBindingHazardTimeline(binding, ctx);
+    const isImpure = (hazard: Node) => !isKnownPure(hazard, ctx, env);
+    return (
+      timeline.someTimelineFullyContained(hazards, start, end, isImpure) ||
+      someExecutionAncestorEffect(ctx.bindingIndex, hazards, end, isImpure)
+    );
+  })();
+
+export const hasBindingMutationBefore = (
+  binding: Binding,
+  end: number,
+  ctx: ExtractionContext,
+  env: EvalEnv,
+  isKnownPure: StaticCallPurity
+): boolean =>
+  timeline.hasTimelineStartBefore(
+    getBindingDirectTimeline(binding, ctx),
+    end
+  ) ||
+  someHazardTimelineEndAtOrBefore(
+    getBindingHazardTimeline(binding, ctx),
+    end,
+    ctx,
+    (hazard) => !isKnownPure(hazard, ctx, env)
+  );

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
@@ -69,7 +69,7 @@ export type MutationTimelineLookup<T extends MutationSpan = Node> = Pick<
 
 export type Scope = {
   bindings: Map<string, Binding>;
-  deferredFunction?: boolean;
+  deferredFunctionNode?: Node;
   depth: number;
   end: number;
   functionBoundary: boolean;

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
@@ -112,6 +112,7 @@ export type TemplateExtractionResult = {
   code: string;
   dependencyNames: string[];
   expressionValues: Omit<ExpressionValue, 'buildCodeFrameError'>[];
+  replacements: OxcValueReplacement[];
   staticValueCandidates: OxcStaticValueCandidate[];
   staticValues: OxcStaticValue[];
 };

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
@@ -69,6 +69,7 @@ export type MutationTimelineLookup<T extends MutationSpan = Node> = Pick<
 
 export type Scope = {
   bindings: Map<string, Binding>;
+  deferredFunction?: boolean;
   depth: number;
   end: number;
   functionBoundary: boolean;

--- a/packages/transform/src/utils/dangerousCodeRemoval.ts
+++ b/packages/transform/src/utils/dangerousCodeRemoval.ts
@@ -6,14 +6,36 @@ import {
   type Replacement,
 } from './oxcPreevalTransforms';
 
-export const collectDangerousCodeRemovalSpansWithOxc = (
+export type DangerousCodePlan = {
+  runtimeOnlyProcessorSpans: Array<Pick<Replacement, 'end' | 'start'>>;
+  removedSpans: Array<Pick<Replacement, 'end' | 'start'>>;
+  replacements: Replacement[];
+};
+
+export const createDangerousCodePlanWithOxc = (
   code: string,
   filename: string,
-  options?: CodeRemoverOptions
-): Array<Pick<Replacement, 'end' | 'start'>> =>
-  collectDangerousCodeReplacementsWithOxc(code, filename, options).map(
-    ({ end, start }) => ({ end, start })
+  options?: CodeRemoverOptions,
+  planningOptions?: {
+    ignoredSpans?: Array<Pick<Replacement, 'end' | 'start'>>;
+    preserveImportMetaEnv?: boolean;
+  }
+): DangerousCodePlan => {
+  const replacements = collectDangerousCodeReplacementsWithOxc(
+    code,
+    filename,
+    options,
+    planningOptions
   );
+
+  return {
+    removedSpans: replacements.map(({ end, start }) => ({ end, start })),
+    replacements,
+    runtimeOnlyProcessorSpans: replacements
+      .filter((replacement) => replacement.kind === 'component')
+      .map(({ end, start }) => ({ end, start })),
+  };
+};
 
 export const removeDangerousCodeWithOxc = (
   code: string,
@@ -22,5 +44,5 @@ export const removeDangerousCodeWithOxc = (
 ): string =>
   applyReplacements(
     code,
-    collectDangerousCodeReplacementsWithOxc(code, filename, options)
+    createDangerousCodePlanWithOxc(code, filename, options).replacements
   );

--- a/packages/transform/src/utils/dangerousCodeRemoval.ts
+++ b/packages/transform/src/utils/dangerousCodeRemoval.ts
@@ -1,0 +1,26 @@
+import type { CodeRemoverOptions } from '@wyw-in-js/shared';
+
+import {
+  applyReplacements,
+  collectDangerousCodeReplacementsWithOxc,
+  type Replacement,
+} from './oxcPreevalTransforms';
+
+export const collectDangerousCodeRemovalSpansWithOxc = (
+  code: string,
+  filename: string,
+  options?: CodeRemoverOptions
+): Array<Pick<Replacement, 'end' | 'start'>> =>
+  collectDangerousCodeReplacementsWithOxc(code, filename, options).map(
+    ({ end, start }) => ({ end, start })
+  );
+
+export const removeDangerousCodeWithOxc = (
+  code: string,
+  filename: string,
+  options?: CodeRemoverOptions
+): string =>
+  applyReplacements(
+    code,
+    collectDangerousCodeReplacementsWithOxc(code, filename, options)
+  );

--- a/packages/transform/src/utils/oxc/__tests__/replacements.test.ts
+++ b/packages/transform/src/utils/oxc/__tests__/replacements.test.ts
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+import { applyOxcReplacementLayers } from '../replacements';
+
+describe('applyOxcReplacementLayers', () => {
+  it('keeps the outer replacement regardless of layer order', () => {
+    const outer = { start: 1, end: 5, value: 'outer' };
+    const inner = { start: 2, end: 4, value: 'inner' };
+
+    expect(applyOxcReplacementLayers('abcdef', [[inner], [outer]])).toBe(
+      'aouterf'
+    );
+    expect(applyOxcReplacementLayers('abcdef', [[outer], [inner]])).toBe(
+      'aouterf'
+    );
+  });
+
+  it('uses the earlier layer for equal ranges', () => {
+    expect(
+      applyOxcReplacementLayers('abc', [
+        [{ start: 0, end: 3, value: 'processor' }],
+        [{ start: 0, end: 3, value: 'dangerous' }],
+      ])
+    ).toBe('processor');
+  });
+
+  it('preserves boundary insertions and drops interior insertions', () => {
+    expect(
+      applyOxcReplacementLayers('abcdef', [
+        [{ start: 1, end: 5, value: 'X' }],
+        [
+          { start: 1, end: 1, text: '<' },
+          { start: 3, end: 3, text: 'discarded' },
+          { start: 5, end: 5, text: '>' },
+        ],
+      ])
+    ).toBe('a<X>f');
+  });
+
+  it('rejects partial overlaps between layers', () => {
+    expect(() =>
+      applyOxcReplacementLayers('abcdef', [
+        [{ start: 1, end: 4, value: 'left' }],
+        [{ start: 3, end: 5, value: 'right' }],
+      ])
+    ).toThrow('Oxc replacement layers overlap without containment');
+  });
+});

--- a/packages/transform/src/utils/oxc/replacements.ts
+++ b/packages/transform/src/utils/oxc/replacements.ts
@@ -20,6 +20,96 @@ const getReplacementValue = (replacement: OxcReplacement): string => {
   return replacement.text;
 };
 
+const containsReplacement = (
+  outer: OxcReplacement,
+  inner: OxcReplacement
+): boolean => outer.start <= inner.start && outer.end >= inner.end;
+
+/**
+ * Applies replacement layers that all refer to the same source text.
+ *
+ * Earlier layers win when two replacements cover the same range. Otherwise,
+ * an outer replacement makes nested replacements irrelevant. Zero-width
+ * insertions at an outer replacement boundary survive, which lets dependency
+ * helpers be emitted immediately before code removed from the evaltime view.
+ */
+export const applyOxcReplacementLayers = (
+  code: string,
+  layers: readonly (readonly OxcReplacement[])[]
+): string => {
+  const replacements: OxcReplacement[] = [];
+
+  layers.forEach((layer) => {
+    layer.forEach((replacement) => {
+      const isInsertion = replacement.start === replacement.end;
+      const overlapsPartially = replacements.some(
+        (current) =>
+          current.start !== current.end &&
+          replacement.start !== replacement.end &&
+          current.start < replacement.end &&
+          replacement.start < current.end &&
+          !containsReplacement(current, replacement) &&
+          !containsReplacement(replacement, current)
+      );
+      if (overlapsPartially) {
+        throw new Error('Oxc replacement layers overlap without containment');
+      }
+
+      const covering = replacements.find(
+        (current) =>
+          current.start !== current.end &&
+          containsReplacement(current, replacement)
+      );
+
+      if (
+        covering &&
+        (!isInsertion ||
+          (replacement.start > covering.start &&
+            replacement.start < covering.end))
+      ) {
+        return;
+      }
+
+      if (!isInsertion) {
+        for (let idx = replacements.length - 1; idx >= 0; idx -= 1) {
+          const current = replacements[idx]!;
+          const currentIsInsertion = current.start === current.end;
+          if (
+            containsReplacement(replacement, current) &&
+            (!currentIsInsertion ||
+              (current.start > replacement.start &&
+                current.start < replacement.end))
+          ) {
+            replacements.splice(idx, 1);
+          }
+        }
+      }
+
+      replacements.push(replacement);
+    });
+  });
+
+  let result = code;
+  replacements
+    .sort((a, b) => {
+      if (a.start !== b.start) {
+        return b.start - a.start;
+      }
+
+      // Apply a consuming replacement first so a boundary insertion is not
+      // swallowed by its source range.
+      return b.end - a.end;
+    })
+    .forEach((replacement) => {
+      result =
+        result.slice(0, replacement.start) +
+        getReplacementValue(replacement) +
+        result.slice(replacement.end);
+    });
+
+  return result;
+};
+
 export const applyOxcReplacements = (
   code: string,
   replacements: OxcReplacement[]

--- a/packages/transform/src/utils/oxcPreevalStage.ts
+++ b/packages/transform/src/utils/oxcPreevalStage.ts
@@ -42,6 +42,7 @@ export const runOxcPreevalStage = (
       metadata: null,
       processorManagedExpressionSpans: [],
       processorClassNames: {},
+      runtimeProcessorPlan: processed.runtimeProcessorPlan,
       staticDependencies: [],
       staticPlanFacts: processed.staticPlanFacts,
       staticValueCandidates: [],
@@ -67,6 +68,7 @@ export const runOxcPreevalStage = (
     processorClassNames: Object.fromEntries(
       processed.processorClassNamesByLocal
     ),
+    runtimeProcessorPlan: processed.runtimeProcessorPlan,
     staticDependencies: [],
     staticPlanFacts: processed.staticPlanFacts,
     staticValueCache: staticOverlay.staticValueCache,

--- a/packages/transform/src/utils/oxcPreevalStage.ts
+++ b/packages/transform/src/utils/oxcPreevalStage.ts
@@ -43,6 +43,7 @@ export const runOxcPreevalStage = (
       processorManagedExpressionSpans: [],
       processorClassNames: {},
       staticDependencies: [],
+      staticPlanFacts: processed.staticPlanFacts,
       staticValueCandidates: [],
       staticValueCache: new Map(),
     };
@@ -67,6 +68,7 @@ export const runOxcPreevalStage = (
       processed.processorClassNamesByLocal
     ),
     staticDependencies: [],
+    staticPlanFacts: processed.staticPlanFacts,
     staticValueCache: staticOverlay.staticValueCache,
     staticValueCandidates: staticOverlay.staticValueCandidates,
   };

--- a/packages/transform/src/utils/oxcPreevalStage.ts
+++ b/packages/transform/src/utils/oxcPreevalStage.ts
@@ -40,6 +40,7 @@ export const runOxcPreevalStage = (
       code: baseCode,
       dependencyNames: [],
       metadata: null,
+      processorManagedExpressionSpans: [],
       processorClassNames: {},
       staticDependencies: [],
       staticValueCandidates: [],
@@ -61,6 +62,7 @@ export const runOxcPreevalStage = (
       replacements: [],
       rules: {},
     },
+    processorManagedExpressionSpans: processed.processorManagedExpressionSpans,
     processorClassNames: Object.fromEntries(
       processed.processorClassNamesByLocal
     ),

--- a/packages/transform/src/utils/oxcPreevalStage/prepareCode.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/prepareCode.ts
@@ -1,7 +1,4 @@
-import { isFeatureEnabled } from '@wyw-in-js/shared';
-
 import type { EventEmitter } from '../EventEmitter';
-import { removeDangerousCodeWithOxc } from '../dangerousCodeRemoval';
 import {
   replaceImportMetaEnvWithOxc,
   rewriteDynamicImportsAndAddRequireFallbackWithOxc,
@@ -20,12 +17,6 @@ export const prepareOxcPreevalCode = (
   let nextCode = eventEmitter.perf('transform:preeval:importMetaEnv', () =>
     replaceImportMetaEnvWithOxc(code, filename)
   );
-
-  if (isFeatureEnabled(options.features, 'dangerousCodeRemover', filename)) {
-    nextCode = eventEmitter.perf('transform:preeval:removeDangerousCode', () =>
-      removeDangerousCodeWithOxc(nextCode, filename, options.codeRemover)
-    );
-  }
 
   const shouldRewriteDynamicImports = DYNAMIC_IMPORT_RE.test(nextCode);
   const shouldAddRequireFallback = REQUIRE_CALL_RE.test(nextCode);

--- a/packages/transform/src/utils/oxcPreevalStage/prepareCode.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/prepareCode.ts
@@ -1,8 +1,8 @@
 import { isFeatureEnabled } from '@wyw-in-js/shared';
 
 import type { EventEmitter } from '../EventEmitter';
+import { removeDangerousCodeWithOxc } from '../dangerousCodeRemoval';
 import {
-  removeDangerousCodeWithOxc,
   replaceImportMetaEnvWithOxc,
   rewriteDynamicImportsAndAddRequireFallbackWithOxc,
 } from '../oxcPreevalTransforms';

--- a/packages/transform/src/utils/oxcPreevalStage/processors.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/processors.ts
@@ -4,7 +4,7 @@ import { isFeatureEnabled } from '@wyw-in-js/shared';
 import type { EventEmitter } from '../EventEmitter';
 import { applyOxcProcessors } from '../applyOxcProcessors';
 import type { ApplyOxcProcessorsResult } from '../applyOxcProcessors/types';
-import { collectDangerousCodeRemovalSpansWithOxc } from '../oxcPreevalTransforms';
+import { collectDangerousCodeRemovalSpansWithOxc } from '../dangerousCodeRemoval';
 import type { OxcPreevalOptions } from './types';
 
 type PreevalProcessorCollection = {

--- a/packages/transform/src/utils/oxcPreevalStage/processors.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/processors.ts
@@ -4,7 +4,7 @@ import { isFeatureEnabled } from '@wyw-in-js/shared';
 import type { EventEmitter } from '../EventEmitter';
 import { applyOxcProcessors } from '../applyOxcProcessors';
 import type { ApplyOxcProcessorsResult } from '../applyOxcProcessors/types';
-import { collectDangerousCodeRemovalSpansWithOxc } from '../dangerousCodeRemoval';
+import { createDangerousCodePlanWithOxc } from '../dangerousCodeRemoval';
 import type { OxcPreevalOptions } from './types';
 
 type PreevalProcessorCollection = {
@@ -19,16 +19,17 @@ export const collectPreevalProcessors = (
   eventEmitter: EventEmitter
 ): PreevalProcessorCollection => {
   const filename = fileContext.filename ?? 'unknown.js';
-  const getMutationHazardIgnoreTreeSpans = isFeatureEnabled(
+  const createEvaltimeCodePlan = isFeatureEnabled(
     options.features,
     'dangerousCodeRemover',
     filename
   )
-    ? () =>
-        collectDangerousCodeRemovalSpansWithOxc(
-          code,
-          filename,
-          options.codeRemover
+    ? (processorSpans: Array<{ end: number; start: number }>) =>
+        eventEmitter.perf('transform:preeval:removeDangerousCode', () =>
+          createDangerousCodePlanWithOxc(code, filename, options.codeRemover, {
+            ignoredSpans: processorSpans,
+            preserveImportMetaEnv: true,
+          })
         )
     : undefined;
   const processed = eventEmitter.perf('transform:preeval:processTemplate', () =>
@@ -37,7 +38,7 @@ export const collectPreevalProcessors = (
       fileContext,
       {
         ...options,
-        getMutationHazardIgnoreTreeSpans,
+        createEvaltimeCodePlan,
       },
       (processor) => {
         processor.doEvaltimeReplacement();

--- a/packages/transform/src/utils/oxcPreevalStage/processors.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/processors.ts
@@ -1,8 +1,10 @@
 import type { IFileContext } from '@wyw-in-js/processor-utils';
+import { isFeatureEnabled } from '@wyw-in-js/shared';
 
 import type { EventEmitter } from '../EventEmitter';
 import { applyOxcProcessors } from '../applyOxcProcessors';
 import type { ApplyOxcProcessorsResult } from '../applyOxcProcessors/types';
+import { collectDangerousCodeRemovalSpansWithOxc } from '../oxcPreevalTransforms';
 import type { OxcPreevalOptions } from './types';
 
 type PreevalProcessorCollection = {
@@ -16,11 +18,27 @@ export const collectPreevalProcessors = (
   options: OxcPreevalOptions,
   eventEmitter: EventEmitter
 ): PreevalProcessorCollection => {
+  const filename = fileContext.filename ?? 'unknown.js';
+  const getMutationHazardIgnoreTreeSpans = isFeatureEnabled(
+    options.features,
+    'dangerousCodeRemover',
+    filename
+  )
+    ? () =>
+        collectDangerousCodeRemovalSpansWithOxc(
+          code,
+          filename,
+          options.codeRemover
+        )
+    : undefined;
   const processed = eventEmitter.perf('transform:preeval:processTemplate', () =>
     applyOxcProcessors(
       code,
       fileContext,
-      options,
+      {
+        ...options,
+        getMutationHazardIgnoreTreeSpans,
+      },
       (processor) => {
         processor.doEvaltimeReplacement();
       },

--- a/packages/transform/src/utils/oxcPreevalStage/types.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/types.ts
@@ -4,6 +4,7 @@ import type { EventEmitter } from '../EventEmitter';
 import type { WYWTransformMetadata } from '../TransformMetadata';
 import type {
   ExpressionSpan,
+  OxcProcessorAnalysisPlan,
   StaticPlanFacts,
 } from '../applyOxcProcessors/types';
 import type { OxcStaticValueCandidate } from '../collectOxcTemplateDependencies';
@@ -31,6 +32,7 @@ export type OxcPreevalResult = {
   metadata: WYWTransformMetadata | null;
   processorManagedExpressionSpans: ExpressionSpan[];
   processorClassNames: Record<string, string>;
+  runtimeProcessorPlan?: OxcProcessorAnalysisPlan;
   staticDependencies: string[];
   staticPlanFacts: StaticPlanFacts;
   staticValueCache: Map<string, unknown>;

--- a/packages/transform/src/utils/oxcPreevalStage/types.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/types.ts
@@ -2,6 +2,7 @@ import type { StrictOptions } from '@wyw-in-js/shared';
 
 import type { EventEmitter } from '../EventEmitter';
 import type { WYWTransformMetadata } from '../TransformMetadata';
+import type { ExpressionSpan } from '../applyOxcProcessors/types';
 import type { OxcStaticValueCandidate } from '../collectOxcTemplateDependencies';
 
 export type OxcPreevalOptions = Pick<
@@ -25,6 +26,7 @@ export type OxcPreevalResult = {
     staticValueCache?: Map<string, unknown>
   ) => void;
   metadata: WYWTransformMetadata | null;
+  processorManagedExpressionSpans: ExpressionSpan[];
   processorClassNames: Record<string, string>;
   staticDependencies: string[];
   staticValueCache: Map<string, unknown>;

--- a/packages/transform/src/utils/oxcPreevalStage/types.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/types.ts
@@ -2,7 +2,10 @@ import type { StrictOptions } from '@wyw-in-js/shared';
 
 import type { EventEmitter } from '../EventEmitter';
 import type { WYWTransformMetadata } from '../TransformMetadata';
-import type { ExpressionSpan } from '../applyOxcProcessors/types';
+import type {
+  ExpressionSpan,
+  StaticPlanFacts,
+} from '../applyOxcProcessors/types';
 import type { OxcStaticValueCandidate } from '../collectOxcTemplateDependencies';
 
 export type OxcPreevalOptions = Pick<
@@ -29,6 +32,7 @@ export type OxcPreevalResult = {
   processorManagedExpressionSpans: ExpressionSpan[];
   processorClassNames: Record<string, string>;
   staticDependencies: string[];
+  staticPlanFacts: StaticPlanFacts;
   staticValueCache: Map<string, unknown>;
   staticValueCandidates: OxcStaticValueCandidate[];
 };

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -1565,11 +1565,11 @@ const normalizeReplacements = (replacements: Replacement[]): Replacement[] => {
   return result;
 };
 
-export const removeDangerousCodeWithOxc = (
+const collectDangerousCodeReplacementsWithOxc = (
   code: string,
   filename: string,
   options?: CodeRemoverOptions
-): string => {
+): Replacement[] => {
   const replacements: Replacement[] = [];
   const derivedForbiddenBindings = new Set<string>();
   const program = parseOxc(code, filename);
@@ -1803,5 +1803,24 @@ export const removeDangerousCodeWithOxc = (
     }
   );
 
-  return applyReplacements(code, normalizeReplacements(replacements));
+  return normalizeReplacements(replacements);
 };
+
+export const collectDangerousCodeRemovalSpansWithOxc = (
+  code: string,
+  filename: string,
+  options?: CodeRemoverOptions
+): Array<Pick<Replacement, 'end' | 'start'>> =>
+  collectDangerousCodeReplacementsWithOxc(code, filename, options).map(
+    ({ end, start }) => ({ end, start })
+  );
+
+export const removeDangerousCodeWithOxc = (
+  code: string,
+  filename: string,
+  options?: CodeRemoverOptions
+): string =>
+  applyReplacements(
+    code,
+    collectDangerousCodeReplacementsWithOxc(code, filename, options)
+  );

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -17,7 +17,7 @@ import { parseOxcProgramCached } from './parseOxc';
 
 type AnyNode = Node & Record<string, unknown>;
 
-type Replacement = {
+export type Replacement = {
   end: number;
   start: number;
   value: string;
@@ -407,7 +407,7 @@ const isLiteralRequireArg = (node: Expression): boolean => {
   return false;
 };
 
-const applyReplacements = (
+export const applyReplacements = (
   code: string,
   replacements: Replacement[]
 ): string => {
@@ -1565,7 +1565,7 @@ const normalizeReplacements = (replacements: Replacement[]): Replacement[] => {
   return result;
 };
 
-const collectDangerousCodeReplacementsWithOxc = (
+export const collectDangerousCodeReplacementsWithOxc = (
   code: string,
   filename: string,
   options?: CodeRemoverOptions
@@ -1805,22 +1805,3 @@ const collectDangerousCodeReplacementsWithOxc = (
 
   return normalizeReplacements(replacements);
 };
-
-export const collectDangerousCodeRemovalSpansWithOxc = (
-  code: string,
-  filename: string,
-  options?: CodeRemoverOptions
-): Array<Pick<Replacement, 'end' | 'start'>> =>
-  collectDangerousCodeReplacementsWithOxc(code, filename, options).map(
-    ({ end, start }) => ({ end, start })
-  );
-
-export const removeDangerousCodeWithOxc = (
-  code: string,
-  filename: string,
-  options?: CodeRemoverOptions
-): string =>
-  applyReplacements(
-    code,
-    collectDangerousCodeReplacementsWithOxc(code, filename, options)
-  );

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -23,6 +23,10 @@ export type Replacement = {
   value: string;
 };
 
+export type DangerousCodeReplacement = Replacement & {
+  kind?: 'component';
+};
+
 type Scope = {
   bindings: Map<string, Expression | null>;
   key: string;
@@ -1070,19 +1074,32 @@ const findPromiseCallbackOwner = (ancestors: Node[]): Node | null => {
   return null;
 };
 
-const containsForbiddenIdentifier = (node: Node): boolean => {
+const containsForbiddenIdentifier = (
+  node: Node,
+  isIgnoredNode: (node: Node) => boolean
+): boolean => {
+  if (isIgnoredNode(node)) {
+    return false;
+  }
+
   if (node.type === 'Identifier' && alwaysForbiddenIdentifiers.has(node.name)) {
     return true;
   }
 
-  return getChildren(node).some(containsForbiddenIdentifier);
+  return getChildren(node).some((child) =>
+    containsForbiddenIdentifier(child, isIgnoredNode)
+  );
 };
 
-const collectWindowScopedNames = (program: Program): Set<string> => {
+const collectWindowScopedNames = (
+  program: Program,
+  isIgnoredNode: (node: Node) => boolean
+): Set<string> => {
   const windowScopedNames = new Set<string>();
 
   visit(program, createScope(null, 'root'), (node, scope) => {
     if (
+      isIgnoredNode(node) ||
       node.type !== 'MemberExpression' ||
       node.object.type !== 'Identifier' ||
       node.object.name !== 'window' ||
@@ -1104,13 +1121,15 @@ const containsForbiddenReference = (
   node: Node,
   scope: Scope,
   windowScopedNames: Set<string>,
-  derivedForbiddenBindings: Set<string> = new Set()
+  derivedForbiddenBindings: Set<string>,
+  isIgnoredNode: (node: Node) => boolean
 ): boolean => {
   let found = false;
 
   visit(node, scope, (child, childScope, parent, ancestors) => {
     if (
       found ||
+      isIgnoredNode(child) ||
       child.type !== 'Identifier' ||
       isTypeContext(ancestors) ||
       isInsideTypeof(ancestors) ||
@@ -1488,7 +1507,9 @@ const isInDeferredFunctionScope = (ancestors: Node[]): boolean => {
   return false;
 };
 
-const findFunctionReplacement = (ancestors: Node[]): Replacement | null => {
+const findFunctionReplacement = (
+  ancestors: Node[]
+): DangerousCodeReplacement | null => {
   const renderMethod = findLastAncestor(
     ancestors,
     (ancestor) =>
@@ -1507,6 +1528,7 @@ const findFunctionReplacement = (ancestors: Node[]): Replacement | null => {
       return {
         start: classDecl.start,
         end: classDecl.end,
+        kind: 'component',
         value: `function ${className}() { return null; }`,
       };
     }
@@ -1522,6 +1544,7 @@ const findFunctionReplacement = (ancestors: Node[]): Replacement | null => {
     return {
       start: functionNode.start,
       end: functionNode.end,
+      kind: 'component',
       value: `${functionNode.async ? 'async ' : ''}() => { return null; }`,
     };
   }
@@ -1530,6 +1553,7 @@ const findFunctionReplacement = (ancestors: Node[]): Replacement | null => {
     return {
       start: functionNode.start,
       end: functionNode.end,
+      kind: 'component',
       value: `${functionNode.async ? 'async ' : ''}function ${
         functionNode.id?.name ?? ''
       }() { return null; }`,
@@ -1539,15 +1563,18 @@ const findFunctionReplacement = (ancestors: Node[]): Replacement | null => {
   return {
     start: functionNode.body.start,
     end: functionNode.body.end,
+    kind: 'component',
     value: '{ return null; }',
   };
 };
 
-const normalizeReplacements = (replacements: Replacement[]): Replacement[] => {
+const normalizeReplacements = (
+  replacements: DangerousCodeReplacement[]
+): DangerousCodeReplacement[] => {
   const sorted = [...replacements].sort((a, b) =>
     a.start === b.start ? b.end - a.end : a.start - b.start
   );
-  const result: Replacement[] = [];
+  const result: DangerousCodeReplacement[] = [];
 
   sorted.forEach((replacement) => {
     const last = result[result.length - 1];
@@ -1568,9 +1595,42 @@ const normalizeReplacements = (replacements: Replacement[]): Replacement[] => {
 export const collectDangerousCodeReplacementsWithOxc = (
   code: string,
   filename: string,
-  options?: CodeRemoverOptions
-): Replacement[] => {
-  const replacements: Replacement[] = [];
+  options?: CodeRemoverOptions,
+  planningOptions?: {
+    ignoredSpans?: Array<{ end: number; start: number }>;
+    preserveImportMetaEnv?: boolean;
+  }
+): DangerousCodeReplacement[] => {
+  const replacements: DangerousCodeReplacement[] = [];
+  const ignoredSpans = [...(planningOptions?.ignoredSpans ?? [])]
+    .sort((a, b) => a.start - b.start)
+    .reduce<Array<{ end: number; start: number }>>((result, span) => {
+      const last = result[result.length - 1];
+      if (last && span.start <= last.end) {
+        last.end = Math.max(last.end, span.end);
+      } else {
+        result.push({ ...span });
+      }
+
+      return result;
+    }, []);
+  const isIgnoredNode = (node: Node): boolean => {
+    let low = 0;
+    let high = ignoredSpans.length - 1;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const span = ignoredSpans[middle]!;
+      if (node.start < span.start) {
+        high = middle - 1;
+      } else if (node.start >= span.end) {
+        low = middle + 1;
+      } else {
+        return node.end <= span.end;
+      }
+    }
+
+    return false;
+  };
   const derivedForbiddenBindings = new Set<string>();
   const program = parseOxc(code, filename);
   const imports = collectImportBindings(code, filename, program);
@@ -1578,7 +1638,7 @@ export const collectDangerousCodeReplacementsWithOxc = (
   const hocs = getHocs(options);
   const hasHocs = Object.keys(hocs).length > 0;
   const windowScopedNames = windowTokenRe.test(code)
-    ? collectWindowScopedNames(program)
+    ? collectWindowScopedNames(program, isIgnoredNode)
     : new Set<string>();
   const exportedLocalNames = collectExportedLocalNames(program);
 
@@ -1601,12 +1661,13 @@ export const collectDangerousCodeReplacementsWithOxc = (
       }
 
       if (
-        containsForbiddenIdentifier(node.init) ||
+        containsForbiddenIdentifier(node.init, isIgnoredNode) ||
         containsForbiddenReference(
           node.init,
           scope,
           windowScopedNames,
-          derivedForbiddenBindings
+          derivedForbiddenBindings,
+          isIgnoredNode
         )
       ) {
         derivedForbiddenBindings.add(bindingKey);
@@ -1619,11 +1680,16 @@ export const collectDangerousCodeReplacementsWithOxc = (
     program,
     createScope(null, 'root'),
     (node, scope, parent, ancestors) => {
+      if (isIgnoredNode(node)) {
+        return;
+      }
+
       if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
         replacements.push(
           findFunctionReplacement(ancestors) ?? {
             start: node.start,
             end: node.end,
+            kind: 'component',
             value: 'null',
           }
         );
@@ -1644,6 +1710,7 @@ export const collectDangerousCodeReplacementsWithOxc = (
           replacements.push({
             start: node.start,
             end: node.end,
+            kind: 'component',
             value: '() => null',
           });
           return;
@@ -1659,6 +1726,7 @@ export const collectDangerousCodeReplacementsWithOxc = (
         replacements.push({
           start: node.init.start,
           end: node.init.end,
+          kind: 'component',
           value: '() => null',
         });
         return;
@@ -1680,6 +1748,13 @@ export const collectDangerousCodeReplacementsWithOxc = (
       }
 
       if (node.type === 'MetaProperty') {
+        if (
+          planningOptions?.preserveImportMetaEnv &&
+          ancestors.some((ancestor) => isImportMetaEnv(ancestor))
+        ) {
+          return;
+        }
+
         const owner = findRemovableOwner(node, ancestors);
         replacements.push({ start: owner.start, end: owner.end, value: '' });
         return;


### PR DESCRIPTION
## Motivation

OXC static evaluation conflated processor-managed values and runtime-only code
with eagerly executed data flow. This caused safe values to become dynamic when
the same module also contained processor interpolations, deferred callbacks,
mutations, or React component bodies that are removed before evaluation.

The processor pipeline also applied dangerous-code removal too late. Processor
callbacks could therefore observe code that should never participate in
evaltime execution, while moving removal earlier without separating evaltime
and runtime code risked losing required runtime replacements.

Original reproduction: https://github.com/Anber/wyw-in-js/compare/main...erictheswift:wyw-in-js:main

Additional regressions: https://github.com/Anber/wyw-in-js/compare/anber/fix-static-tagged-template-scalar-hazard...erictheswift:wyw-in-js:anber/fix-static-tagged-template-scalar-hazard?expand=1

## Summary

- Split processor handling into explicit evaltime and runtime paths. Dangerous
  code is removed before evaltime processor callbacks, while runtime processors
  still apply `doRuntimeReplacement` to the original runtime branch.
- Exclude processors located inside removed component bodies from evaltime
  callbacks without dropping their runtime replacements.
- Carry processor-managed expression spans and static processor exports through
  pre-evaluation so generated class names do not poison unrelated static values.
- Model deferred function and mutation execution separately from eager module
  execution, including tagged-template reads, local pure helpers, resolved
  scalar imports, and styled runtime callbacks.
- Preserve required sibling imports and nested mutation dependencies while
  removing only code that is unreachable from static evaluation.
- Reuse the preeval static plan and processor analysis during runtime collect,
  avoiding the duplicate import, usage, dependency, and binding analysis caused
  by the two code paths.
- Add a patch changeset and regression coverage for the original and additional
  reproductions.

## Performance

The evaltime/runtime split initially introduced a second processor-analysis
pass. Reusing the preeval plans removes that overhead. Across three local runs,
the representative large application build improved by about 6% versus 2.1.6,
with runtime collect about 22% faster. A second application build remained
about 5% faster than the same baseline.

## Test plan

- `bun test packages/transform/src`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform lint`
- Full integration builds for the representative applications, with generated
  CSS hashes unchanged from 2.1.6

Full transform suite: 1556 passed, 0 failed.
