### PR TITLE
fix(transform): project mutation hazards around processor expressions

### DIFF
--- a/.changeset/tag-wrapping-call-mutation-hazard.md
+++ b/.changeset/tag-wrapping-call-mutation-hazard.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Preserve static values when a processor tag is wrapped in a class-name combiner such as `cx(css`…`)`. The wrapping call is no longer treated as a mutation hazard for the bindings interpolated inside the tag.

--- a/.changeset/tag-wrapping-call-mutation-hazard.md
+++ b/.changeset/tag-wrapping-call-mutation-hazard.md
@@ -2,4 +2,4 @@
 '@wyw-in-js/transform': patch
 ---
 
-Preserve static values when a processor tag is wrapped in a class-name combiner such as `cx(css`…`)`. The wrapping call is no longer treated as a mutation hazard for the bindings interpolated inside the tag.
+Preserve static values when processor expressions are nested inside opaque wrappers. Mutation analysis now projects their eval-time replacements through surrounding containers while retaining hazards from other wrapper inputs and processor interpolations.

--- a/packages/transform/src/__tests__/transform.static-imported-css-class.test.ts
+++ b/packages/transform/src/__tests__/transform.static-imported-css-class.test.ts
@@ -149,6 +149,32 @@ describe('static strategy with a css class imported from another module', () => 
     await expect(run(root, entryFile)).resolves.toBeDefined();
   });
 
