### PR TITLE
fix(transform): stop reporting an evicted-but-unchanged dependency as changed forever

### DIFF
--- a/.changeset/retain-evicted-dependency-graphs.md
+++ b/.changeset/retain-evicted-dependency-graphs.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Stop repeatedly invalidating cached transforms after an unchanged dependency entrypoint is evicted. Retain a lightweight dependency graph snapshot so transitive file changes are still detected without keeping the full entrypoint alive.

--- a/packages/transform/src/__tests__/cache.evicted-dependency-loop.test.ts
+++ b/packages/transform/src/__tests__/cache.evicted-dependency-loop.test.ts
@@ -8,6 +8,7 @@ type MockEntrypoint = {
   dependencies: Map<string, Pick<IEntrypointDependency, 'resolved'>>;
   generation: number;
   initialCode?: string;
+  isProcessing?: boolean;
   invalidateOnDependencyChange?: Set<string>;
   invalidationDependencies?: Map<
     string,
@@ -151,5 +152,196 @@ describe('TransformCacheCollection: evicted-but-unchanged dependency', () => {
     // entrypoint was never re-created -- this is pure cache churn, not a
     // real change on disk.
     expect(cache.has('entrypoints', depName)).toBe(false);
+  });
+
+  it('keeps checking transitive dependencies after an intermediate entrypoint is evicted', () => {
+    const leafName = 'leaf.js';
+    const leafContent = 'export const token = "red";';
+    const nextLeafContent = 'export const token = "blue";';
+    const intermediateName = 'intermediate.js';
+    const intermediateContent =
+      'import { token } from "./leaf.js"; export { token };';
+    const parentName = 'parent.js';
+    const parentContent =
+      'import { token } from "./intermediate.js"; console.log(token);';
+
+    const leaf = setupCacheWithEntrypoint(leafName, leafContent).entrypoint;
+    const intermediateDependencies = new Map<
+      string,
+      Pick<IEntrypointDependency, 'resolved'>
+    >([['./leaf.js', { resolved: leafName }]]);
+    const intermediate = setupCacheWithEntrypoint(
+      intermediateName,
+      intermediateContent,
+      intermediateDependencies
+    ).entrypoint;
+    const parentDependencies = new Map<
+      string,
+      Pick<IEntrypointDependency, 'resolved'>
+    >([['./intermediate.js', { resolved: intermediateName }]]);
+    const { cache } = setupCacheWithEntrypoint(
+      parentName,
+      parentContent,
+      parentDependencies
+    );
+
+    cache.add('entrypoints', intermediateName, intermediate);
+    cache.add('entrypoints', leafName, leaf);
+
+    let leafMtime = 200;
+    let leafDiskContent = leafContent;
+    mockedStatSync.mockImplementation((path) => {
+      if (path === intermediateName) return { mtimeMs: 100 } as fs.Stats;
+      if (path === leafName) return { mtimeMs: leafMtime } as fs.Stats;
+      throw new Error(`Unexpected statSync call: ${String(path)}`);
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      if (path === intermediateName) return intermediateContent;
+      if (path === leafName) return leafDiskContent;
+      throw new Error(`Unexpected readFileSync call: ${String(path)}`);
+    });
+
+    cache.invalidateIfChanged(
+      intermediateName,
+      intermediateContent,
+      undefined,
+      'fs'
+    );
+    cache.invalidateIfChanged(leafName, leafContent, undefined, 'fs');
+    cache.delete('entrypoints', intermediateName);
+
+    leafMtime = 201;
+    leafDiskContent = nextLeafContent;
+    mockedReadFileSync.mockClear();
+
+    expect(cache.invalidateIfChanged(parentName, parentContent)).toBe(true);
+    expect(mockedReadFileSync).toHaveBeenCalledWith(intermediateName, 'utf8');
+    expect(mockedReadFileSync).toHaveBeenCalledWith(leafName, 'utf8');
+  });
+
+  it('keeps treating a missing entrypoint as unknown when only its content hash is cached', () => {
+    const depName = 'dep.js';
+    const depContent = 'export const token = "red";';
+    const parentName = 'parent.js';
+    const parentContent =
+      'import { token } from "./dep.js"; console.log(token);';
+    const parentDependencies = new Map<
+      string,
+      Pick<IEntrypointDependency, 'resolved'>
+    >([['./dep.js', { resolved: depName }]]);
+    const { cache } = setupCacheWithEntrypoint(
+      parentName,
+      parentContent,
+      parentDependencies
+    );
+
+    mockedStatSync.mockImplementation((path) => {
+      if (path === depName) return { mtimeMs: 123 } as fs.Stats;
+      throw new Error(`Unexpected statSync call: ${String(path)}`);
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      if (path === depName) return depContent;
+      throw new Error(`Unexpected readFileSync call: ${String(path)}`);
+    });
+
+    cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+
+    expect(cache.has('entrypoints', depName)).toBe(false);
+    expect(cache.invalidateIfChanged(parentName, parentContent)).toBe(true);
+  });
+
+  it('does not retain an incomplete graph when a processing entrypoint is evicted', () => {
+    const depName = 'dep.js';
+    const depContent = 'export const token = "red";';
+    const parentName = 'parent.js';
+    const parentContent =
+      'import { token } from "./dep.js"; console.log(token);';
+    const dep = setupCacheWithEntrypoint(depName, depContent).entrypoint;
+    dep.isProcessing = true;
+    const parentDependencies = new Map<
+      string,
+      Pick<IEntrypointDependency, 'resolved'>
+    >([['./dep.js', { resolved: depName }]]);
+    const { cache } = setupCacheWithEntrypoint(
+      parentName,
+      parentContent,
+      parentDependencies
+    );
+
+    cache.add('entrypoints', depName, dep);
+    mockedStatSync.mockImplementation((path) => {
+      if (path === depName) return { mtimeMs: 123 } as fs.Stats;
+      throw new Error(`Unexpected statSync call: ${String(path)}`);
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      if (path === depName) return depContent;
+      throw new Error(`Unexpected readFileSync call: ${String(path)}`);
+    });
+
+    cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+    cache.delete('entrypoints', depName);
+
+    expect(cache.invalidateIfChanged(parentName, parentContent)).toBe(true);
+  });
+
+  it('forgets an evicted dependency graph when that file content changes', () => {
+    const leafName = 'leaf.js';
+    const leafContent = 'export const token = "red";';
+    const depName = 'dep.js';
+    const depContent = 'import { token } from "./leaf.js"; export { token };';
+    const nextDepContent = 'export const token = "blue";';
+    const parentName = 'parent.js';
+    const parentContent =
+      'import { token } from "./dep.js"; console.log(token);';
+    const depDependencies = new Map<
+      string,
+      Pick<IEntrypointDependency, 'resolved'>
+    >([['./leaf.js', { resolved: leafName }]]);
+    const dep = setupCacheWithEntrypoint(
+      depName,
+      depContent,
+      depDependencies
+    ).entrypoint;
+    const leaf = setupCacheWithEntrypoint(leafName, leafContent).entrypoint;
+    const parentDependencies = new Map<
+      string,
+      Pick<IEntrypointDependency, 'resolved'>
+    >([['./dep.js', { resolved: depName }]]);
+    const { cache } = setupCacheWithEntrypoint(
+      parentName,
+      parentContent,
+      parentDependencies
+    );
+
+    cache.add('entrypoints', depName, dep);
+    cache.add('entrypoints', leafName, leaf);
+
+    let depContentOnDisk = depContent;
+    let depMtime = 100;
+    mockedStatSync.mockImplementation((path) => {
+      if (path === depName) return { mtimeMs: depMtime } as fs.Stats;
+      if (path === leafName) return { mtimeMs: 200 } as fs.Stats;
+      throw new Error(`Unexpected statSync call: ${String(path)}`);
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      if (path === depName) return depContentOnDisk;
+      if (path === leafName) return leafContent;
+      throw new Error(`Unexpected readFileSync call: ${String(path)}`);
+    });
+
+    cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+    cache.invalidateIfChanged(leafName, leafContent, undefined, 'fs');
+    cache.delete('entrypoints', depName);
+
+    depContentOnDisk = nextDepContent;
+    depMtime = 101;
+    expect(
+      cache.invalidateIfChanged(depName, nextDepContent, undefined, 'fs')
+    ).toBe(true);
+
+    // The old graph described depContent, not nextDepContent. Until the
+    // dependency is processed again, its graph is unknown and the parent
+    // must stay conservative.
+    expect(cache.invalidateIfChanged(parentName, parentContent)).toBe(true);
   });
 });

