### PR TITLE
fix(transform): ship real empty code instead of a reuse sentinel on first eval load

### DIFF
--- a/.changeset/eval-empty-module-first-load.md
+++ b/.changeset/eval-empty-module-first-load.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix a broker/runner cache desync error thrown for the first eval-time load of a module that legitimately shakes down to zero runtime bytes (e.g. a types-only module reached through a barrel's `export *`). The broker previously used an empty `code` string to mean both "here is real, empty content" and "nothing to ship, reuse your cache," so genuinely empty modules were misread as the latter and rejected by the runner on first load. `code` is now omitted from the LoadResult when nothing should be shipped, and only that omission is treated as a signal to reuse a cached variant.

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -1524,6 +1524,127 @@ describe('EvalBroker', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('evaluates a barrel that wildcard re-exports a runtime-empty module', async () => {
+    // A module can be a real, resolvable ESM dependency edge while shaking
+    // down to zero runtime bytes (e.g. it only ever declared TypeScript
+    // types). `export * from './dep'` in a barrel can't be selectively
+    // pruned without knowing the wildcard target's exports, so the
+    // statement survives shaking and the runner's native ESM linker still
+    // requests `dep` on first load. The broker must ship the genuine empty
+    // string in that case rather than treating "no code" as license to
+    // reuse a cached module the runner has never seen.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.ts');
+    const barrel = join(root, 'barrel.ts');
+    const dep = join(root, 'dep.ts');
+
+    writeFileSync(dep, 'export type Foo = string;\n');
+    writeFileSync(
+      barrel,
+      ["export * from './dep';", 'export const marker = 1;'].join('\n')
+    );
+    writeFileSync(
+      entry,
+      [
+        "import { marker } from './barrel';",
+        'export const __wywPreval = {',
+        '  value: () => marker,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(services, asyncResolve);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf-8')
+    );
+
+    const result = await broker.evaluate(entrypoint);
+
+    expect(result.values?.get('value')).toBe(1);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reuses a first-load runtime-empty module on a second request in the same session', async () => {
+    // Companion to the barrel test above: once the runner has actually seen
+    // (and cached) the empty module under its hash, a later request for the
+    // same id/hash must still short-circuit via the cache-reuse path instead
+    // of re-shipping — proving the fix doesn't just move the bug to the
+    // second load.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entryA = join(root, 'entry-a.ts');
+    const entryB = join(root, 'entry-b.ts');
+    const barrel = join(root, 'barrel.ts');
+    const dep = join(root, 'dep.ts');
+
+    writeFileSync(dep, 'export type Foo = string;\n');
+    writeFileSync(
+      barrel,
+      ["export * from './dep';", 'export const marker = 1;'].join('\n')
+    );
+    writeFileSync(
+      entryA,
+      [
+        "import { marker } from './barrel';",
+        'export const __wywPreval = {',
+        '  value: () => marker,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entryB,
+      [
+        "import { marker } from './barrel';",
+        'export const __wywPreval = {',
+        '  value: () => marker + 1,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA);
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const first = await broker.evaluate(
+      Entrypoint.createRoot(
+        services,
+        entryA,
+        ['__wywPreval'],
+        readFileSync(entryA, 'utf-8')
+      )
+    );
+    expect(first.values?.get('value')).toBe(1);
+
+    const second = await broker.evaluate(
+      Entrypoint.createRoot(
+        services,
+        entryB,
+        ['__wywPreval'],
+        readFileSync(entryB, 'utf-8')
+      )
+    );
+    expect(second.values?.get('value')).toBe(2);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   describe('eval.globals lifecycle', () => {
     it('re-evaluates when eval.globals value changes between runs', async () => {
       const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
@@ -4072,9 +4193,10 @@ describe('EvalBroker', () => {
   it('skips re-shipping LoadResult code when runner already has matching hash', async () => {
     // Multiple importers asking for the same dependency in one runner session
     // produce identical prepared variants (same hash, same `only`). The first
-    // LOAD must ship code; subsequent LOADs must ship `code: ''` so the
-    // runner's hash-match short-circuit (runner.js:1834) reuses its cached
-    // SourceTextModule instead of re-parsing identical bytes.
+    // LOAD must ship code; subsequent LOADs must omit `code` entirely (not
+    // ship `''` — that's a legitimate payload for a runtime-empty module) so
+    // the runner's hash-match short-circuit (runner.js:1834) reuses its
+    // cached SourceTextModule instead of re-parsing identical bytes.
     const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
     const importerA = join(root, 'a.js');
     const importerB = join(root, 'b.js');
@@ -4137,7 +4259,7 @@ describe('EvalBroker', () => {
     const [first, second] = captured;
     expect(first.payload.code).toBe('export const value = 1;');
     expect(first.payload.hash).toBeTruthy();
-    expect(second.payload.code).toBe('');
+    expect(second.payload.code).toBeUndefined();
     expect(second.payload.hash).toBe(first.payload.hash);
 
     // Third LOAD with a wider `only` (forces a new prepared variant via the
@@ -4350,7 +4472,7 @@ describe('EvalBroker', () => {
 
     expect(captured).toHaveLength(2);
     expect(captured[0].payload.code).toBe('export const value = 1;');
-    expect(captured[1].payload.code).toBe('');
+    expect(captured[1].payload.code).toBeUndefined();
     expect(captured[1].payload.hash).toBe(captured[0].payload.hash);
 
     broker.dispose();

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -2905,8 +2905,16 @@ export class EvalBroker {
         sameStorageShape &&
         isSuperSet(previouslySent.only, prepared.only)
     );
+    // `prepared.code` is a plain string, never absent — a module whose
+    // runtime footprint is genuinely nothing (types-only, or a barrel's
+    // `export *` target that shakes to zero bytes) legitimately prepares to
+    // ''. Gating on its truthiness treated that real payload the same as
+    // "nothing to ship", so the first request for such a module shipped ''
+    // with no prior variant for the runner to fall back on. Ship whenever
+    // the runner doesn't already have an equivalent variant cached; only
+    // omit the field (see the LoadResult below) when it does.
     const shouldShipCode = Boolean(
-      prepared.code && !prepared.exports && !runnerHasCachedVariant
+      !prepared.exports && !runnerHasCachedVariant
     );
 
     if (debugEvalDir) {
@@ -2938,7 +2946,10 @@ export class EvalBroker {
 
     await this.sendLoadResult(id, {
       id: payload.id,
-      code: shouldShipCode ? prepared.code : '',
+      // Omit `code` entirely — rather than sending '' — when we're not
+      // shipping. '' is a legitimate LoadResult for a runtime-empty module;
+      // only an *absent* field means "reuse what you already have".
+      ...(shouldShipCode ? { code: prepared.code } : {}),
       map: null,
       hash: prepared.hash,
       only: prepared.only,

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1980,14 +1980,18 @@ loadModule = async (id, importer, requestSpec) => {
       }
     }
 
-    // The broker only ships empty `code` when it expects the runner to reuse
-    // a cached module via the hash-match short-circuit above. Reaching this
-    // point with no code means the broker's "what runner has" mirror is out
-    // of sync with our actual moduleCache/moduleVariants — fail loudly rather
-    // than feeding empty source into vm.SourceTextModule.
-    if (loaded.code == null || loaded.code === '') {
+    // The broker omits `code` entirely when it expects the runner to reuse a
+    // cached module via the hash-match short-circuit above — an empty
+    // string is a legitimate LoadResult in its own right (a module whose
+    // runtime footprint genuinely shakes down to zero bytes, e.g. a
+    // types-only module reached through a barrel's `export *`). Reaching
+    // this point with `code` truly absent means the broker's "what runner
+    // has" mirror is out of sync with our actual moduleCache/moduleVariants
+    // — fail loudly rather than feeding undefined source into
+    // vm.SourceTextModule.
+    if (loaded.code == null) {
       throw new Error(
-        `[wyw-in-js] LoadResult for ${id} has empty code but no cached module ` +
+        `[wyw-in-js] LoadResult for ${id} has no code but no cached module ` +
           `matched hash ${loaded.hash ?? '(none)'}. ` +
           `This indicates a broker/runner cache desync.`
       );


### PR DESCRIPTION
## Motivation

A module can be a real, resolvable ESM dependency edge while its compiled
code shakes down to zero runtime bytes — for example a types-only module
reached through a barrel's `export * from './dep'`. `export *` can't be
selectively pruned without knowing the wildcard target's exports, so the
statement survives shaking even when the target itself has nothing left at
runtime, and the native ESM linker in the eval runner still requests that
target on first load.

`EvalBroker.handleLoad` decides whether to ship a module's code with:

```ts
const shouldShipCode = Boolean(
  prepared.code && !prepared.exports && !runnerHasCachedVariant
);
```

`prepared.code` is a plain string, never absent — a genuinely empty module
prepares to `''`, which is falsy. On the *first* request for such a module,
`shouldShipCode` is `false` even though the runner has never seen it, so the
broker ships `code: ''` anyway (`code: shouldShipCode ? prepared.code : ''`).
The runner can't tell "here is real, empty content" apart from "nothing to
ship, reuse your cache" — both are the empty string — so it throws:

```text
[wyw-in-js] LoadResult for <dep> has empty code but no cached module
matched hash <hash>. This indicates a broker/runner cache desync.
```

on a module that never actually desynced; it's simply legitimately empty.

## Summary

- `code` is only included in the `LoadResult` payload when the broker
  intends to ship it (`shouldShipCode`); otherwise the field is omitted
  entirely rather than set to `''`. `''` is now unambiguously "real, empty
  content."
- The runner's desync check changes from `loaded.code == null ||
  loaded.code === ''` to `loaded.code == null` — only a genuinely *absent*
  `code` field is treated as a signal to reuse a cached variant.
- Two pre-existing tests asserted the old sentinel behavior directly
  (`payload.code === ''` on a cache-reuse LOAD); updated both to expect
  `undefined`, since that's the correct signal now.

No public API changes. This is entirely internal to the eval broker/runner
IPC protocol (`LoadResultPayload.code` was already typed `code?: string`,
so this is not even a wire-format change — the field simply starts being
omitted when it should have been all along).

## Test plan

Added two tests to `packages/transform/src/__tests__/eval-broker.test.ts`,
run via the real `EvalBroker`/runner subprocess (not mocked):

1. `evaluates a barrel that wildcard re-exports a runtime-empty module` — a
   `.ts` barrel with `export * from './dep'` where `dep` is a type-only
   module. Reproduces the crash verbatim on unpatched code; asserts a
   correct value after the fix.
2. `reuses a first-load runtime-empty module on a second request in the
   same session` — a second, distinct entrypoint requests the same barrel
   afterward, proving the fix doesn't just move the bug to the reuse path.

```text
$ bun test packages/transform/src/__tests__/eval-broker.test.ts
 72 pass
 0 fail
 2 snapshots, 209 expect() calls
Ran 72 tests across 1 file. [6.60s]
```

Full package suite, unaffected:

```text
$ bun test packages/transform/src
 1558 pass
 1 skip
 1 todo
 0 fail
 91 snapshots, 4735 expect() calls
Ran 1560 tests across 97 files. [33.43s]
```

(1556 pass on `main` before this change + 2 new tests here.)

`bun run lint`, `tsc --project ./tsconfig.lib.json` (via `build:types`),
and `build:esm` all clean. Also ran the esbuild, rollup, vite, webpack, and
next-webpack e2e suites locally — all pass.

Opening as a draft to let CI (including the Windows/Node-24 lanes and
adapters I couldn't run locally) confirm before asking for review.