+  it.each([
+    ['array', '[css`padding: ${space.s18}px;`]'],
+    ['object', '{ className: css`padding: ${space.s18}px;` }'],
+    ['conditional', "true ? css`padding: ${space.s18}px;` : ''"],
+  ])(
+    'resolves a processor nested in a %s wrapper argument',
+    async (_description, wrappedProcessor) => {
+      const entryFile = join(root, 'nested-wrapper.ts');
+      writeFileSync(
+        entryFile,
+        dedent`
+          import { css, cx } from 'test-css-processor';
+          import { space } from './tokens';
+
+          export const first = cx(${wrappedProcessor});
+
+          export const second = css\`
+            gap: ${'${space.s2}'}px;
+          \`;
+        `
+      );
+
+      await expect(run(root, entryFile)).resolves.toBeDefined();
+    }
+  );
+
   it('keeps mutation hazards from non-processor wrapper arguments', async () => {
     const entryFile = join(root, 'mutating-wrapper.ts');
     writeFileSync(
@@ -168,6 +194,35 @@ describe('static strategy with a css class imported from another module', () => 
             padding: ${'${space.s18}'}px;
           \`
         );
+
+        export const second = css\`
+          gap: ${'${space.s2}'}px;
+        \`;
+      `
+    );
+
+    await expect(run(root, entryFile)).rejects.toBeDefined();
+  });
+
+  it('keeps hazards beside a nested processor in the same argument', async () => {
+    const entryFile = join(root, 'mutating-nested-wrapper.ts');
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space } from './tokens';
+
+        const mutate = (value) => {
+          value.tokens.s2 = 99;
+          return value.className;
+        };
+
+        export const first = mutate({
+          tokens: space,
+          className: css\`
+            padding: ${'${space.s18}'}px;
+          \`,
+        });
 
         export const second = css\`
           gap: ${'${space.s2}'}px;

--- a/packages/transform/src/__tests__/transform.static-imported-css-class.test.ts
+++ b/packages/transform/src/__tests__/transform.static-imported-css-class.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const run = async (root: string, entryFile: string) =>
+  transform(
+    {
+      cache: new TransformCacheCollection(),
+      eventEmitter: new EventEmitter(
+        () => {},
+        () => 0,
+        () => {}
+      ),
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          eval: { strategy: 'static' },
+          tagResolver: (source, tag) =>
+            source === 'test-css-processor' && tag === 'css'
+              ? processorFile
+              : null,
+        },
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    async (what: string) =>
+      what === 'test-css-processor'
+        ? processorFile
+        : join(root, `${what.replace(/^\.\//, '')}.ts`)
+  );
+
+describe('static strategy with a css class imported from another module', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'wyw-imported-css-class-'));
+
+    writeFileSync(
+      join(root, 'tokens.ts'),
+      'export const space = { s2: 2, s18: 18 } as const;\n'
+    );
+
+    // A css tag evaluated in its own module and re-used by the entry file.
+    writeFileSync(
+      join(root, 'typography.ts'),
+      dedent`
+        import { css } from 'test-css-processor';
+
+        export const textClasses = {
+          small: css\`
+            font-size: 12px;
+          \`,
+        } as const;
+      `
+    );
+  });
+
+  afterEach(() => {
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  it('resolves every interpolation when no css class is imported', async () => {
+    const entryFile = join(root, 'without-class.ts');
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css, cx } from 'test-css-processor';
+        import { space } from './tokens';
+
+        export const kbdCss = css\`
+          min-width: ${'${space.s18}'}px;
+        \`;
+
+        export const Group = () =>
+          cx(css\`
+            gap: ${'${space.s2}'}px;
+          \`);
+      `
+    );
+
+    await expect(run(root, entryFile)).resolves.toBeDefined();
+  });
+
+  // The wrapping cx() call is a mutation hazard seed, so without the
+  // processor-managed-argument exemption it marks `space` as mutated. Every
+  // later interpolation reached through the deferred-execution path then loses
+  // that import, is never enumerated as a static candidate, and is reported
+  // unresolved with no reason attached.
+  it('resolves interpolations that follow a cx()-wrapped tag', async () => {
+    const entryFile = join(root, 'with-class.ts');
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css, cx } from 'test-css-processor';
+        import { space } from './tokens';
+        import { textClasses } from './typography';
+
+        export const kbdCss = cx(
+          textClasses.small,
+          css\`
+            min-width: ${'${space.s18}'}px;
+          \`
+        );
+
+        export const Group = () =>
+          cx(css\`
+            gap: ${'${space.s2}'}px;
+          \`);
+      `
+    );
+
+    await expect(run(root, entryFile)).resolves.toBeDefined();
+  });
+
+  // The @fibery/ui-kit hints.tsx shape: the later tag is at module scope
+  // rather than inside a component.
+  it('resolves a later module-scope tag after a cx()-wrapped tag', async () => {
+    const entryFile = join(root, 'module-scope-after.ts');
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css, cx } from 'test-css-processor';
+        import { space } from './tokens';
+        import { textClasses } from './typography';
+
+        export const hintsCss = cx(
+          textClasses.small,
+          css\`
+            padding: ${'${space.s18}'}px;
+          \`
+        );
+
+        export const hintCss = css\`
+          gap: ${'${space.s2}'}px;
+        \`;
+      `
+    );
+
+    await expect(run(root, entryFile)).resolves.toBeDefined();
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-imported-css-class.test.ts
+++ b/packages/transform/src/__tests__/transform.static-imported-css-class.test.ts
@@ -122,8 +122,8 @@ describe('static strategy with a css class imported from another module', () => 
     await expect(run(root, entryFile)).resolves.toBeDefined();
   });
 
-  // The @fibery/ui-kit hints.tsx shape: the later tag is at module scope
-  // rather than inside a component.
+  // A real-world shape where the later tag is at module scope rather than
+  // inside a component.
   it('resolves a later module-scope tag after a cx()-wrapped tag', async () => {
     const entryFile = join(root, 'module-scope-after.ts');
     writeFileSync(
@@ -147,5 +147,60 @@ describe('static strategy with a css class imported from another module', () => 
     );
 
     await expect(run(root, entryFile)).resolves.toBeDefined();
+  });
+
+  it('keeps mutation hazards from non-processor wrapper arguments', async () => {
+    const entryFile = join(root, 'mutating-wrapper.ts');
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space } from './tokens';
+
+        const mutate = (value, className) => {
+          value.s2 = 99;
+          return className;
+        };
+
+        export const first = mutate(
+          space,
+          css\`
+            padding: ${'${space.s18}'}px;
+          \`
+        );
+
+        export const second = css\`
+          gap: ${'${space.s2}'}px;
+        \`;
+      `
+    );
+
+    await expect(run(root, entryFile)).rejects.toBeDefined();
+  });
+
+  it('keeps mutation hazards nested inside a processor argument', async () => {
+    const entryFile = join(root, 'mutating-interpolation.ts');
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css, cx } from 'test-css-processor';
+        import { space } from './tokens';
+
+        const mutate = (value) => {
+          value.s2 = 99;
+          return value.s18;
+        };
+
+        export const first = cx(css\`
+          padding: ${'${mutate(space)}'}px;
+        \`);
+
+        export const second = css\`
+          gap: ${'${space.s2}'}px;
+        \`;
+      `
+    );
+
+    await expect(run(root, entryFile)).rejects.toBeDefined();
   });
 });

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -827,6 +827,54 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     expect(result.staticValueCandidates[0]?.source).toContain('=> width');
   });
 