--- a/packages/transform/src/__tests__/cache.evicted-dependency-loop.test.ts
+++ b/packages/transform/src/__tests__/cache.evicted-dependency-loop.test.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+
+import { TransformCacheCollection } from '../cache';
+import type { IEntrypointDependency } from '../transform/Entrypoint.types';
+
+// Mocking the minimal interface needed by the cache
+type MockEntrypoint = {
+  dependencies: Map<string, Pick<IEntrypointDependency, 'resolved'>>;
+  generation: number;
+  initialCode?: string;
+  invalidateOnDependencyChange?: Set<string>;
+  invalidationDependencies?: Map<
+    string,
+    Pick<IEntrypointDependency, 'resolved'>
+  >;
+  name: string;
+};
+
+const mockedReadFileSync = jest.spyOn(fs, 'readFileSync');
+const mockedStatSync = jest.spyOn(fs, 'statSync');
+
+const setupCacheWithEntrypoint = (
+  filename: string,
+  content: string,
+  dependencies: MockEntrypoint['dependencies'] = new Map(),
+  invalidationDependencies: MockEntrypoint['invalidationDependencies'] = new Map()
+): {
+  cache: TransformCacheCollection<MockEntrypoint>;
+  entrypoint: MockEntrypoint;
+} => {
+  const cache = new TransformCacheCollection<MockEntrypoint>();
+  const entrypoint: MockEntrypoint = {
+    name: filename,
+    initialCode: content,
+    dependencies,
+    invalidationDependencies,
+    generation: 1,
+  };
+
+  cache.add('entrypoints', filename, entrypoint);
+
+  return { cache, entrypoint };
+};
+
+describe('TransformCacheCollection: evicted-but-unchanged dependency', () => {
+  afterAll(() => {
+    mockedReadFileSync.mockRestore();
+    mockedStatSync.mockRestore();
+  });
+
+  beforeEach(() => {
+    mockedReadFileSync.mockReset();
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error('Unexpected readFileSync call.');
+    });
+    mockedStatSync.mockReset();
+    mockedStatSync.mockImplementation(() => {
+      throw new Error('Unexpected statSync call.');
+    });
+  });
+
+  // This is the non-forced twin of the existing test
+  // "does not invalidate an output-affecting dependency when only its
+  // entrypoint was evicted" (cache.test.ts). That test covers a dependency
+  // registered in `invalidateOnDependencyChange`, which goes through the
+  // `forceContentCheck` escape hatch added in #319. Before the fix, an
+  // *ordinary* dependency (the common case — most imports are not in that
+  // set) took the non-forced branch in `didDependencyChange`, which had no
+  // escape hatch: once its entrypoint was evicted (e.g. by `workflow.ts`'s
+  // `cache.delete('entrypoints', ...)` for a plain bundler-root pass, or by
+  // Vite's `handleHotUpdate` -> `invalidateForFile` on every dependency of an
+  // affected module), it was reported "changed" on every subsequent check —
+  // forever, even though the file on disk never changed. This test pins the
+  // fix: an ordinary dependency now gets the same content-hash-backed escape
+  // hatch, regardless of `forceContentCheck`.
+  it('does not report an ordinary dependency as changed once its entrypoint is evicted, as long as its content is unchanged', () => {
+    const depName = 'dep.js';
+    const depContent = 'export const token = "red";';
+    const parentName = 'parent.js';
+    const parentContent =
+      'import { token } from "./dep.js"; console.log(token);';
+
+    const { entrypoint: depEntrypoint } = setupCacheWithEntrypoint(
+      depName,
+      depContent
+    );
+
+    const parentDeps = new Map<string, Pick<IEntrypointDependency, 'resolved'>>(
+      [['./dep.js', { resolved: depName }]]
+    );
+    const { cache } = setupCacheWithEntrypoint(
+      parentName,
+      parentContent,
+      parentDeps
+    );
+    // Deliberately no `invalidateOnDependencyChange` entry for depName: this
+    // is the ordinary, non-output-affecting dependency case.
+
+    cache.add('entrypoints', depName, depEntrypoint as any);
+
+    mockedStatSync.mockImplementation((path) => {
+      if (path === depName) {
+        return { mtimeMs: 123 } as fs.Stats;
+      }
+
+      throw new Error(`Unexpected statSync call: ${String(path)}`);
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      if (path === depName) {
+        return depContent;
+      }
+
+      throw new Error(`Unexpected readFileSync call: ${String(path)}`);
+    });
+
+    // Record the dependency's `fs` content hash + mtime (what happens the
+    // first time it's seen), then evict just its entrypoint -- the state
+    // `workflow.ts`'s root-bundler-pass eviction and Vite's HMR
+    // `invalidateForFile` both produce.
+    expect(cache.checkFreshness(depName, depName)).toBe(false);
+    cache.delete('entrypoints', depName);
+    mockedReadFileSync.mockClear();
+
+    // First check after eviction converges immediately: the dependency's
+    // content hash is stable, so its missing entrypoint is treated as cache
+    // churn rather than a real change.
+    const firstCheck = cache.invalidateIfChanged(parentName, parentContent);
+    expect(firstCheck).toBe(false);
+
+    // Before the fix, `Entrypoint.innerCreate`'s pattern of re-adding the
+    // parent (inheriting the *same* `dependencies` Map) immediately after
+    // every invalidation re-armed the check against the same still-evicted
+    // dependency, forever. Reproduce that re-arming pattern directly and
+    // confirm it now stays converged across repeated checks, with the
+    // dependency file never actually touched.
+    for (let i = 0; i < 5; i += 1) {
+      cache.add('entrypoints', parentName, {
+        name: parentName,
+        initialCode: parentContent,
+        dependencies: parentDeps,
+        invalidationDependencies: new Map(),
+        generation: i + 2,
+      });
+
+      // eslint-disable-next-line no-await-in-loop
+      const invalidated = cache.invalidateIfChanged(parentName, parentContent);
+      expect(invalidated).toBe(false);
+    }
+
+    // The dependency's own recorded content hash never changed, and its
+    // entrypoint was never re-created -- this is pure cache churn, not a
+    // real change on disk.
+    expect(cache.has('entrypoints', depName)).toBe(false);
+  });
+});

