### PR TITLE
fix(nextjs): resolve RuleSetUseItem for next-rspack compatibility

### DIFF
--- a/.changeset/tidy-rspack-loaders.md
+++ b/.changeset/tidy-rspack-loaders.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/nextjs': patch
+---
+
+Fix Next.js builds with `next-rspack` by keeping conditional loader selection at the `use` rule level instead of placing a function inside the loader array.

--- a/packages/nextjs/src/__tests__/withWyw.test.ts
+++ b/packages/nextjs/src/__tests__/withWyw.test.ts
@@ -43,11 +43,25 @@ describe('withWyw', () => {
     return tsRule.loaders[0].options;
   };
 
-  const getWebpackLoaderForResource = (use: any[], resource: string): any => {
-    const resolvedUse = use.flatMap((item) => {
-      const resolved = typeof item === 'function' ? item({ resource }) : item;
-      return Array.isArray(resolved) ? resolved : [resolved];
-    });
+  const resolveWebpackUse = (
+    use: RuleSetRule['use'],
+    resource: string
+  ): any[] => {
+    if (!use) return [];
+
+    const resolved =
+      typeof use === 'function'
+        ? use({ resource, realResource: resource } as any)
+        : use;
+
+    return (Array.isArray(resolved) ? resolved : [resolved]).filter(Boolean);
+  };
+
+  const getWebpackLoaderForResource = (
+    use: RuleSetRule['use'],
+    resource: string
+  ): any => {
+    const resolvedUse = resolveWebpackUse(use, resource);
 
     return resolvedUse.find((item) => item?.loader?.includes('webpack-loader'));
   };
@@ -196,9 +210,12 @@ describe('withWyw', () => {
     const nextConfig = withWyw();
 
     const result = nextConfig.webpack!(config, { dev: true } as any);
-    const use = (result.module!.rules![0] as RuleSetRule).use as any[];
+    const { use } = result.module!.rules![0] as RuleSetRule;
 
-    expect(use).toHaveLength(2);
+    expect(typeof use).toBe('function');
+    const localUse = resolveWebpackUse(use, '/project/app/page.tsx');
+    expect(localUse).toHaveLength(2);
+    expect(localUse.every((item) => typeof item !== 'function')).toBe(true);
     const localLoader = getWebpackLoaderForResource(
       use,
       '/project/app/page.tsx'
@@ -215,6 +232,15 @@ describe('withWyw', () => {
         '/project/node_modules/swr/dist/index.mjs'
       )
     ).toBeUndefined();
+    const nodeModulesUse = resolveWebpackUse(
+      use,
+      '/project/node_modules/swr/dist/index.mjs'
+    );
+    expect(nodeModulesUse).toHaveLength(1);
+    expect(nodeModulesUse[0].loader).toContain('next-swc-loader');
+    expect(nodeModulesUse.every((item) => typeof item !== 'function')).toBe(
+      true
+    );
     expect(
       getWebpackLoaderForResource(
         use,
@@ -246,7 +272,7 @@ describe('withWyw', () => {
     );
 
     const result = nextConfig.webpack!(config, { dev: true } as any);
-    const use = (result.module!.rules![0] as RuleSetRule).use as any[];
+    const { use } = result.module!.rules![0] as RuleSetRule;
     const localLoader = getWebpackLoaderForResource(
       use,
       '/project/pages/index.tsx'
@@ -259,7 +285,7 @@ describe('withWyw', () => {
     });
   });
 
-  it('converts loader+options rules to use[] when injecting', () => {
+  it('converts loader+options rules to functional use when injecting', () => {
     const config: Configuration = {
       module: {
         rules: [
@@ -280,11 +306,14 @@ describe('withWyw', () => {
 
     expect(rule.loader).toBeUndefined();
     expect(rule.options).toBeUndefined();
-    expect(rule.use).toHaveLength(2);
-    expect(rule.use[0].loader).toContain('next-swc-loader');
-    expect(rule.use[0].options).toEqual({ some: 'option' });
+    expect(typeof rule.use).toBe('function');
+    const use = resolveWebpackUse(rule.use, '/project/pages/index.tsx');
+    expect(use).toHaveLength(2);
+    expect(use.every((item) => typeof item !== 'function')).toBe(true);
+    expect(use[0].loader).toContain('next-swc-loader');
+    expect(use[0].options).toEqual({ some: 'option' });
     expect(
-      getWebpackLoaderForResource(rule.use, '/project/pages/index.tsx').loader
+      getWebpackLoaderForResource(use, '/project/pages/index.tsx').loader
     ).toContain('webpack-loader');
   });
 

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -101,7 +101,6 @@ function isWywLoaderPath(loader: string) {
 
 function convertLoaderRuleToUseRule(
   rule: RuleSetRule,
-  wywLoaderItem: RuleSetUseItem
 ) {
   const { loader } = rule as { loader?: unknown };
   if (typeof loader !== 'string') return;
@@ -129,8 +128,7 @@ function convertLoaderRuleToUseRule(
   // Loader order is right-to-left. We want WyW to run first, so it should be last.
   Object.assign(nextRule, {
     use: [
-      { loader, ...(options !== undefined ? { options } : {}) },
-      wywLoaderItem,
+      { loader, ...(options !== undefined ? { options } : {}) }
     ],
   });
 }
@@ -334,14 +332,8 @@ function injectWywLoader(
     sourceMap: wywNext.loaderOptions?.sourceMap ?? nextOptions.dev,
   } satisfies WywWebpackLoaderOptions;
 
-  const wywLoaderItem: RuleSetUseItem = {
-    loader,
-    options: loaderOptions,
-  };
-  const wywLoaderUse = createWywLoaderUseFunction(loader, wywLoaderItem);
-
   traverseRules(config.module?.rules ?? [], (rule) => {
-    convertLoaderRuleToUseRule(rule, wywLoaderUse);
+    convertLoaderRuleToUseRule(rule);
 
     const use = normalizeUseItems(rule.use);
     if (!use) return;
@@ -360,8 +352,14 @@ function injectWywLoader(
     );
     if (!isNextJsTranspileRule) return;
 
+    const wywLoaderItem: RuleSetUseItem = {
+      loader,
+      options: loaderOptions,
+    };
+    const wywLoaderUse = createWywLoaderUseFunction(loader, wywLoaderItem);
+
     // Loader order is right-to-left. We want WyW to run first, so it should be last.
-    Object.assign(rule, { use: [...use, wywLoaderUse] });
+    Object.assign(rule, { use: (data) => [...use, wywLoaderUse(data)].flat() });
   });
 
   ensureWywCssModuleRules(config, extension);

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -18,7 +18,6 @@ const DEFAULT_EXTENSION = '.wyw-in-js.module.css';
 const CSS_OUTPUT_QUERY = '__wyw_css';
 const CSS_OUTPUT_QUERY_RE = new RegExp(`^\\??${CSS_OUTPUT_QUERY}$`);
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/;
-const WYW_LOADER_USE = Symbol('wywLoaderUse');
 
 const DEFAULT_TURBO_RULE_KEYS = ['*.js', '*.jsx', '*.ts', '*.tsx'];
 
@@ -42,10 +41,6 @@ type NextVersion = {
   major: number;
   minor: number;
 };
-type WywLoaderUseFunction = RuleSetUseFunction & {
-  [WYW_LOADER_USE]: string;
-};
-
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -67,29 +62,22 @@ function normalizeUseItems(use: RuleSetRule['use']): RuleSetUseItem[] | null {
   return list.length ? (list as RuleSetUseItem[]) : null;
 }
 
-function isWywLoaderUseFunction(
-  item: RuleSetUseItem
-): item is WywLoaderUseFunction {
-  return typeof item === 'function' && WYW_LOADER_USE in item;
-}
-
 function getLoaderName(item: RuleSetUseItem): string {
   if (typeof item === 'string') return item;
-  if (isWywLoaderUseFunction(item)) return item[WYW_LOADER_USE];
   if (isUseLoaderObject(item)) return item.loader;
   return '';
 }
 
 function createWywLoaderUseFunction(
-  loader: string,
+  use: RuleSetUseItem[],
   loaderItem: RuleSetUseItem
-): WywLoaderUseFunction {
-  const use: RuleSetUseFunction = ({ realResource, resource }) => {
+): RuleSetUseFunction {
+  return ({ realResource, resource }) => {
     const resourcePath = realResource ?? resource;
-    return resourcePath && NODE_MODULES_RE.test(resourcePath) ? [] : loaderItem;
+    return resourcePath && NODE_MODULES_RE.test(resourcePath)
+      ? use
+      : [...use, loaderItem];
   };
-
-  return Object.assign(use, { [WYW_LOADER_USE]: loader });
 }
 
 function isWywLoaderPath(loader: string) {
@@ -99,9 +87,7 @@ function isWywLoaderPath(loader: string) {
   );
 }
 
-function convertLoaderRuleToUseRule(
-  rule: RuleSetRule,
-) {
+function convertLoaderRuleToUseRule(rule: RuleSetRule) {
   const { loader } = rule as { loader?: unknown };
   if (typeof loader !== 'string') return;
 
@@ -127,9 +113,7 @@ function convertLoaderRuleToUseRule(
 
   // Loader order is right-to-left. We want WyW to run first, so it should be last.
   Object.assign(nextRule, {
-    use: [
-      { loader, ...(options !== undefined ? { options } : {}) }
-    ],
+    use: [{ loader, ...(options !== undefined ? { options } : {}) }],
   });
 }
 
@@ -356,10 +340,10 @@ function injectWywLoader(
       loader,
       options: loaderOptions,
     };
-    const wywLoaderUse = createWywLoaderUseFunction(loader, wywLoaderItem);
+    const wywLoaderUse = createWywLoaderUseFunction(use, wywLoaderItem);
 
     // Loader order is right-to-left. We want WyW to run first, so it should be last.
-    Object.assign(rule, { use: (data) => [...use, wywLoaderUse(data)].flat() });
+    Object.assign(rule, { use: wywLoaderUse });
   });
 
   ensureWywCssModuleRules(config, extension);


### PR DESCRIPTION
`@wyw-in-js/nextjs@2.4.0` breaks `next build` with `next-rspack`:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
```

## Root cause

The `node_modules` guard introduced in 2.4.0 was represented as a function inside the rule's `use` array. Webpack accepts function items in that array, but Rspack expects every array item to be a loader string or object and dereferences its `loader` property.

## Fix

Keep the conditional logic on the rule-level `use` function instead. It returns the original Next.js loader chain for dependencies and appends the WyW loader for application files. The resolved array therefore contains only static loader items in both cases, which preserves webpack behavior and matches Rspack's supported configuration shape.

## Validation

- Added regression coverage for the rule-level function, loader order, static resolved items, and the `node_modules` exclusion on POSIX and Windows paths.
- Verified package lint, unit tests, ESM build, and type declarations.
- Ran the full repository test suite and package build.
- Reproduced the failure with Next.js 16.3 and `next-rspack` on the published 2.4.0 package, then confirmed the same project builds and statically generates its pages with this fix.

## Minimal reproduction

https://github.com/defaultsamson/wyw-in-js-rspack-bug