+  it.each([
+    ['an array', 'wrapper([PROCESSOR]);', 'processor`${alias}`'],
+    ['an object', 'wrapper({ className: PROCESSOR });', 'processor`${alias}`'],
+    ['a conditional', "wrapper(true ? PROCESSOR : '');", 'processor`${alias}`'],
+    [
+      'a managed call',
+      'wrapper({ className: PROCESSOR });',
+      'processor(alias)',
+    ],
+  ])(
+    'projects processor provenance through %s wrapper argument',
+    (_description, wrapperSource, processorSource) => {
+      const code = dedent`
+        import { alias, source } from './tokens';
+
+        const wrapper = (value) => value;
+
+        ${wrapperSource.replace('PROCESSOR', processorSource)}
+        const { width } = source;
+        width;
+      `;
+      const processorStart = code.indexOf(processorSource);
+      const expressionStart = code.lastIndexOf('width');
+      const result = collectOxcExpressionDependencies(
+        code,
+        filename,
+        true,
+        [
+          {
+            end: expressionStart + 'width'.length,
+            start: expressionStart,
+          },
+        ],
+        undefined,
+        [
+          {
+            end: processorStart + processorSource.length,
+            start: processorStart,
+          },
+        ]
+      );
+
+      expect(result.staticValues).toEqual([]);
+      expect(result.staticValueCandidates).toHaveLength(1);
+      expect(result.staticValueCandidates[0]?.source).toContain('=> width');
+    }
+  );
+
   it('evaluates a later imported member after a processor-managed scalar interpolation', () => {
     const code = dedent`
       import { source } from './tokens';

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -256,7 +256,7 @@ const collectRootMutationHazards = (
     createDeferredReferencePolicyCollector(bindingIndex);
   const collectEagerReferenceKeys = (
     node: Node,
-    includeBinding: (binding: Binding | null) => boolean = () => true
+    includeReference?: (start: number, end: number) => boolean
   ): string[] => {
     const { ignoredStarts } = collectDeferredReferencePolicy(node);
     return collectMutationReferenceKeys(
@@ -264,7 +264,8 @@ const collectRootMutationHazards = (
       bindingIndex,
       [ignoredHazardTreeReferenceStarts, ignoredStarts],
       toReferenceKey,
-      includeBinding
+      undefined,
+      includeReference
     );
   };
 
@@ -413,9 +414,10 @@ const collectRootMutationHazards = (
   const addReferences = (
     node: Node,
     hazard: Node,
-    canAffectSiblingImport = false
+    canAffectSiblingImport = false,
+    includeReference?: (start: number, end: number) => boolean
   ): void => {
-    collectEagerReferenceKeys(node).forEach((key) => {
+    collectEagerReferenceKeys(node, includeReference).forEach((key) => {
       addHazard(key, hazard, canAffectSiblingImport);
     });
   };
@@ -489,12 +491,27 @@ const collectRootMutationHazards = (
       // Any object passed to unknown code, or used as a method receiver, can
       // be mutated. Pure calls are intentionally rejected here rather than
       // risking a stale static snapshot.
+      // Processor-managed arguments are replaced before this invocation, so
+      // their internal references cannot escape through the outer call. Keep
+      // the call hazardous for its callee and every other argument.
       // Starting at the invocation keeps an inline IIFE body eager while the
       // deferred-reference policy still skips callback arguments.
-      addReferences(node, node, true);
+      const processorArguments = node.arguments.filter((argument) =>
+        ignoredHazardNodes.has(argument)
+      );
+      const includeOuterCallReference =
+        processorArguments.length === 0
+          ? undefined
+          : (start: number, end: number): boolean =>
+              !processorArguments.some(
+                (argument) => argument.start <= start && end <= argument.end
+              );
+      addReferences(node, node, true, includeOuterCallReference);
       addExecutionUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
-        addExecutionUnknownAliasHazard(argument, node);
+        if (!ignoredHazardNodes.has(argument)) {
+          addExecutionUnknownAliasHazard(argument, node);
+        }
       });
       return;
     }

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -66,6 +66,7 @@ export const registerMutationHazardNode = (
   node: Node,
   ignoreLookup: SpanLookup,
   ignoreTreeLookup: SpanLookup,
+  processorManagedExpressionNodes: Set<Node>,
   ignoredHazardNodes: Set<Node>,
   ignoredHazardTreeNodes: Set<Node>
 ): void => {
@@ -79,6 +80,7 @@ export const registerMutationHazardNode = (
     return;
   }
 
+  processorManagedExpressionNodes.add(node);
   ignoredHazardNodes.add(node);
   if (node.type === 'TaggedTemplateExpression') {
     // Suppress the processor tag construction/invocation itself. Quasi
@@ -193,6 +195,7 @@ const collectRootMutationHazards = (
   program: Program,
   mutations: Map<string, Array<AssignmentExpression | UpdateExpression>>,
   bindingIndex: BindingIndex,
+  processorManagedExpressionNodes: ReadonlySet<Node>,
   ignoredHazardNodes: ReadonlySet<Node>,
   ignoredHazardTreeNodes: ReadonlySet<Node>
 ): Map<string, Node[]> => {
@@ -244,51 +247,110 @@ const collectRootMutationHazards = (
 
   const toReferenceKey = (binding: Binding | null, name: string): string =>
     binding ? toMutationBindingKey(binding) : name;
-  const collectReferenceKeys = (node: Node): string[] =>
-    collectMutationReferenceKeys(
-      node,
-      bindingIndex,
-      [ignoredHazardTreeReferenceStarts],
-      toReferenceKey
-    );
+  type ProcessorProjection = {
+    referenceStarts: ReadonlySet<number>;
+    roots: ReadonlySet<Node>;
+  };
+  const processorManagedRoots = [...processorManagedExpressionNodes].sort(
+    (left, right) => left.start - right.start || left.end - right.end
+  );
+  const processorReferenceStarts = new WeakMap<Node, readonly number[]>();
+  const processorProjectionCache = new WeakMap<
+    Node,
+    ProcessorProjection | null
+  >();
+  const findFirstProcessorRootAtOrAfter = (start: number): number => {
+    let low = 0;
+    let high = processorManagedRoots.length;
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      if (processorManagedRoots[middle]!.start < start) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  };
+  const getProcessorProjection = (node: Node): ProcessorProjection | null => {
+    const cached = processorProjectionCache.get(node);
+    if (cached !== undefined) {
+      return cached;
+    }
 
-  const collectDeferredReferencePolicy =
-    createDeferredReferencePolicyCollector(bindingIndex);
-  const collectEagerReferenceKeys = (
-    node: Node,
-    includeReference?: (start: number, end: number) => boolean
-  ): string[] => {
-    const { ignoredStarts } = collectDeferredReferencePolicy(node);
+    const roots = new Set<Node>();
+    const referenceStarts = new Set<number>();
+    const first = findFirstProcessorRootAtOrAfter(node.start);
+    for (let index = first; index < processorManagedRoots.length; index += 1) {
+      const root = processorManagedRoots[index]!;
+      if (root.start > node.end) {
+        break;
+      }
+      if (root.end > node.end) {
+        continue;
+      }
+
+      roots.add(root);
+      let starts = processorReferenceStarts.get(root);
+      if (!starts) {
+        starts = getReferences(root, bindingIndex).map(
+          (reference) => reference.start
+        );
+        processorReferenceStarts.set(root, starts);
+      }
+      starts.forEach((start) => referenceStarts.add(start));
+    }
+
+    const projection = roots.size === 0 ? null : { referenceStarts, roots };
+    processorProjectionCache.set(node, projection);
+    return projection;
+  };
+  const collectReferenceKeys = (node: Node): string[] => {
+    const projection = getProcessorProjection(node);
     return collectMutationReferenceKeys(
       node,
       bindingIndex,
-      [ignoredHazardTreeReferenceStarts, ignoredStarts],
-      toReferenceKey,
-      undefined,
-      includeReference
+      [
+        ignoredHazardTreeReferenceStarts,
+        ...(projection ? [projection.referenceStarts] : []),
+      ],
+      toReferenceKey
     );
   };
 
-  const processorManagedAliasReferenceStarts = new Set<number>();
-  ignoredHazardNodes.forEach((node) => {
-    if (node.type !== 'TaggedTemplateExpression') {
-      return;
-    }
-    getReferences(node, bindingIndex).forEach(({ start }) =>
-      processorManagedAliasReferenceStarts.add(start)
+  const collectDeferredReferencePolicy =
+    createDeferredReferencePolicyCollector(bindingIndex);
+  const collectEagerReferenceKeys = (node: Node): string[] => {
+    const { ignoredStarts } = collectDeferredReferencePolicy(node);
+    const projection = getProcessorProjection(node);
+    return collectMutationReferenceKeys(
+      node,
+      bindingIndex,
+      [
+        ignoredHazardTreeReferenceStarts,
+        ignoredStarts,
+        ...(projection ? [projection.referenceStarts] : []),
+      ],
+      toReferenceKey
     );
-  });
+  };
+
   const collectAliasReferenceKeys = (
     node: Node,
     includeBinding: (binding: Binding | null) => boolean = () => true
-  ): string[] =>
-    collectMutationReferenceKeys(
+  ): string[] => {
+    const projection = getProcessorProjection(node);
+    return collectMutationReferenceKeys(
       node,
       bindingIndex,
-      [processorManagedAliasReferenceStarts, ignoredHazardTreeReferenceStarts],
+      [
+        ignoredHazardTreeReferenceStarts,
+        ...(projection ? [projection.referenceStarts] : []),
+      ],
       toReferenceKey,
       includeBinding
     );
+  };
   const collectCapturedAliasReferenceKeys = (node: Node): string[] =>
     collectAliasReferenceKeys(
       node,
@@ -298,23 +360,28 @@ const collectRootMutationHazards = (
         node.end <= binding.declaredAt
     );
 
-  const containsUnprovenAlias = (node: Node): boolean =>
-    containsUnprovenAliasSource(
-      node,
-      bindingIndex,
-      ignoredHazardTreeNodes,
-      ignoredHazardTreeReferenceStarts
-    );
-  const containsEagerUnprovenAlias = (node: Node): boolean => {
-    const { ignoredRoots, ignoredStarts } =
-      collectDeferredReferencePolicy(node);
+  const containsUnprovenAlias = (node: Node): boolean => {
+    const projection = getProcessorProjection(node);
     return containsUnprovenAliasSource(
       node,
       bindingIndex,
       ignoredHazardTreeNodes,
       ignoredHazardTreeReferenceStarts,
-      ignoredRoots,
-      ignoredStarts
+      projection ? [projection.roots] : [],
+      projection ? [projection.referenceStarts] : []
+    );
+  };
+  const containsEagerUnprovenAlias = (node: Node): boolean => {
+    const { ignoredRoots, ignoredStarts } =
+      collectDeferredReferencePolicy(node);
+    const projection = getProcessorProjection(node);
+    return containsUnprovenAliasSource(
+      node,
+      bindingIndex,
+      ignoredHazardTreeNodes,
+      ignoredHazardTreeReferenceStarts,
+      [ignoredRoots, ...(projection ? [projection.roots] : [])],
+      [ignoredStarts, ...(projection ? [projection.referenceStarts] : [])]
     );
   };
 
@@ -414,10 +481,9 @@ const collectRootMutationHazards = (
   const addReferences = (
     node: Node,
     hazard: Node,
-    canAffectSiblingImport = false,
-    includeReference?: (start: number, end: number) => boolean
+    canAffectSiblingImport = false
   ): void => {
-    collectEagerReferenceKeys(node, includeReference).forEach((key) => {
+    collectEagerReferenceKeys(node).forEach((key) => {
       addHazard(key, hazard, canAffectSiblingImport);
     });
   };
@@ -491,27 +557,15 @@ const collectRootMutationHazards = (
       // Any object passed to unknown code, or used as a method receiver, can
       // be mutated. Pure calls are intentionally rejected here rather than
       // risking a stale static snapshot.
-      // Processor-managed arguments are replaced before this invocation, so
-      // their internal references cannot escape through the outer call. Keep
-      // the call hazardous for its callee and every other argument.
+      // References inside nested processor-managed expressions are projected
+      // out by addReferences because the outer invocation receives their
+      // evaltime replacements, not their original interpolation inputs.
       // Starting at the invocation keeps an inline IIFE body eager while the
       // deferred-reference policy still skips callback arguments.
-      const processorArguments = node.arguments.filter((argument) =>
-        ignoredHazardNodes.has(argument)
-      );
-      const includeOuterCallReference =
-        processorArguments.length === 0
-          ? undefined
-          : (start: number, end: number): boolean =>
-              !processorArguments.some(
-                (argument) => argument.start <= start && end <= argument.end
-              );
-      addReferences(node, node, true, includeOuterCallReference);
+      addReferences(node, node, true);
       addExecutionUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
-        if (!ignoredHazardNodes.has(argument)) {
-          addExecutionUnknownAliasHazard(argument, node);
-        }
+        addExecutionUnknownAliasHazard(argument, node);
       });
       return;
     }
@@ -992,6 +1046,7 @@ const collectRootMutationHazards = (
 export const collectProgramMutationAnalysis = (
   program: Program,
   bindingIndex: BindingIndex,
+  processorManagedExpressionNodes: ReadonlySet<Node>,
   ignoredMutationHazardNodes: ReadonlySet<Node>,
   ignoredMutationHazardTreeNodes: ReadonlySet<Node>,
   hasEffectiveMutationHazardSeed: boolean
@@ -1007,6 +1062,7 @@ export const collectProgramMutationAnalysis = (
           program,
           rootMutationsByBinding,
           bindingIndex,
+          processorManagedExpressionNodes,
           ignoredMutationHazardNodes,
           ignoredMutationHazardTreeNodes
         );

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
@@ -230,16 +230,14 @@ export const collectMutationReferenceKeys = (
   bindingIndex: BindingIndex,
   ignoredStarts: readonly ReadonlySet<number>[],
   toKey: (binding: Binding | null, name: string) => string,
-  includeBinding: (binding: Binding | null) => boolean = () => true,
-  includeReference: (start: number, end: number) => boolean = () => true
+  includeBinding: (binding: Binding | null) => boolean = () => true
 ): string[] => [
   ...new Set(
     getReferences(node, bindingIndex)
       .filter(
         (reference) =>
           ignoredStarts.every((starts) => !starts.has(reference.start)) &&
-          includeBinding(reference.binding) &&
-          includeReference(reference.start, reference.end)
+          includeBinding(reference.binding)
       )
       .map(({ binding, name }) => toKey(binding, name))
   ),
@@ -308,10 +306,13 @@ const containsOpaqueAliasConstruct = (
   bindingIndex: BindingIndex,
   ignoredTreeNodes: ReadonlySet<Node>,
   ignoredReferenceStarts: ReadonlySet<number>,
-  ignoredSubtreeRoots?: ReadonlySet<Node>,
-  ignoredExtraReferenceStarts?: ReadonlySet<number>
+  ignoredSubtreeRootSets: readonly ReadonlySet<Node>[] = [],
+  ignoredExtraReferenceStartSets: readonly ReadonlySet<number>[] = []
 ): boolean => {
-  if (ignoredTreeNodes.has(node) || ignoredSubtreeRoots?.has(node)) {
+  if (
+    ignoredTreeNodes.has(node) ||
+    ignoredSubtreeRootSets.some((roots) => roots.has(node))
+  ) {
     return false;
   }
 
@@ -326,7 +327,9 @@ const containsOpaqueAliasConstruct = (
       getReferences(node, bindingIndex).every(
         (reference) =>
           ignoredReferenceStarts.has(reference.start) ||
-          ignoredExtraReferenceStarts?.has(reference.start)
+          ignoredExtraReferenceStartSets.some((starts) =>
+            starts.has(reference.start)
+          )
       )) ||
     getOxcNodeChildren(node).some((child) =>
       containsOpaqueAliasConstruct(
@@ -334,8 +337,8 @@ const containsOpaqueAliasConstruct = (
         bindingIndex,
         ignoredTreeNodes,
         ignoredReferenceStarts,
-        ignoredSubtreeRoots,
-        ignoredExtraReferenceStarts
+        ignoredSubtreeRootSets,
+        ignoredExtraReferenceStartSets
       )
     )
   );
@@ -346,15 +349,17 @@ export const containsUnprovenAliasSource = (
   bindingIndex: BindingIndex,
   ignoredTreeNodes: ReadonlySet<Node>,
   ignoredReferenceStarts: ReadonlySet<number>,
-  ignoredSubtreeRoots?: ReadonlySet<Node>,
-  ignoredExtraReferenceStarts?: ReadonlySet<number>
+  ignoredSubtreeRootSets: readonly ReadonlySet<Node>[] = [],
+  ignoredExtraReferenceStartSets: readonly ReadonlySet<number>[] = []
 ): boolean =>
   !ignoredTreeNodes.has(node) &&
-  !ignoredSubtreeRoots?.has(node) &&
+  !ignoredSubtreeRootSets.some((roots) => roots.has(node)) &&
   (getReferences(node, bindingIndex).some(
     (reference) =>
       !ignoredReferenceStarts.has(reference.start) &&
-      !ignoredExtraReferenceStarts?.has(reference.start) &&
+      ignoredExtraReferenceStartSets.every(
+        (starts) => !starts.has(reference.start)
+      ) &&
       reference.binding === null
   ) ||
     containsOpaqueAliasConstruct(
@@ -362,8 +367,8 @@ export const containsUnprovenAliasSource = (
       bindingIndex,
       ignoredTreeNodes,
       ignoredReferenceStarts,
-      ignoredSubtreeRoots,
-      ignoredExtraReferenceStarts
+      ignoredSubtreeRootSets,
+      ignoredExtraReferenceStartSets
     ));
 
 export const collectThrownExpressions = (

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationExecution.ts
@@ -230,14 +230,16 @@ export const collectMutationReferenceKeys = (
   bindingIndex: BindingIndex,
   ignoredStarts: readonly ReadonlySet<number>[],
   toKey: (binding: Binding | null, name: string) => string,
-  includeBinding: (binding: Binding | null) => boolean = () => true
+  includeBinding: (binding: Binding | null) => boolean = () => true,
+  includeReference: (start: number, end: number) => boolean = () => true
 ): string[] => [
   ...new Set(
     getReferences(node, bindingIndex)
       .filter(
         (reference) =>
           ignoredStarts.every((starts) => !starts.has(reference.start)) &&
-          includeBinding(reference.binding)
+          includeBinding(reference.binding) &&
+          includeReference(reference.start, reference.end)
       )
       .map(({ binding, name }) => toKey(binding, name))
   ),

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/scopeAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/scopeAnalysis.ts
@@ -214,6 +214,7 @@ type RequestAnalysis = Pick<
   hasEffectiveMutationHazardSeed: boolean;
   ignoredMutationHazardNodes: Set<Node>;
   ignoredMutationHazardTreeNodes: Set<Node>;
+  processorManagedExpressionNodes: Set<Node>;
 };
 
 const programScopeFacts = new WeakMap<Program, ProgramScopeFacts>();
@@ -340,6 +341,7 @@ const createRequestAnalysis = ({
     hasEffectiveMutationHazardSeed: false,
     ignoredMutationHazardNodes: new Set(),
     ignoredMutationHazardTreeNodes: new Set(),
+    processorManagedExpressionNodes: new Set(),
     targetExpressions: [],
     templateLiterals: [],
   };
@@ -350,6 +352,7 @@ const createRequestAnalysis = ({
         node,
         mutationHazardIgnoreLookup,
         mutationHazardIgnoreTreeLookup,
+        result.processorManagedExpressionNodes,
         result.ignoredMutationHazardNodes,
         result.ignoredMutationHazardTreeNodes
       );
@@ -358,6 +361,7 @@ const createRequestAnalysis = ({
         node,
         null,
         mutationHazardIgnoreTreeLookup,
+        result.processorManagedExpressionNodes,
         result.ignoredMutationHazardNodes,
         result.ignoredMutationHazardTreeNodes
       );
@@ -625,6 +629,7 @@ export const analyzeProgram = (
     const mutationAnalysis = collectProgramMutationAnalysis(
       program,
       scopeFacts.bindingIndex,
+      request.result.processorManagedExpressionNodes,
       request.result.ignoredMutationHazardNodes,
       request.result.ignoredMutationHazardTreeNodes,
       request.result.hasEffectiveMutationHazardSeed

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
@@ -62,33 +62,6 @@ import type { ExtractionContext } from './types';
 
 export { createOxcStaticCallableValue } from './staticEvaluationRuntime';
 
-// A processor tag is replaced by its own value (a class name) before the
-// enclosing call runs, so passing one cannot expose the bindings interpolated
-// inside it. Literals and plain identifier/member reads are inert for the same
-// reason: they hand the callee a value, not a route to the tag's bindings.
-const isProcessorManagedArgument = (
-  argument: Node,
-  ctx: ExtractionContext
-): boolean => {
-  if (argument.type === 'TaggedTemplateExpression') {
-    return ctx.processorManagedExpressionSpans.has(
-      `${argument.start}:${argument.end}`
-    );
-  }
-
-  if (argument.type === 'Identifier' || argument.type === 'Literal') {
-    return true;
-  }
-
-  // Only static, non-computed property reads: `a.b.c` cannot run user code,
-  // while `a[fn()]` can.
-  return (
-    argument.type === 'MemberExpression' &&
-    !argument.computed &&
-    isProcessorManagedArgument(argument.object, ctx)
-  );
-};
-
 export const isKnownPureStaticCall = (
   node: Node,
   ctx: ExtractionContext,
@@ -110,25 +83,6 @@ export const isKnownPureStaticCall = (
 
   if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') {
     return false;
-  }
-
-  // A class-name combiner such as `cx(a, css`…`)` only ever receives the
-  // processor's already-substituted result, so it cannot reach the bindings
-  // interpolated inside the tag. Without this, the wrapping call is an opaque
-  // hazard that invalidates those imports for every later deferred reference.
-  // Restricted to calls that actually wrap a processor tag so ordinary calls
-  // keep their conservative classification.
-  if (
-    node.arguments.some(
-      (argument) =>
-        argument.type === 'TaggedTemplateExpression' &&
-        ctx.processorManagedExpressionSpans.has(
-          `${argument.start}:${argument.end}`
-        )
-    ) &&
-    node.arguments.every((argument) => isProcessorManagedArgument(argument, ctx))
-  ) {
-    return true;
   }
 
   const binding = resolveBindingAt(ctx, node.callee.name, node.callee.start);

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
@@ -62,6 +62,33 @@ import type { ExtractionContext } from './types';
 
 export { createOxcStaticCallableValue } from './staticEvaluationRuntime';
 
+// A processor tag is replaced by its own value (a class name) before the
+// enclosing call runs, so passing one cannot expose the bindings interpolated
+// inside it. Literals and plain identifier/member reads are inert for the same
+// reason: they hand the callee a value, not a route to the tag's bindings.
+const isProcessorManagedArgument = (
+  argument: Node,
+  ctx: ExtractionContext
+): boolean => {
+  if (argument.type === 'TaggedTemplateExpression') {
+    return ctx.processorManagedExpressionSpans.has(
+      `${argument.start}:${argument.end}`
+    );
+  }
+
+  if (argument.type === 'Identifier' || argument.type === 'Literal') {
+    return true;
+  }
+
+  // Only static, non-computed property reads: `a.b.c` cannot run user code,
+  // while `a[fn()]` can.
+  return (
+    argument.type === 'MemberExpression' &&
+    !argument.computed &&
+    isProcessorManagedArgument(argument.object, ctx)
+  );
+};
+
 export const isKnownPureStaticCall = (
   node: Node,
   ctx: ExtractionContext,
@@ -83,6 +110,25 @@ export const isKnownPureStaticCall = (
 
   if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') {
     return false;
+  }
+
+  // A class-name combiner such as `cx(a, css`…`)` only ever receives the
+  // processor's already-substituted result, so it cannot reach the bindings
+  // interpolated inside the tag. Without this, the wrapping call is an opaque
+  // hazard that invalidates those imports for every later deferred reference.
+  // Restricted to calls that actually wrap a processor tag so ordinary calls
+  // keep their conservative classification.
+  if (
+    node.arguments.some(
+      (argument) =>
+        argument.type === 'TaggedTemplateExpression' &&
+        ctx.processorManagedExpressionSpans.has(
+          `${argument.start}:${argument.end}`
+        )
+    ) &&
+    node.arguments.every((argument) => isProcessorManagedArgument(argument, ctx))
+  ) {
+    return true;
   }
 
   const binding = resolveBindingAt(ctx, node.callee.name, node.callee.start);


### PR DESCRIPTION
## Problem

Mutation analysis conservatively treats potentially opaque expressions as mutation hazards and attributes references from their descendants to the outer expression. When a processor usage is nested inside such an expression, this can incorrectly make bindings used by the processor look as though they escape through the surrounding array, object, conditional, or call.

The processor-managed expression is replaced before the surrounding expression is evaluated, so the wrapper cannot observe those original references. A later processor usage can nevertheless see the false hazard, drop the affected import from static evaluation, and leave an unresolved interpolation under `eval.strategy: "static"`.

The behavior regressed in [`8eb2759`](https://github.com/Anber/wyw-in-js/commit/8eb275927b102c24aa51eb84b8940b0e8f35b11f) when static destructuring projection support expanded mutation-hazard propagation.

## Fix

Model processor-managed expressions as eval-time projection boundaries during mutation analysis.

For an enclosing hazard, references owned by a nested processor expression are projected out because the processor replacement runs first. The analysis still retains:

- mutations and aliases from sibling values in the surrounding container;
- calls and mutations inside processor interpolations;
- hazards analyzed from inside the processor expression itself;
- ordinary non-processor arguments and callees.

This works uniformly for tagged and call processors nested through arrays, objects, conditionals, and opaque calls. Processor roots are ordered by source span, their binding references are cached once, and each analyzed node caches its projected reference view to avoid repeated AST walks.

## Regression range

| version | result |
| --- | --- |
| 2.1.6 | pass |
| 2.2.0 | pass |
| 2.3.0 | pass |
| **2.4.0** | **fail** |

## Repro

```js
import { css, cx } from '@linaria/core';
import { space, textClasses } from './design-system';

export const hintsCss = cx(
  textClasses.small,
  css`
    padding: ${space.s18}px;
  `
);

export const hintCss = css`
  gap: ${space.s2}px;
`;
```

## Verification

- Focused transform and mutation-provenance suites cover direct and nested processor projections plus negative safety cases.
- Transform lint and type build pass.
- Downstream production builds and typechecks pass.
- Generated CSS is byte-for-byte unchanged from the control revision.
- Across three performance runs, total builds changed by -0.4% to +0.9% versus the fresh control; directly affected pre-evaluation time changed by -1.0% to +2.6%, within normal run-to-run variance.