--- a/packages/transform/src/__tests__/workflow.evicted-dependency-restart.test.ts
+++ b/packages/transform/src/__tests__/workflow.evicted-dependency-restart.test.ts
@@ -70,18 +70,12 @@ const createServices = (
   };
 };
 
-// This is the "prove the loop end-to-end" half of the reproduction for
-// pr-description-3-restart-cap.md. cache.evicted-dependency-loop.test.ts
-// proves the fixed point exists in `TransformCacheCollection` in isolation;
-// this test drives the real production entrypoint-creation path
-// (`Entrypoint.createRoot` / `Entrypoint.innerCreate`) to show it reaches
-// that same fixed point reaches the production entrypoint-creation code path,
-// and pins the fix: once `didDependencyChange` gets the same content-hash
-// escape hatch for ordinary dependencies, repeated requests for the parent
-// converge and stop regenerating it.
+// The cache-level tests prove the fixed point in
+// `TransformCacheCollection`; this test drives the production
+// `Entrypoint.createRoot` / `Entrypoint.innerCreate` path and verifies that
+// repeated requests for the parent converge instead of regenerating it.
 //
-// `cache.invalidateForFile()` below is exactly what two call sites on `main`
-// do to a dependency that hasn't changed:
+// The eviction below models the states produced by two call sites:
 //   - packages/transform/src/transform/generators/workflow.ts:71/:115
 //     (`cache.delete('entrypoints', ...)`, a root bundler pass over a plain
 //     dependency)
