### PR TITLE
fix(transform): defer unsupported nested preval values

### DIFF
--- a/.changeset/deferred-preval-fields.md
+++ b/.changeset/deferred-preval-fields.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/processor-utils': patch
+'@wyw-in-js/transform': patch
+---
+
+Preserve serializable fields of evaluated objects when unrelated nested fields cannot cross the eval IPC boundary, and prioritize processor metadata before treating objects as CSS data. Unsupported nested fields remain strict errors when accessed, while direct unsupported values are still rejected.

--- a/packages/processor-utils/src/BaseProcessor.ts
+++ b/packages/processor-utils/src/BaseProcessor.ts
@@ -129,7 +129,7 @@ export abstract class BaseProcessor {
 
   public isValidValue(value: unknown): value is Value {
     return (
-      typeof value === 'function' || isCSSable(value) || hasEvalMeta(value)
+      typeof value === 'function' || hasEvalMeta(value) || isCSSable(value)
     );
   }
   /* eslint-enable @typescript-eslint/member-ordering */

--- a/packages/processor-utils/src/__tests__/BaseProcessor.test.ts
+++ b/packages/processor-utils/src/__tests__/BaseProcessor.test.ts
@@ -1,0 +1,23 @@
+import { BaseProcessor } from '../BaseProcessor';
+
+describe('BaseProcessor', () => {
+  it('accepts eval metadata without reading unrelated enumerable fields', () => {
+    const readRuntimeState = jest.fn(() => {
+      throw new Error('runtime state is unavailable');
+    });
+    const value = {
+      __wyw_meta: {
+        className: 'base',
+        extends: null,
+      },
+    };
+
+    Object.defineProperty(value, 'runtimeState', {
+      enumerable: true,
+      get: readRuntimeState,
+    });
+
+    expect(BaseProcessor.prototype.isValidValue(value)).toBe(true);
+    expect(readRuntimeState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -2373,12 +2373,67 @@ describe('EvalBroker', () => {
       );
 
       try {
-        await broker.evaluate(entrypoint);
-        throw new Error('Expected broker.evaluate() to reject');
-      } catch (error) {
-        expect(String(error)).toContain('[wyw-in-js] __wywPreval');
-        expect(String(error)).toContain('__wywPreval.value.nested');
-        expect(String(error)).toContain('unsupported non-plain object (Map)');
+        const result = await broker.evaluate(entrypoint);
+        const value = result.values?.get('value') as { nested: unknown };
+
+        expect(() => value.nested).toThrow('[wyw-in-js] __wywPreval');
+        expect(() => value.nested).toThrow('__wywPreval.value.nested');
+        expect(() => value.nested).toThrow(
+          'unsupported non-plain object (Map)'
+        );
+      } finally {
+        broker.dispose();
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves deferred getter errors from the eval VM context', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entry = join(root, 'entry.js');
+
+      writeFileSync(
+        entry,
+        [
+          'const value = { usable: true };',
+          "Object.defineProperty(value, 'runtimeOnly', {",
+          '  enumerable: true,',
+          '  get() {',
+          "    throw new TypeError('runtime getter failed');",
+          '  },',
+          '});',
+          'export const __wywPreval = { value: () => value };',
+        ].join('\n')
+      );
+
+      const services = createServices(root, entry);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoint = Entrypoint.createRoot(
+        services,
+        entry,
+        ['__wywPreval'],
+        readFileSync(entry, 'utf-8')
+      );
+
+      try {
+        const result = await broker.evaluate(entrypoint);
+        const value = result.values?.get('value') as {
+          runtimeOnly: unknown;
+          usable: boolean;
+        };
+
+        expect(value.usable).toBe(true);
+        try {
+          Reflect.get(value, 'runtimeOnly');
+          throw new Error('Expected runtimeOnly to throw');
+        } catch (error) {
+          expect(error).toMatchObject({
+            message: 'runtime getter failed',
+            name: 'TypeError',
+          });
+        }
       } finally {
         broker.dispose();
         rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/serialize.ipc.test.ts
+++ b/packages/transform/src/__tests__/serialize.ipc.test.ts
@@ -4,6 +4,10 @@ import {
   serializeValue,
 } from '../eval/serialize';
 
+class ComponentStyle {
+  public readonly current = 1;
+}
+
 describe('eval IPC serialization', () => {
   it('round-trips nested plain data without JSON coercion', () => {
     const boom = new TypeError('boom');
@@ -85,6 +89,128 @@ describe('eval IPC serialization', () => {
     expect(roundTripped.nested.marker).toBe(Symbol.for('react.forward_ref'));
   });
 
+  it('defers unsupported nested properties until they are read', () => {
+    const descriptor = {
+      kind: 'foreign-descriptor',
+      marker: Symbol.for('acme.handle'),
+      metadata: {
+        className: 'base',
+      },
+      runtimeState: new ComponentStyle(),
+    };
+    const serialized = serializePreval({ descriptor }).descriptor;
+    const roundTripped = deserializeValue(serialized) as {
+      kind: string;
+      marker: symbol;
+      metadata: { className: string };
+      runtimeState: ComponentStyle;
+    };
+
+    expect(roundTripped.kind).toBe('foreign-descriptor');
+    expect(roundTripped.marker).toBe(Symbol.for('acme.handle'));
+    expect(roundTripped.metadata).toEqual({ className: 'base' });
+    expect(Object.keys(roundTripped)).toEqual([
+      'kind',
+      'marker',
+      'metadata',
+      'runtimeState',
+    ]);
+    expect(() => roundTripped.runtimeState).toThrow(
+      'unsupported non-plain object (ComponentStyle)'
+    );
+    expect(() => roundTripped.runtimeState).toThrow(
+      '__wywPreval.descriptor.runtimeState'
+    );
+
+    roundTripped.runtimeState = {
+      normalized: true,
+    } as unknown as ComponentStyle;
+    expect(roundTripped.runtimeState).toEqual({ normalized: true });
+
+    expect(() =>
+      serializeValue(descriptor, {
+        allowFunctions: true,
+        allowSymbols: true,
+      })
+    ).toThrow('unsupported non-plain object (ComponentStyle)');
+  });
+
+  it('preserves the serializable surface of a foreign component descriptor', () => {
+    const descriptor = {
+      $$typeof: Symbol.for('react.forward_ref'),
+      attrs: [],
+      componentStyle: new ComponentStyle(),
+      foldedComponentIds: '',
+      render: () => null,
+      shouldForwardProp: () => true,
+      styledComponentId: 'sc-example',
+      target: 'div',
+      warnTooManyClasses: () => undefined,
+    };
+    const roundTripped = deserializeValue(
+      serializePreval({ descriptor }).descriptor
+    ) as typeof descriptor;
+
+    expect(roundTripped.$$typeof).toBe(Symbol.for('react.forward_ref'));
+    expect(roundTripped.attrs).toEqual([]);
+    expect(roundTripped.foldedComponentIds).toBe('');
+    expect(roundTripped.styledComponentId).toBe('sc-example');
+    expect(roundTripped.target).toBe('div');
+    expect(typeof roundTripped.render).toBe('function');
+    expect(typeof roundTripped.shouldForwardProp).toBe('function');
+    expect(typeof roundTripped.warnTooManyClasses).toBe('function');
+    expect(() => roundTripped.componentStyle).toThrow(
+      '__wywPreval.descriptor.componentStyle'
+    );
+    expect(() => roundTripped.componentStyle).toThrow(
+      'unsupported non-plain object (ComponentStyle)'
+    );
+  });
+
+  it('defers circular branches without losing their serializable siblings', () => {
+    const descriptor: { label: string; runtime?: unknown } = {
+      label: 'safe',
+    };
+    descriptor.runtime = descriptor;
+
+    const roundTripped = deserializeValue(
+      serializePreval({ descriptor }).descriptor
+    ) as typeof descriptor;
+
+    expect(roundTripped.label).toBe('safe');
+    expect(() => roundTripped.runtime).toThrow(
+      'contains a circular reference at __wywPreval.descriptor.runtime'
+    );
+  });
+
+  it('defers a nested getter failure but not an unexpected traversal failure', () => {
+    const getterFailure = deserializeValue(
+      serializePreval({
+        value: {
+          get unused() {
+            throw new Error('unused getter failed');
+          },
+          usable: true,
+        },
+      }).value
+    ) as { unused: unknown; usable: boolean };
+
+    expect(getterFailure.usable).toBe(true);
+    expect(() => getterFailure.unused).toThrow('unused getter failed');
+
+    const traversalFailure = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error('proxy traversal failed');
+        },
+      }
+    );
+    expect(() =>
+      serializePreval({ value: { nested: traversalFailure } })
+    ).toThrow('proxy traversal failed');
+  });
+
   it('drops symbol-keyed properties only when serializing __wywPreval values', () => {
     const marker = Symbol('runtimeMetadata');
     const input = {
@@ -126,11 +252,23 @@ describe('eval IPC serialization', () => {
     });
   });
 
+  it('defers unsupported values nested inside serializable containers', () => {
+    const roundTripped = deserializeValue(
+      serializePreval({ value: { nested: [new Date(0)], usable: true } }).value
+    ) as { nested: Date[]; usable: boolean };
+
+    expect(roundTripped.usable).toBe(true);
+    expect(() => roundTripped.nested[0]).toThrow('__wywPreval.value.nested[0]');
+    expect(() => roundTripped.nested[0]).toThrow(
+      'unsupported non-plain object (Date)'
+    );
+  });
+
   it.each([
     {
       label: 'Date',
-      value: { value: { nested: [new Date(0)] } },
-      path: '__wywPreval.value.nested[0]',
+      value: { value: new Date(0) },
+      path: '__wywPreval.value',
       detail: 'unsupported non-plain object (Date)',
     },
     {
@@ -148,12 +286,10 @@ describe('eval IPC serialization', () => {
     {
       label: 'class instance',
       value: {
-        value: new (class Box {
-          public readonly current = 1;
-        })(),
+        value: new ComponentStyle(),
       },
       path: '__wywPreval.value',
-      detail: 'unsupported non-plain object (Box)',
+      detail: 'unsupported non-plain object (ComponentStyle)',
     },
   ])(
     'reports path-aware failures for $label values',

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -4309,6 +4309,298 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it.each(['hybrid', 'execute'] as const)(
+    'wraps a styled-components-shaped imported target in %s mode',
+    async (strategy) => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+      const entryFile = join(root, 'entry.js');
+      const baseFile = join(root, 'ForeignDescriptor.js');
+      const cache = new TransformCacheCollection();
+      const perf = createPerfEventRecorder();
+
+      writeFileSync(
+        baseFile,
+        dedent`
+          class ComponentStyle {
+            constructor() {
+              this.rules = ['color: red;'];
+            }
+          }
+
+          const RuntimeTarget = () => null;
+
+          export const Base = {
+            $$typeof: Symbol.for('react.forward_ref'),
+            render: () => null,
+            attrs: [],
+            componentStyle: new ComponentStyle(),
+            shouldForwardProp: (prop) => prop !== 'hidden',
+            foldedComponentIds: 'sc-foreign-base ',
+            styledComponentId: 'sc-foreign-base',
+            target: RuntimeTarget,
+            warnTooManyClasses: () => {},
+          };
+        `
+      );
+      writeFileSync(
+        entryFile,
+        dedent`
+          import { styled } from 'test-styled-processor';
+          import { Base } from './ForeignDescriptor.js';
+
+          export const Derived = styled(Base)\`
+            font-weight: bold;
+          \`;
+        `
+      );
+
+      try {
+        const result = await runTransform(
+          root,
+          entryFile,
+          cache,
+          perf.eventEmitter,
+          { eval: { strategy } }
+        );
+
+        expect(result.cssText).toContain('font-weight:bold');
+        expect(result.dependencies).toContain('./ForeignDescriptor.js');
+        if (strategy === 'hybrid') {
+          expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+        }
+      } finally {
+        disposeEvalBroker(cache);
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it.each(['hybrid', 'execute'] as const)(
+    'preserves styled-components-shaped selector metadata beside opaque runtime fields in %s mode',
+    async (strategy) => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+      const entryFile = join(root, 'entry.js');
+      const baseFile = join(root, 'ForeignDescriptor.js');
+      const cache = new TransformCacheCollection();
+      const perf = createPerfEventRecorder();
+
+      writeFileSync(
+        baseFile,
+        dedent`
+          class ComponentStyle {
+            constructor() {
+              this.rules = ['color: red;'];
+            }
+          }
+
+          const RuntimeTarget = () => null;
+
+          export const Base = {
+            $$typeof: Symbol.for('react.forward_ref'),
+            render: () => null,
+            attrs: [],
+            componentStyle: new ComponentStyle(),
+            shouldForwardProp: (prop) => prop !== 'hidden',
+            foldedComponentIds: 'sc-foreign-base ',
+            styledComponentId: 'sc-foreign-base',
+            target: RuntimeTarget,
+            warnTooManyClasses: () => {},
+            __wyw_meta: {
+              className: 'foreign-base',
+              extends: null,
+            },
+          };
+        `
+      );
+      writeFileSync(
+        entryFile,
+        dedent`
+          import { styled } from 'test-styled-processor';
+          import { Base } from './ForeignDescriptor.js';
+
+          export const Derived = styled.div\`
+            ${'${Base}'} {
+              font-weight: bold;
+            }
+          \`;
+        `
+      );
+
+      try {
+        const result = await runTransform(
+          root,
+          entryFile,
+          cache,
+          perf.eventEmitter,
+          { eval: { strategy } }
+        );
+
+        expect(result.cssText).toContain('font-weight:bold');
+        expect(result.cssText).toContain('.foreign-base');
+        expect(result.dependencies).toContain('./ForeignDescriptor.js');
+        if (strategy === 'hybrid') {
+          expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+        }
+      } finally {
+        disposeEvalBroker(cache);
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it.each(['hybrid', 'execute'] as const)(
+    'keeps imported foreign descriptor targets in runtime styled output in %s mode',
+    async (strategy) => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+      const entryFile = join(root, 'entry.js');
+      const baseFile = join(root, 'ForeignDescriptor.js');
+      const cache = new TransformCacheCollection();
+
+      writeFileSync(
+        baseFile,
+        dedent`
+          class ComponentStyle {}
+
+          const RuntimeTarget = () => 'runtime target';
+
+          export const Base = {
+            $$typeof: Symbol.for('react.forward_ref'),
+            render: RuntimeTarget,
+            attrs: [],
+            componentStyle: new ComponentStyle(),
+            shouldForwardProp: (prop) => prop !== 'hidden',
+            foldedComponentIds: 'sc-foreign-base ',
+            styledComponentId: 'sc-foreign-base',
+            target: RuntimeTarget,
+            warnTooManyClasses: () => {},
+            __wyw_meta: {
+              className: 'foreign-base',
+              extends: null,
+            },
+          };
+        `
+      );
+      writeFileSync(
+        entryFile,
+        dedent`
+          import { styled } from 'test-runtime-styled-processor';
+          import { Base } from './ForeignDescriptor.js';
+
+          export const Wrapped = styled(Base)\`
+            color: red;
+          \`;
+        `
+      );
+
+      try {
+        const result = await runTransform(root, entryFile, cache, undefined, {
+          eval: { strategy },
+        });
+
+        expect(result.cssText).toContain('color:red');
+        expect(result.code).toMatch(
+          /import\s*\{\s*Base\s*\}\s*from\s*['"]\.\/ForeignDescriptor\.js['"]/
+        );
+        expect(result.code).toContain('const _exp = () => (Base);');
+        expect(result.code).toContain('styled(_exp())');
+        expect(result.code).not.toContain('styled(() => {})');
+        expect(result.code).not.toContain('styled(null)');
+        expect(result.dependencies).toContain('./ForeignDescriptor.js');
+      } finally {
+        disposeEvalBroker(cache);
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it('preserves readable metadata beside unreadable runtime fields', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'ForeignDescriptor.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        class RuntimeState {}
+
+        const RuntimeBase = {
+          kind: 'runtime-base',
+          runtimeState: new RuntimeState(),
+        };
+
+        export const Base = {
+          __wyw_meta: {
+            className: 'foreign-base',
+            extends: RuntimeBase,
+          },
+          runtimeState: new RuntimeState(),
+        };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './ForeignDescriptor.js';
+
+        export const Derived = styled(Base)\`
+          font-weight: bold;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache, undefined, {
+        eval: { strategy: 'execute' },
+      });
+
+      expect(result.cssText).toContain('font-weight:bold');
+      expect(result.cssText).toContain('.foreign-base');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still rejects unreadable runtime fields used as CSS data', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'ForeignDescriptor.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        class RuntimeState {}
+
+        export const Base = {
+          kind: 'foreign-descriptor',
+          render: () => null,
+          runtimeState: new RuntimeState(),
+        };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { Base } from './ForeignDescriptor.js';
+
+        export const className = css\`
+          ${'${Base}'}
+        \`;
+      `
+    );
+
+    try {
+      await expect(runTransform(root, entryFile, cache)).rejects.toThrow(
+        '__wywPreval._exp.runtimeState'
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines nested styled metadata object values with runtime bases without eval', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -336,6 +336,16 @@ const getEnumerableSymbolKeys = (value) =>
     Object.prototype.propertyIsEnumerable.call(value, key)
   );
 
+const IPC_SERIALIZATION_ERROR = Symbol('wyw.ipcSerializationError');
+
+const createIpcSerializationError = (message) =>
+  Object.assign(new Error(message), { [IPC_SERIALIZATION_ERROR]: true });
+
+const isIpcSerializationError = (error) =>
+  typeof error === 'object' &&
+  error !== null &&
+  IPC_SERIALIZATION_ERROR in error;
+
 const isLikeError = (value) =>
   typeof value === 'object' &&
   value !== null &&
@@ -345,12 +355,83 @@ const isLikeError = (value) =>
   ('stack' in value || 'name' in value);
 
 const throwUnsupportedIpcValue = (rootLabel, pathSegments, description) => {
-  throw new Error(
+  throw createIpcSerializationError(
     `[wyw-in-js] ${rootLabel} contains ${description} at ${formatPath(
       rootLabel,
       pathSegments
     )}. ${IPC_SUPPORTED_VALUE_HINT}`
   );
+};
+
+const serializeUnavailableError = (error) => {
+  if (typeof error === 'object' && error !== null) {
+    try {
+      const { message, name, stack } = error;
+      if (typeof message === 'string') {
+        return {
+          message,
+          name: typeof name === 'string' ? name : undefined,
+          stack: typeof stack === 'string' ? stack : undefined,
+        };
+      }
+    } catch {
+      // Fall through to the guarded string representation below. Errors may
+      // come from another VM context or even be proxy-like thrown values.
+    }
+  }
+
+  try {
+    return { message: String(error) };
+  } catch {
+    return { message: 'Unknown error' };
+  }
+};
+
+const serializeNestedValue = (
+  readValue,
+  rootLabel,
+  pathSegments,
+  seen,
+  allowFunctions,
+  allowSymbols,
+  ignoreSymbolKeys,
+  serialize
+) => {
+  // Processor values are demand-driven: a processor may inspect one metadata
+  // field without observing unrelated runtime state on the same object. Keep
+  // the serializable shell usable, but preserve failures at the exact property
+  // so data consumers still fail when they actually read it.
+  let value;
+  try {
+    value = readValue();
+  } catch (error) {
+    return {
+      kind: 'unavailable',
+      error: serializeUnavailableError(error),
+    };
+  }
+
+  try {
+    return serialize(
+      value,
+      rootLabel,
+      pathSegments,
+      seen,
+      allowFunctions,
+      allowSymbols,
+      true,
+      ignoreSymbolKeys
+    );
+  } catch (error) {
+    if (!isIpcSerializationError(error)) {
+      throw error;
+    }
+
+    return {
+      kind: 'unavailable',
+      error: serializeUnavailableError(error),
+    };
+  }
 };
 
 const serializeValueAtPath = (
@@ -360,6 +441,7 @@ const serializeValueAtPath = (
   seen,
   allowFunctions,
   allowSymbols,
+  deferNestedFailures,
   ignoreSymbolKeys
 ) => {
   if (value === null) {
@@ -428,7 +510,7 @@ const serializeValueAtPath = (
   const currentPath = formatPath(rootLabel, pathSegments);
   const seenAt = seen.get(value);
   if (seenAt) {
-    throw new Error(
+    throw createIpcSerializationError(
       `[wyw-in-js] ${rootLabel} contains a circular reference at ${currentPath} (from ${seenAt}). ${IPC_SUPPORTED_VALUE_HINT}`
     );
   }
@@ -459,15 +541,27 @@ const serializeValueAtPath = (
       return {
         kind: 'array',
         items: Array.from({ length: value.length }, (_, index) =>
-          serializeValueAtPath(
-            value[index],
-            rootLabel,
-            [...pathSegments, index],
-            seen,
-            allowFunctions,
-            allowSymbols,
-            ignoreSymbolKeys
-          )
+          deferNestedFailures
+            ? serializeNestedValue(
+                () => value[index],
+                rootLabel,
+                [...pathSegments, index],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                ignoreSymbolKeys,
+                serializeValueAtPath
+              )
+            : serializeValueAtPath(
+                value[index],
+                rootLabel,
+                [...pathSegments, index],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                false,
+                ignoreSymbolKeys
+              )
         ),
       };
     } finally {
@@ -497,18 +591,33 @@ const serializeValueAtPath = (
     return {
       kind: 'object',
       entries: Object.fromEntries(
-        Object.entries(value).map(([key, item]) => [
-          key,
-          serializeValueAtPath(
-            item,
-            rootLabel,
-            [...pathSegments, key],
-            seen,
-            allowFunctions,
-            allowSymbols,
-            ignoreSymbolKeys
-          ),
-        ])
+        deferNestedFailures
+          ? Object.keys(value).map((key) => [
+              key,
+              serializeNestedValue(
+                () => value[key],
+                rootLabel,
+                [...pathSegments, key],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                ignoreSymbolKeys,
+                serializeValueAtPath
+              ),
+            ])
+          : Object.entries(value).map(([key, item]) => [
+              key,
+              serializeValueAtPath(
+                item,
+                rootLabel,
+                [...pathSegments, key],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                false,
+                ignoreSymbolKeys
+              ),
+            ])
       ),
     };
   } finally {
@@ -530,8 +639,48 @@ const serializeValue = (value, options = {}) =>
     new WeakMap(),
     options.allowFunctions ?? false,
     options.allowSymbols ?? false,
+    options.deferNestedFailures ?? false,
     options.ignoreSymbolKeys ?? false
   );
+
+const deserializeError = (value) => {
+  const error = new Error(value?.message ?? '');
+  if (value?.name) {
+    error.name = value.name;
+  }
+  if (value?.stack) {
+    error.stack = value.stack;
+  }
+  return error;
+};
+
+const defineDeserializedProperty = (target, key, value, deserialize) => {
+  if (value?.kind === 'unavailable') {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      get() {
+        throw deserializeError(value.error);
+      },
+      set(replacement) {
+        Object.defineProperty(this, key, {
+          configurable: true,
+          enumerable: true,
+          value: replacement,
+          writable: true,
+        });
+      },
+    });
+    return;
+  }
+
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value: deserialize(value),
+    writable: true,
+  });
+};
 
 const deserializeValue = (value) => {
   switch (value?.kind) {
@@ -556,25 +705,25 @@ const deserializeValue = (value) => {
     case 'symbol':
       // eslint-disable-next-line symbol-description
       return value.description ? Symbol.for(value.description) : Symbol();
+    case 'unavailable':
+      throw deserializeError(value.error);
     case 'error': {
-      const error = new Error(value.error?.message ?? '');
-      if (value.error?.name) {
-        error.name = value.error.name;
-      }
-      if (value.error?.stack) {
-        error.stack = value.error.stack;
-      }
-      return error;
+      return deserializeError(value.error);
     }
-    case 'array':
-      return value.items.map((item) => deserializeValue(item));
-    case 'object':
-      return Object.fromEntries(
-        Object.entries(value.entries).map(([key, item]) => [
-          key,
-          deserializeValue(item),
-        ])
-      );
+    case 'array': {
+      const result = new Array(value.items.length);
+      value.items.forEach((item, index) => {
+        defineDeserializedProperty(result, index, item, deserializeValue);
+      });
+      return result;
+    }
+    case 'object': {
+      const result = {};
+      Object.entries(value.entries).forEach(([key, item]) => {
+        defineDeserializedProperty(result, key, item, deserializeValue);
+      });
+      return result;
+    }
     case 'value':
     default:
       return value?.value;
@@ -2282,6 +2431,7 @@ async function evaluateEntrypoint(id) {
     values[key] = serializeValue(value, {
       allowFunctions: true,
       allowSymbols: true,
+      deferNestedFailures: true,
       ignoreSymbolKeys: true,
       rootLabel: '__wywPreval',
       path: [key],

--- a/packages/transform/src/eval/serialize.ts
+++ b/packages/transform/src/eval/serialize.ts
@@ -13,6 +13,7 @@ export type SerializedValue =
   | { kind: 'number'; value: number }
   | { kind: 'function' }
   | { kind: 'symbol'; description: string }
+  | { kind: 'unavailable'; error: SerializedError }
   | { kind: 'error'; error: SerializedError }
   | { kind: 'undefined' }
   | { kind: 'bigint'; value: string }
@@ -55,6 +56,7 @@ type PathSegment = string | number | symbol;
 type SerializeValueOptions = {
   allowFunctions?: boolean;
   allowSymbols?: boolean;
+  deferNestedFailures?: boolean;
   ignoreSymbolKeys?: boolean;
   path?: PathSegment[];
   rootLabel?: string;
@@ -151,12 +153,22 @@ const getEnumerableSymbolKeys = (value: object): symbol[] =>
     Object.prototype.propertyIsEnumerable.call(value, key)
   );
 
+const IPC_SERIALIZATION_ERROR = Symbol('wyw.ipcSerializationError');
+
+const createIpcSerializationError = (message: string): Error =>
+  Object.assign(new Error(message), { [IPC_SERIALIZATION_ERROR]: true });
+
+const isIpcSerializationError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  IPC_SERIALIZATION_ERROR in error;
+
 const throwUnsupportedIpcValue = (
   rootLabel: string,
   path: PathSegment[],
   description: string
 ): never => {
-  throw new Error(
+  throw createIpcSerializationError(
     `[wyw-in-js] ${rootLabel} contains ${description} at ${formatPath(
       rootLabel,
       path
@@ -164,13 +176,100 @@ const throwUnsupportedIpcValue = (
   );
 };
 
-const serializeValueAtPath = (
+const serializeUnavailableError = (error: unknown): SerializedError => {
+  if (typeof error === 'object' && error !== null) {
+    try {
+      const { message, name, stack } = error as {
+        message?: unknown;
+        name?: unknown;
+        stack?: unknown;
+      };
+      if (typeof message === 'string') {
+        return {
+          message,
+          name: typeof name === 'string' ? name : undefined,
+          stack: typeof stack === 'string' ? stack : undefined,
+        };
+      }
+    } catch {
+      // Fall through to the guarded string representation below. Errors may
+      // come from another VM context or even be proxy-like thrown values.
+    }
+  }
+
+  try {
+    return { message: String(error) };
+  } catch {
+    return { message: 'Unknown error' };
+  }
+};
+
+type SerializeValueAtPath = (
   value: unknown,
   rootLabel: string,
   path: PathSegment[],
   seen: WeakMap<object, string>,
   allowFunctions: boolean,
   allowSymbols: boolean,
+  deferNestedFailures: boolean,
+  ignoreSymbolKeys: boolean
+) => SerializedValue;
+
+const serializeNestedValue = (
+  readValue: () => unknown,
+  rootLabel: string,
+  path: PathSegment[],
+  seen: WeakMap<object, string>,
+  allowFunctions: boolean,
+  allowSymbols: boolean,
+  ignoreSymbolKeys: boolean,
+  serialize: SerializeValueAtPath
+): SerializedValue => {
+  // Processor values are demand-driven: a processor may inspect one metadata
+  // field without observing unrelated runtime state on the same object. Keep
+  // the serializable shell usable, but preserve failures at the exact property
+  // so data consumers still fail when they actually read it.
+  let value: unknown;
+  try {
+    value = readValue();
+  } catch (error) {
+    return {
+      kind: 'unavailable',
+      error: serializeUnavailableError(error),
+    };
+  }
+
+  try {
+    return serialize(
+      value,
+      rootLabel,
+      path,
+      seen,
+      allowFunctions,
+      allowSymbols,
+      true,
+      ignoreSymbolKeys
+    );
+  } catch (error) {
+    if (!isIpcSerializationError(error)) {
+      throw error;
+    }
+
+    return {
+      kind: 'unavailable',
+      error: serializeUnavailableError(error),
+    };
+  }
+};
+
+const serializeValueAtPath: SerializeValueAtPath = (
+  value: unknown,
+  rootLabel: string,
+  path: PathSegment[],
+  seen: WeakMap<object, string>,
+  allowFunctions: boolean,
+  allowSymbols: boolean,
+  deferNestedFailures: boolean,
   ignoreSymbolKeys: boolean
 ): SerializedValue => {
   if (value === null) {
@@ -259,7 +358,7 @@ const serializeValueAtPath = (
   const currentPath = formatPath(rootLabel, path);
   const seenAt = seen.get(value as object);
   if (seenAt) {
-    throw new Error(
+    throw createIpcSerializationError(
       `[wyw-in-js] ${rootLabel} contains a circular reference at ${currentPath} (from ${seenAt}). ${IPC_SUPPORTED_VALUE_HINT}`
     );
   }
@@ -290,15 +389,27 @@ const serializeValueAtPath = (
       return {
         kind: 'array',
         items: Array.from({ length: value.length }, (_, index) =>
-          serializeValueAtPath(
-            value[index],
-            rootLabel,
-            [...path, index],
-            seen,
-            allowFunctions,
-            allowSymbols,
-            ignoreSymbolKeys
-          )
+          deferNestedFailures
+            ? serializeNestedValue(
+                () => value[index],
+                rootLabel,
+                [...path, index],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                ignoreSymbolKeys,
+                serializeValueAtPath
+              )
+            : serializeValueAtPath(
+                value[index],
+                rootLabel,
+                [...path, index],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                false,
+                ignoreSymbolKeys
+              )
         ),
       };
     } finally {
@@ -328,18 +439,33 @@ const serializeValueAtPath = (
     return {
       kind: 'object',
       entries: Object.fromEntries(
-        Object.entries(value).map(([key, item]) => [
-          key,
-          serializeValueAtPath(
-            item,
-            rootLabel,
-            [...path, key],
-            seen,
-            allowFunctions,
-            allowSymbols,
-            ignoreSymbolKeys
-          ),
-        ])
+        deferNestedFailures
+          ? Object.keys(value).map((key) => [
+              key,
+              serializeNestedValue(
+                () => (value as Record<string, unknown>)[key],
+                rootLabel,
+                [...path, key],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                ignoreSymbolKeys,
+                serializeValueAtPath
+              ),
+            ])
+          : Object.entries(value).map(([key, item]) => [
+              key,
+              serializeValueAtPath(
+                item,
+                rootLabel,
+                [...path, key],
+                seen,
+                allowFunctions,
+                allowSymbols,
+                false,
+                ignoreSymbolKeys
+              ),
+            ])
       ),
     };
   } finally {
@@ -358,8 +484,55 @@ export const serializeValue = (
     new WeakMap<object, string>(),
     options.allowFunctions ?? false,
     options.allowSymbols ?? false,
+    options.deferNestedFailures ?? false,
     options.ignoreSymbolKeys ?? false
   );
+
+const deserializeError = (value: SerializedError): Error => {
+  const error = new Error(value.message);
+  if (value.name) {
+    error.name = value.name;
+  }
+
+  if (value.stack) {
+    error.stack = value.stack;
+  }
+
+  return error;
+};
+
+const defineDeserializedProperty = (
+  target: object,
+  key: string | number,
+  value: SerializedValue,
+  deserialize: (serialized: SerializedValue) => unknown
+): void => {
+  if (value.kind === 'unavailable') {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      get() {
+        throw deserializeError(value.error);
+      },
+      set(this: object, replacement: unknown) {
+        Object.defineProperty(this, key, {
+          configurable: true,
+          enumerable: true,
+          value: replacement,
+          writable: true,
+        });
+      },
+    });
+    return;
+  }
+
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value: deserialize(value),
+    writable: true,
+  });
+};
 
 export const deserializeValue = (value: SerializedValue): unknown => {
   switch (value.kind) {
@@ -384,27 +557,25 @@ export const deserializeValue = (value: SerializedValue): unknown => {
     case 'symbol':
       // eslint-disable-next-line symbol-description
       return value.description ? Symbol.for(value.description) : Symbol();
+    case 'unavailable':
+      throw deserializeError(value.error);
     case 'error': {
-      const error = new Error(value.error.message);
-      if (value.error.name) {
-        error.name = value.error.name;
-      }
-
-      if (value.error.stack) {
-        error.stack = value.error.stack;
-      }
-
-      return error;
+      return deserializeError(value.error);
     }
-    case 'array':
-      return value.items.map((item) => deserializeValue(item));
-    case 'object':
-      return Object.fromEntries(
-        Object.entries(value.entries).map(([key, item]) => [
-          key,
-          deserializeValue(item),
-        ])
-      );
+    case 'array': {
+      const result = new Array(value.items.length) as unknown[];
+      value.items.forEach((item, index) => {
+        defineDeserializedProperty(result, index, item, deserializeValue);
+      });
+      return result;
+    }
+    case 'object': {
+      const result: Record<string, unknown> = {};
+      Object.entries(value.entries).forEach(([key, item]) => {
+        defineDeserializedProperty(result, key, item, deserializeValue);
+      });
+      return result;
+    }
     case 'value':
     default:
       return value.value;
@@ -420,6 +591,7 @@ export const serializePreval = (
       serializeValue(value, {
         allowFunctions: true,
         allowSymbols: true,
+        deferNestedFailures: true,
         ignoreSymbolKeys: true,
         rootLabel: '__wywPreval',
         path: [key],

--- a/packages/transform/src/transform/__tests__/prevalPayload.test.ts
+++ b/packages/transform/src/transform/__tests__/prevalPayload.test.ts
@@ -118,6 +118,26 @@ describe('createPrevalPayload', () => {
     ).toThrow('[wyw-in-js] PrevalPayload disagreement');
   });
 
+  it('treats values that throw during comparison as disagreements', () => {
+    process.env.NODE_ENV = 'test';
+    const evaluated = {};
+    Object.defineProperty(evaluated, 'unavailable', {
+      enumerable: true,
+      get() {
+        throw new Error('unavailable eval field');
+      },
+    });
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', evaluated]]),
+        filename,
+        staticValues: new Map([['_exp', { unavailable: 'static' }]]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
   it('warns and keeps static precedence on hybrid disagreement in production', () => {
     process.env.NODE_ENV = 'production';
     const warnings: string[] = [];
@@ -133,6 +153,39 @@ describe('createPrevalPayload', () => {
     expect(warnings[0]).toContain('PrevalPayload disagreement');
     expect(payload.values).toEqual(new Map([['_exp', 'static-red']]));
     expect(payload.sources).toEqual(new Map([['_exp', 'static']]));
+  });
+
+  it('warns once and keeps static precedence when a value cannot be formatted', () => {
+    process.env.NODE_ENV = 'production';
+    const warnings: string[] = [];
+    const evaluated = {};
+    Object.defineProperties(evaluated, {
+      unavailable: {
+        enumerable: true,
+        get() {
+          throw new Error('unavailable eval field');
+        },
+      },
+      toString: {
+        get() {
+          throw new Error('cannot format eval value');
+        },
+      },
+    });
+    const staticValue = { unavailable: 'static' };
+
+    const payload = createPrevalPayload({
+      emitWarning: (message) => warnings.push(message),
+      evalValues: new Map([['_exp', evaluated]]),
+      filename,
+      staticValues: new Map([['_exp', staticValue]]),
+      strategy: 'hybrid',
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('eval: <unprintable>');
+    expect(payload.values.get('_exp')).toBe(staticValue);
+    expect(payload.sources.get('_exp')).toBe('static');
   });
 
   it('deduplicates selected dependencies in hybrid mode', () => {

--- a/packages/transform/src/transform/prevalPayload.ts
+++ b/packages/transform/src/transform/prevalPayload.ts
@@ -26,6 +26,25 @@ const addUnique = <T>(target: T[], value: T): void => {
   }
 };
 
+const isSafelyDeepStrictEqual = (left: unknown, right: unknown): boolean => {
+  try {
+    return isDeepStrictEqual(left, right);
+  } catch {
+    // Deferred eval fields throw when observed. A value that cannot be fully
+    // compared is not proven equal, so preserve the existing disagreement
+    // handling and static-value precedence.
+    return false;
+  }
+};
+
+const formatDiagnosticValue = (value: unknown): string => {
+  try {
+    return String(value);
+  } catch {
+    return '<unprintable>';
+  }
+};
+
 const emitProductionWarning = (
   emitWarning: ((message: string) => void) | undefined,
   message: string
@@ -49,8 +68,8 @@ const handleDisagreement = (
   const message = [
     `[wyw-in-js] PrevalPayload disagreement for "${name}" in ${filename}.`,
     'Static and evaluated values differ; keeping the static value to preserve baseline precedence.',
-    `eval: ${String(evalValue)}`,
-    `static: ${String(staticValue)}`,
+    `eval: ${formatDiagnosticValue(evalValue)}`,
+    `static: ${formatDiagnosticValue(staticValue)}`,
   ].join(' ');
 
   if (process.env.NODE_ENV === 'production') {
@@ -89,7 +108,10 @@ export const createPrevalPayload = ({
       addUnique(dependencies, dependency)
     );
     staticValues?.forEach((value, name) => {
-      if (values.has(name) && !isDeepStrictEqual(values.get(name), value)) {
+      if (
+        values.has(name) &&
+        !isSafelyDeepStrictEqual(values.get(name), value)
+      ) {
         handleDisagreement(
           filename,
           String(name),


### PR DESCRIPTION
## Motivation

Fixes #382.

Strict eval IPC serialization rejected an entire `__wywPreval` value when any nested property could not cross the boundary. Foreign component descriptors can contain both processor-relevant metadata and runtime-only class instances, so an unrelated nested field prevented otherwise valid static evaluation.

## Summary

- Preserve serializable fields of evaluated objects while deferring unsupported nested branches.
- Reconstruct deferred fields as enumerable properties that retain the original path-aware error and throw only when read.
- Keep direct unsupported values and non-preval IPC serialization strict.
- Check processor metadata before attempting to enumerate an object as CSS data.
- Treat deferred-field access during hybrid comparison as a disagreement while preserving static-value precedence and safe diagnostics.
- Cover foreign component descriptors as processor arguments, selector metadata, runtime replacements, and CSS data.

There are no public API or configuration changes. Unsupported data does not become silently usable: reading a deferred field, spreading the object, or consuming it as CSS still reports the original serialization error.

## Test plan

- `bun test packages/transform/src packages/processor-utils/src`
- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform build:esm`
- `bun run --filter @wyw-in-js/processor-utils lint`
- `bun run --filter @wyw-in-js/processor-utils build:types`
- `bun run --filter @wyw-in-js/processor-utils build:esm`
- Full consumer integration builds; generated CSS baselines remained unchanged.