@@ -179,17 +173,3 @@ describe('evicted-but-unchanged dependency no longer defeats entrypoint caching'
     }
   });
 });
-
-// Note: an additional attempt to reproduce this same defect through the
-// public `transform()` entrypoint (as a bundler plugin would call it,
-// combined with a genuine `cache.invalidateForFile` HMR-style eviction) was
-// made and abandoned -- not because the defect doesn't reach that far, but
-// because `dangerousCodeRemover` shakes out any dependency that isn't
-// actually required to compute the css tag's evaluated value in this
-// minimal fixture, and the fixture's `TaggedTemplateProcessor` throws on
-// interpolated values, making it impractical to keep the dependency alive
-// without a heavier evaluation-capable processor fixture. The test above,
-// which drives the identical `Entrypoint.createRoot` / `innerCreate`
-// production code path directly, is the reproduction for this defect; see
-// pr-description-3-restart-cap.md and cache.evicted-dependency-loop.test.ts
-// for the full chain of evidence.

--- a/packages/transform/src/__tests__/workflow.evicted-dependency-restart.test.ts
+++ b/packages/transform/src/__tests__/workflow.evicted-dependency-restart.test.ts
@@ -1,0 +1,195 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import * as babel from '@babel/core';
+import dedent from 'dedent';
+
+import { logger } from '@wyw-in-js/shared';
+import type { StrictOptions } from '@wyw-in-js/shared';
+
+import { TransformCacheCollection } from '../cache';
+import { Entrypoint } from '../transform/Entrypoint';
+import type { LoadAndParseFn } from '../transform/Entrypoint.types';
+import type { Services } from '../transform/types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const pluginOptions: StrictOptions = {
+  babelOptions: {
+    babelrc: false,
+    configFile: false,
+    presets: [
+      ['@babel/preset-env', { loose: true }],
+      '@babel/preset-typescript',
+    ],
+  },
+  displayName: false,
+  extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
+  features: {
+    dangerousCodeRemover: true,
+    globalCache: true,
+    happyDOM: true,
+    softErrors: false,
+    useBabelConfigs: true,
+    useWeakRefInEval: true,
+  },
+  highPriorityPlugins: [],
+  rules: [],
+};
+
+const createServices = (
+  cache: TransformCacheCollection,
+  filename: string
+): Services => {
+  const loadAndParseFn: LoadAndParseFn = (services, name, loadedCode) => ({
+    get ast() {
+      return services.babel.parseSync(loadedCode ?? '', {
+        filename: name,
+        presets: [
+          ['@babel/preset-env', { loose: true }],
+          '@babel/preset-typescript',
+        ],
+      })!;
+    },
+    code: loadedCode!,
+    evaluator: jest.fn(),
+    evalConfig: {},
+  });
+
+  return {
+    babel,
+    cache,
+    emitWarning: jest.fn(),
+    loadAndParseFn,
+    log: logger,
+    eventEmitter: EventEmitter.dummy,
+    options: {
+      filename,
+      pluginOptions,
+    },
+  };
+};
+
+// This is the "prove the loop end-to-end" half of the reproduction for
+// pr-description-3-restart-cap.md. cache.evicted-dependency-loop.test.ts
+// proves the fixed point exists in `TransformCacheCollection` in isolation;
+// this test drives the real production entrypoint-creation path
+// (`Entrypoint.createRoot` / `Entrypoint.innerCreate`) to show it reaches
+// that same fixed point reaches the production entrypoint-creation code path,
+// and pins the fix: once `didDependencyChange` gets the same content-hash
+// escape hatch for ordinary dependencies, repeated requests for the parent
+// converge and stop regenerating it.
+//
+// `cache.invalidateForFile()` below is exactly what two call sites on `main`
+// do to a dependency that hasn't changed:
+//   - packages/transform/src/transform/generators/workflow.ts:71/:115
+//     (`cache.delete('entrypoints', ...)`, a root bundler pass over a plain
+//     dependency)
+//   - packages/vite/src/index.ts:977 (`handleHotUpdate` invalidates every
+//     dependency of every affected module, changed or not)
+describe('evicted-but-unchanged dependency no longer defeats entrypoint caching', () => {
+  it('reuses the parent entrypoint across repeated requests, even after its dependency is evicted, as long as the dependency is unchanged', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-evicted-dep-'));
+    const parentFile = path.join(root, 'parent.ts');
+    const depFile = path.join(root, 'dep.ts');
+
+    try {
+      fs.writeFileSync(depFile, dedent`export const val = 'stable';`);
+      fs.writeFileSync(
+        parentFile,
+        dedent`
+          import { val } from './dep';
+          export const result = val;
+        `
+      );
+
+      const cache = new TransformCacheCollection();
+
+      const depServices = createServices(cache, depFile);
+      const depCode = fs.readFileSync(depFile, 'utf-8');
+      Entrypoint.createRoot(depServices, depFile, ['val'], depCode);
+
+      // Record the dependency's `fs` content hash + mtime, exactly as
+      // `processImports.ts`'s cached-dependency reuse check
+      // (`cache.checkFreshness`) does for every dependency on every pass.
+      // This is what makes the later eviction land in the mtime-gated branch
+      // of `didDependencyChange` (`cache.ts:426-505`) that contains the bug.
+      cache.checkFreshness(depFile, depFile);
+
+      const parentServices = createServices(cache, parentFile);
+      const parentCode = fs.readFileSync(parentFile, 'utf-8');
+      const firstEntrypoint = Entrypoint.createRoot(
+        parentServices,
+        parentFile,
+        ['result'],
+        parentCode
+      );
+      firstEntrypoint.addDependency({
+        only: ['val'],
+        resolved: depFile,
+        source: './dep',
+      });
+
+      // Simulate the eviction both real call sites perform: drop the
+      // dependency's *entrypoint* only. Its recorded content hash and mtime
+      // (set by `Entrypoint.createRoot` above) are untouched, and the file
+      // on disk is never written to again in this test.
+      cache.invalidateForFile(depFile);
+
+      const readFileSpy = jest.spyOn(fs, 'readFileSync');
+      const depReadCountBefore = () =>
+        readFileSpy.mock.calls.filter(([p]) => p === depFile).length;
+
+      const generations: number[] = [firstEntrypoint.generation];
+
+      // Repeatedly re-request the parent, exactly as a watch-mode rebuild or
+      // a superseding create-during-processing retry would. Before the fix,
+      // this never converged: each call saw `changed === true` from the
+      // permanently-"changed" dependency and manufactured a brand new
+      // superseding entrypoint, forever, though nothing changed on disk.
+      for (let i = 0; i < 10; i += 1) {
+        const next = Entrypoint.createRoot(
+          parentServices,
+          parentFile,
+          ['result'],
+          parentCode
+        );
+        generations.push(next.generation);
+      }
+
+      // Converges: the dependency's absence is recognized as stale cache
+      // state rather than a real change, so the same entrypoint (and
+      // generation) is reused across every one of these ten re-requests.
+      for (let i = 1; i < generations.length; i += 1) {
+        expect(generations[i]).toBe(generations[0]);
+      }
+
+      // The fix trades an unbounded number of full parent re-synthesis passes
+      // for, at most, one cheap content-hash read of the dependency per check
+      // (`didFileContentHashChange`) -- and the dependency's content on disk
+      // never actually changed across any of them.
+      expect(depReadCountBefore()).toBeLessThanOrEqual(generations.length);
+      expect(fs.readFileSync(depFile, 'utf-8')).toBe(
+        dedent`export const val = 'stable';`
+      );
+
+      readFileSpy.mockRestore();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// Note: an additional attempt to reproduce this same defect through the
+// public `transform()` entrypoint (as a bundler plugin would call it,
+// combined with a genuine `cache.invalidateForFile` HMR-style eviction) was
+// made and abandoned -- not because the defect doesn't reach that far, but
+// because `dangerousCodeRemover` shakes out any dependency that isn't
+// actually required to compute the css tag's evaluated value in this
+// minimal fixture, and the fixture's `TaggedTemplateProcessor` throws on
+// interpolated values, making it impractical to keep the dependency alive
+// without a heavier evaluation-capable processor fixture. The test above,
+// which drives the identical `Entrypoint.createRoot` / `innerCreate`
+// production code path directly, is the reproduction for this defect; see
+// pr-description-3-restart-cap.md and cache.evicted-dependency-loop.test.ts
+// for the full chain of evidence.

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -457,21 +457,39 @@ export class TransformCacheCollection<
           return true;
         }
 
-        // A cached file without a cached entrypoint was invalidated earlier.
-        // If the caller forced a content check and the content hash is stable,
-        // the missing entrypoint is only cache churn and must not invalidate
-        // output-dependent parents.
+        // A cached file without a cached entrypoint was invalidated earlier --
+        // e.g. by `workflow()` evicting a plain bundler-root dependency
+        // (`cache.delete('entrypoints', ...)`), or by a bundler's HMR handler
+        // invalidating every dependency of an affected module regardless of
+        // whether that particular one changed (`cache.invalidateForFile`).
+        // If its recorded `fs` content hash is still stable, the missing
+        // entrypoint is only cache churn, not a real change, and must not
+        // invalidate output-dependent parents -- regardless of whether the
+        // caller happens to force a content check for this dependency.
+        // `forceContentCheck` is only set for `invalidateOnDependencyChange`
+        // entries; an ordinary dependency must get the same protection, or it
+        // is reported "changed" on every check, forever, once its entrypoint
+        // is evicted.
         if (!cachedEntrypoint && nestedDependencies.size === 0) {
-          if (
-            forceContentCheck &&
-            this.contentHashes.get(dependencyFilename)?.fs !== undefined
-          ) {
-            dependencyChangeMemo.set(dependencyFilename, false);
-            return false;
+          if (this.contentHashes.get(dependencyFilename)?.fs === undefined) {
+            // No recorded content hash to compare against: genuinely unknown.
+            dependencyChangeMemo.set(dependencyFilename, true);
+            return true;
           }
 
-          dependencyChangeMemo.set(dependencyFilename, true);
-          return true;
+          // If `forceContentCheck` is true, the `didFileContentHashChange`
+          // call above already established the content is unchanged (a
+          // change would have returned `true` before reaching here).
+          const changed =
+            !forceContentCheck &&
+            this.didFileContentHashChange(
+              dependencyFilename,
+              strippedDependencyFilename,
+              changedFiles
+            );
+
+          dependencyChangeMemo.set(dependencyFilename, changed);
+          return changed;
         }
 
         if (nestedDependencies.size === 0) {

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -24,9 +24,15 @@ function isMissingFileError(error: unknown): boolean {
 interface IBaseCachedEntrypoint {
   dependencies: Map<string, { resolved: string | null }>;
   initialCode?: string;
+  isProcessing?: boolean;
   invalidateOnDependencyChange?: Set<string>;
   invalidationDependencies?: Map<string, { resolved: string | null }>;
 }
+
+type EntrypointDependencySnapshot = Pick<
+  IBaseCachedEntrypoint,
+  'dependencies' | 'invalidationDependencies'
+>;
 
 interface ICaches<TEntrypoint extends IBaseCachedEntrypoint> {
   barrelManifests: Map<string, BarrelManifestCacheEntry>;
@@ -66,6 +72,11 @@ export class TransformCacheCollection<
 
   private readonly exportDependencies = new Map<string, Set<string>>();
 
+  private readonly entrypointDependencySnapshots = new Map<
+    string,
+    EntrypointDependencySnapshot
+  >();
+
   private keySalt: string | null = null;
 
   private invalidatedFiles = new Map<string, number>();
@@ -97,6 +108,7 @@ export class TransformCacheCollection<
       migrate(this.entrypoints);
       migrate(this.exports);
       migrate(this.barrelManifestDependencies);
+      migrate(this.entrypointDependencySnapshots);
       migrate(this.exportDependencies);
       return;
     }
@@ -104,6 +116,7 @@ export class TransformCacheCollection<
     this.barrelManifests.clear();
     this.entrypoints.clear();
     this.exports.clear();
+    this.entrypointDependencySnapshots.clear();
     this.clearCacheDependencies('all');
   }
 
@@ -137,12 +150,22 @@ export class TransformCacheCollection<
     if (value === undefined) {
       cache.delete(cacheKey);
       this.contentHashes.delete(key);
+      if (cacheName === 'entrypoints') {
+        this.entrypointDependencySnapshots.delete(cacheKey);
+      }
       this.clearCacheDependencies(cacheName, key);
       return;
     }
 
     this.clearCacheDependencies(cacheName, key);
     cache.set(cacheKey, value);
+
+    if (cacheName === 'entrypoints') {
+      // A live entrypoint is authoritative. If it is evicted later, its
+      // dependency graph will be snapshotted at that point, after processing
+      // has had a chance to populate the mutable dependency maps.
+      this.entrypointDependencySnapshots.delete(cacheKey);
+    }
 
     if ('initialCode' in value) {
       const maybeOriginalCode = (value as unknown as { originalCode?: unknown })
@@ -195,6 +218,9 @@ export class TransformCacheCollection<
     const cache = this[cacheName] as Map<string, unknown>;
 
     cache.clear();
+    if (cacheName === 'entrypoints') {
+      this.entrypointDependencySnapshots.clear();
+    }
     this.clearCacheDependencies(cacheName);
   }
 
@@ -230,6 +256,13 @@ export class TransformCacheCollection<
     }
 
     loggers[cacheName]('invalidate', key);
+
+    if (cacheName === 'entrypoints') {
+      this.snapshotEntrypointDependencies(
+        key,
+        cache.get(cacheKey) as TEntrypoint
+      );
+    }
 
     cache.delete(cacheKey);
     this.clearCacheDependencies(cacheName, key);
@@ -334,31 +367,32 @@ export class TransformCacheCollection<
     if (previousHash === undefined) {
       const otherSource = source === 'fs' ? 'loaded' : 'fs';
       const otherHash = existing?.[otherSource];
+      const contentChanged = otherHash !== undefined && otherHash !== newHash;
 
-      if ((otherHash !== undefined && otherHash !== newHash) || anyDepChanged) {
+      if (contentChanged || anyDepChanged) {
         cacheLogger('content has changed, invalidate all for %s', filename);
         this.setContentHash(filename, source, newHash);
         this.invalidateForFile(filename);
+        if (contentChanged) {
+          this.forgetEntrypointDependencySnapshot(filename);
+        }
         changedFiles.add(filename);
 
         return true;
       }
 
       this.setContentHash(filename, source, newHash);
-
-      if (anyDepChanged) {
-        this.invalidateForFile(filename);
-        changedFiles.add(filename);
-        return true;
-      }
-
       return false;
     }
 
-    if (previousHash !== newHash || anyDepChanged) {
+    const contentChanged = previousHash !== newHash;
+    if (contentChanged || anyDepChanged) {
       cacheLogger('content has changed, invalidate all for %s', filename);
       this.setContentHash(filename, source, newHash);
       this.invalidateForFile(filename);
+      if (contentChanged) {
+        this.forgetEntrypointDependencySnapshot(filename);
+      }
       changedFiles.add(filename);
 
       return true;
@@ -372,13 +406,18 @@ export class TransformCacheCollection<
     fileEntrypoint?: TEntrypoint
   ): Map<string, { resolved: string | null }> {
     const dependenciesToCheck = new Map<string, { resolved: string | null }>();
+    const dependencySource =
+      fileEntrypoint ??
+      this.entrypointDependencySnapshots.get(this.getKey(filename));
 
-    for (const [key, dependency] of fileEntrypoint?.dependencies ?? []) {
+    for (const [key, dependency] of dependencySource?.dependencies ?? []) {
       dependenciesToCheck.set(key, dependency);
     }
 
-    for (const [key, dependency] of fileEntrypoint?.invalidationDependencies ??
-      []) {
+    for (const [
+      key,
+      dependency,
+    ] of dependencySource?.invalidationDependencies ?? []) {
       if (!dependenciesToCheck.has(key)) {
         dependenciesToCheck.set(key, dependency);
       }
@@ -434,6 +473,7 @@ export class TransformCacheCollection<
         }
 
         this.invalidateForFile(dependencyFilename);
+        this.forgetEntrypointDependencySnapshot(dependencyFilename);
         changedFiles.add(dependencyFilename);
         dependencyChangeMemo.set(dependencyFilename, true);
         return true;
@@ -457,39 +497,36 @@ export class TransformCacheCollection<
           return true;
         }
 
-        // A cached file without a cached entrypoint was invalidated earlier --
-        // e.g. by `workflow()` evicting a plain bundler-root dependency
-        // (`cache.delete('entrypoints', ...)`), or by a bundler's HMR handler
-        // invalidating every dependency of an affected module regardless of
-        // whether that particular one changed (`cache.invalidateForFile`).
-        // If its recorded `fs` content hash is still stable, the missing
-        // entrypoint is only cache churn, not a real change, and must not
-        // invalidate output-dependent parents -- regardless of whether the
-        // caller happens to force a content check for this dependency.
-        // `forceContentCheck` is only set for `invalidateOnDependencyChange`
-        // entries; an ordinary dependency must get the same protection, or it
-        // is reported "changed" on every check, forever, once its entrypoint
-        // is evicted.
-        if (!cachedEntrypoint && nestedDependencies.size === 0) {
-          if (this.contentHashes.get(dependencyFilename)?.fs === undefined) {
-            // No recorded content hash to compare against: genuinely unknown.
+        if (!cachedEntrypoint) {
+          const hasKnownDependencyGraph =
+            this.entrypointDependencySnapshots.has(
+              this.getKey(dependencyFilename)
+            ) || this.hasCachedDependencies(dependencyFilename);
+          if (
+            !hasKnownDependencyGraph ||
+            this.contentHashes.get(dependencyFilename)?.fs === undefined
+          ) {
+            // A content hash only proves that this file is unchanged. Without
+            // a retained graph, an evicted entrypoint may still hide a changed
+            // transitive dependency, so the state remains unknown.
             dependencyChangeMemo.set(dependencyFilename, true);
             return true;
           }
 
-          // If `forceContentCheck` is true, the `didFileContentHashChange`
-          // call above already established the content is unchanged (a
-          // change would have returned `true` before reaching here).
-          const changed =
+          // A missing entrypoint can be cache churn. Verify its own source,
+          // then continue through the lightweight dependency snapshot taken
+          // when the entrypoint was evicted.
+          if (
             !forceContentCheck &&
             this.didFileContentHashChange(
               dependencyFilename,
               strippedDependencyFilename,
               changedFiles
-            );
-
-          dependencyChangeMemo.set(dependencyFilename, changed);
-          return changed;
+            )
+          ) {
+            dependencyChangeMemo.set(dependencyFilename, true);
+            return true;
+          }
         }
 
         if (nestedDependencies.size === 0) {
@@ -533,6 +570,7 @@ export class TransformCacheCollection<
       }
 
       this.invalidateForFile(dependencyFilename);
+      this.forgetEntrypointDependencySnapshot(dependencyFilename);
       changedFiles.add(dependencyFilename);
       dependencyChangeMemo.set(dependencyFilename, true);
       return true;
@@ -571,6 +609,7 @@ export class TransformCacheCollection<
       }
 
       this.invalidateForFile(filename);
+      this.forgetEntrypointDependencySnapshot(filename);
       changedFiles.add(filename);
       return true;
     }
@@ -582,6 +621,7 @@ export class TransformCacheCollection<
 
     this.setContentHash(filename, 'fs', nextHash);
     this.invalidateForFile(filename);
+    this.forgetEntrypointDependencySnapshot(filename);
     changedFiles.add(filename);
     return true;
   }
@@ -632,6 +672,7 @@ export class TransformCacheCollection<
       }
 
       this.invalidateForFile(filename);
+      this.forgetEntrypointDependencySnapshot(filename);
       return true;
     }
   }
@@ -678,6 +719,35 @@ export class TransformCacheCollection<
 
   private hasCachedDependencies(filename: string): boolean {
     return this.getCachedDependencies(filename).size > 0;
+  }
+
+  private snapshotEntrypointDependencies(
+    filename: string,
+    entrypoint: TEntrypoint
+  ): void {
+    if (entrypoint.isProcessing) {
+      this.forgetEntrypointDependencySnapshot(filename);
+      return;
+    }
+
+    const copy = (
+      dependencies: Map<string, { resolved: string | null }> | undefined
+    ): Map<string, { resolved: string | null }> =>
+      new Map(
+        Array.from(dependencies ?? [], ([key, dependency]) => [
+          key,
+          { resolved: dependency.resolved },
+        ])
+      );
+
+    this.entrypointDependencySnapshots.set(this.getKey(filename), {
+      dependencies: copy(entrypoint.dependencies),
+      invalidationDependencies: copy(entrypoint.invalidationDependencies),
+    });
+  }
+
+  private forgetEntrypointDependencySnapshot(filename: string): void {
+    this.entrypointDependencySnapshots.delete(this.getKey(filename));
   }
 
   private setContentHash(


### PR DESCRIPTION
## Motivation

An evicted dependency entrypoint could make its parent look changed forever even when no file changed. In a real build this caused one entrypoint to restart 10,925 times in 63.6 seconds and eventually run out of memory.

The regression came from the mtime fast path added in #283. When a dependency's mtime was stable but its entrypoint was absent, `didDependencyChange` conservatively returned `true`. #319 added a content-hash escape hatch for output-affecting dependencies, but ordinary dependencies still remained permanently changed after eviction.

## Why a content hash alone is not enough

An entrypoint owns its ordinary dependency graph. Evicting the entrypoint therefore loses both the object and the graph that was stored on it.

A stable hash proves that the dependency's own source is unchanged, but it does not prove that a transitive dependency is unchanged. Treating `nestedDependencies.size === 0` as a known leaf is unsafe after eviction because it can also mean that the graph was discarded.

## Fix

Retain a lightweight dependency graph snapshot when a completed entrypoint is evicted:

- Store only dependency keys and resolved filenames; do not retain the entrypoint, loaded source, AST, parents, or processing state.
- Accept the existing barrel/export dependency caches as another known graph source.
- Use a stable filesystem content hash as an escape hatch only when a known graph is available.
- Continue checking retained transitive dependencies before reusing a parent.
- Keep hash-only and in-progress eviction states conservative because their graphs are unknown or incomplete.
- Forget a retained graph when the file's own content changes or disappears; the next processed entrypoint will replace it with a current graph.

This lets true leaf dependencies converge after cache churn without hiding changes behind an evicted intermediate module.

## Tests

Coverage includes:

- unchanged ordinary leaf entrypoint eviction converges instead of invalidating forever;
- repeated `Entrypoint.createRoot` requests reuse the same parent generation;
- a changed transitive leaf still invalidates through an evicted intermediate dependency;
- a cached hash without a known graph remains conservative;
- an entrypoint evicted while still processing does not publish an incomplete graph;
- changing an evicted file discards its old graph;
- existing barrel/export-star invalidation remains intact.

Validation:

```text
bun test packages/transform/src
1582 pass, 1 skip, 1 todo, 0 fail

bun run --filter @wyw-in-js/transform lint
bun run --filter @wyw-in-js/transform build:types
bun run --filter @wyw-in-js/transform build:esm
```

Includes a patch changeset for `@wyw-in-js/transform`.

## Not included

- A restart cap in `workflow()`. With the cache invariant fixed, a speculative cap would hide rather than solve the underlying state problem.
- The separate missing `hasLoop` check on one `Entrypoint.innerCreate` branch; no concrete path into that issue is established here.
