### PR TITLE
fix(transform): preserve processor CSS side effects with execute evaluation

### DIFF
--- a/.changeset/tidy-mice-import.md
+++ b/.changeset/tidy-mice-import.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Preserve CSS-producing module imports with execute evaluation.

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2232,7 +2232,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('does not emit static resolve debug events when eval.strategy uses execute', async () => {
+  it('keeps execute values on the evaluator while reporting provenance resolution', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const depFile = join(root, 'unsafe.js');
@@ -2259,13 +2259,31 @@ describe('transform static import value inlining', () => {
     );
 
     try {
-      await runTransformWithOptions(root, entryFile, cache, perf.eventEmitter, {
-        eval: { strategy: 'execute' },
-      });
+      const result = await runTransformWithOptions(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {
+          eval: { strategy: 'execute' },
+        }
+      );
 
+      expect(result.cssText).toContain('color:red');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
       expect(
         perf.events.filter((event) => event.type === 'staticResolve')
-      ).toEqual([]);
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            exported: 'color',
+            filename: depFile,
+            phase: 'export',
+            reason: 'unsupported-expression',
+            status: 'rejected',
+          }),
+        ])
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -3280,16 +3298,25 @@ describe('transform static import value inlining', () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const classesFile = join(root, 'classes.js');
+    const helperFile = join(root, 'helper.js');
     const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
 
     writeFileSync(
       classesFile,
       dedent`
         import { css } from 'test-css-processor';
 
+        const color = String('blue');
         export const marker = css\`
-          color: blue;
+          color: ${'${color}'};
         \`;
+      `
+    );
+    writeFileSync(
+      helperFile,
+      dedent`
+        export const select = (value) => value;
       `
     );
     writeFileSync(
@@ -3297,9 +3324,10 @@ describe('transform static import value inlining', () => {
       dedent`
         import { css } from 'test-css-processor';
         import { marker } from './classes.js';
+        import { select } from './helper.js';
 
         export const className = css\`
-          .${'${marker}'} {
+          .${'${select(marker)}'} {
             color: red;
           }
         \`;
@@ -3307,15 +3335,36 @@ describe('transform static import value inlining', () => {
     );
 
     try {
-      const result = await runTransform(root, entryFile, cache, undefined, {
-        eval: { strategy: 'execute' },
-      });
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {
+          eval: { strategy: 'execute' },
+        }
+      );
 
       expect(result.cssText).toContain('color:red');
       expect(result.cssText).not.toContain('color:blue');
       expect(result.code).toContain("import './classes.js';");
       expect(result.code).not.toContain('import { marker }');
+      expect(result.code).not.toContain('./helper.js');
       expect(result.dependencies).toContain(classesFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+      expect(
+        perf.events.filter((event) => event.type === 'staticResolve')
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            exported: 'marker',
+            filename: classesFile,
+            phase: 'processor-metadata',
+            reason: 'non-empty-css-artifact-side-effect',
+            status: 'resolved',
+          }),
+        ])
+      );
     } finally {
       disposeEvalBroker(cache);
       rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -1120,6 +1120,7 @@ describe('transform static import value inlining', () => {
       );
 
       expect(result.cssText).toContain('color:red');
+      expect(result.code).not.toContain('./tokens.js');
       expect(result.dependencies).toContain('./tokens.js');
       expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
@@ -3271,6 +3272,52 @@ describe('transform static import value inlining', () => {
       expect(result.dependencies).toContain(classesFile);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves imported processor CSS side effects with execute evaluation', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const classesFile = join(root, 'classes.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      classesFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        export const marker = css\`
+          color: blue;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { marker } from './classes.js';
+
+        export const className = css\`
+          .${'${marker}'} {
+            color: red;
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache, undefined, {
+        eval: { strategy: 'execute' },
+      });
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).not.toContain('color:blue');
+      expect(result.code).toContain("import './classes.js';");
+      expect(result.code).not.toContain('import { marker }');
+      expect(result.dependencies).toContain(classesFile);
+    } finally {
+      disposeEvalBroker(cache);
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -41,7 +41,7 @@ export interface IPreevalResult {
   dependencyNames?: string[];
   evalCode?: string;
   executeSideEffectDependencies?: string[];
-  executeSideEffectImportsResolved?: boolean;
+  executeSideEffectProvenanceResolved?: boolean;
   finalizeEvaltimeReplacements?: (
     staticValueCache?: Map<string, unknown>
   ) => void;

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -40,6 +40,8 @@ export interface IPreevalResult {
   code: string;
   dependencyNames?: string[];
   evalCode?: string;
+  executeSideEffectDependencies?: string[];
+  executeSideEffectImportsResolved?: boolean;
   finalizeEvaltimeReplacements?: (
     staticValueCache?: Map<string, unknown>
   ) => void;

--- a/packages/transform/src/transform/generators/evalFile.ts
+++ b/packages/transform/src/transform/generators/evalFile.ts
@@ -24,6 +24,7 @@ export async function* evalFile(
   if (preevalResult && (preevalResult.dependencyNames?.length ?? 0) === 0) {
     const prevalPayload = createPrevalPayload({
       emitWarning: this.services.emitWarning,
+      evalDependencies: preevalResult.executeSideEffectDependencies,
       filename,
       strategy,
       staticDependencies: preevalResult.staticDependencies,
@@ -63,7 +64,10 @@ export async function* evalFile(
 
   const prevalPayload = createPrevalPayload({
     emitWarning: this.services.emitWarning,
-    evalDependencies: evaluated.dependencies,
+    evalDependencies: [
+      ...evaluated.dependencies,
+      ...(preevalResult?.executeSideEffectDependencies ?? []),
+    ],
     evalValues: evaluated.values,
     filename,
     strategy,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
@@ -24,6 +24,52 @@ import {
 } from './staticExpression';
 import type { OpaqueRuntimeImportProof, StaticExportResult } from './types';
 
+export type CandidateSideEffectProvenance = {
+  dependencies: string[];
+  importLocals: string[];
+};
+
+/**
+ * Proves which imports must remain for CSS artifacts produced by the import
+ * graph. The execute evaluator remains the sole owner of the candidate value.
+ */
+export function* resolveCandidateSideEffectProvenance(
+  action: ITransformAction,
+  candidate: OxcStaticValueCandidate,
+  filename: string,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<CandidateSideEffectProvenance | null> {
+  const dependencies = new Set<string>();
+  const importLocals = new Set<string>();
+
+  for (const item of candidate.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      item,
+      new Set(),
+      memo
+    );
+    if (!resolved?.sideEffectDependencies?.length) {
+      continue;
+    }
+
+    resolved.sideEffectDependencies.forEach((dependency) =>
+      dependencies.add(dependency)
+    );
+    importLocals.add(item.importLocal ?? item.local);
+  }
+
+  if (importLocals.size === 0) {
+    return null;
+  }
+
+  return {
+    dependencies: [...dependencies],
+    importLocals: [...importLocals],
+  };
+}
+
 export function* resolveCandidateValue(
   action: ITransformAction,
   candidate: OxcStaticValueCandidate,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -155,6 +155,10 @@ export const debugStaticResolve = (
   action: ITransformAction,
   event: StaticResolveDebugEvent
 ): void => {
+  if (getEvalStrategy(action) === 'execute') {
+    return;
+  }
+
   const labels = Object.fromEntries(
     Object.entries({
       ...event,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -155,10 +155,6 @@ export const debugStaticResolve = (
   action: ITransformAction,
   event: StaticResolveDebugEvent
 ): void => {
-  if (getEvalStrategy(action) === 'execute') {
-    return;
-  }
-
   const labels = Object.fromEntries(
     Object.entries({
       ...event,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveExecuteOxcSideEffectProvenance.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveExecuteOxcSideEffectProvenance.ts
@@ -1,0 +1,92 @@
+/* eslint-disable no-restricted-syntax,no-continue */
+
+import { isAbsolute } from 'path';
+
+import type { OxcStaticValueCandidate } from '../../../utils/collectOxcTemplateDependencies';
+import { stripQueryAndHash } from '../../../utils/parseRequest';
+import type { ITransformAction, SyncScenarioFor } from '../../types';
+import { resolveCandidateSideEffectProvenance } from './candidateResolver';
+import type { StaticExportResult } from './types';
+
+/**
+ * Collects only CSS side-effect provenance for execute evaluation. Candidate
+ * values are intentionally neither returned nor installed in the preeval
+ * static-value cache.
+ */
+export function* resolveExecuteOxcSideEffectProvenance(
+  action: ITransformAction,
+  candidates: OxcStaticValueCandidate[],
+  filename: string
+): SyncScenarioFor<void> {
+  const preevalResult = action.entrypoint.getPreevalResult();
+  if (!preevalResult) {
+    return;
+  }
+
+  if (preevalResult.executeSideEffectProvenanceResolved) {
+    return;
+  }
+
+  const executeDependencyNames = new Set(preevalResult.dependencyNames ?? []);
+  const executeSideEffectImportLocals = new Set(
+    preevalResult.staticSideEffectImportLocals ?? []
+  );
+  const executeSideEffectDependencies = new Set(
+    preevalResult.executeSideEffectDependencies ?? []
+  );
+  const memo = new Map<string, StaticExportResult | null>();
+
+  for (const candidate of candidates) {
+    if (
+      !executeDependencyNames.has(candidate.name) ||
+      candidate.imports.length === 0
+    ) {
+      continue;
+    }
+
+    const provenance = yield* resolveCandidateSideEffectProvenance(
+      action,
+      candidate,
+      filename,
+      memo
+    );
+    if (!provenance) {
+      continue;
+    }
+
+    provenance.importLocals.forEach((local) =>
+      executeSideEffectImportLocals.add(local)
+    );
+    provenance.dependencies.forEach((dependency) =>
+      executeSideEffectDependencies.add(dependency)
+    );
+  }
+
+  preevalResult.staticImportLocals = [
+    ...new Set([
+      ...(preevalResult.staticImportLocals ?? []),
+      ...executeSideEffectImportLocals,
+    ]),
+  ];
+  preevalResult.staticSideEffectImportLocals = [
+    ...executeSideEffectImportLocals,
+  ];
+  preevalResult.executeSideEffectDependencies = [
+    ...executeSideEffectDependencies,
+  ];
+  preevalResult.executeSideEffectProvenanceResolved = true;
+
+  for (const dependency of executeSideEffectDependencies) {
+    const strippedDependency = stripQueryAndHash(dependency);
+    if (isAbsolute(strippedDependency)) {
+      action.services.cache.checkFreshness(dependency, strippedDependency);
+    }
+
+    action.entrypoint.addInvalidationDependency({
+      only: ['*'],
+      resolved: dependency,
+      source: dependency,
+    });
+    action.entrypoint.markInvalidateOnDependencyChange(dependency);
+  }
+}

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
@@ -24,6 +24,7 @@ import {
   createSameFileStaticWYWMetaHelperResolver,
 } from './processorStaticModel';
 import { pruneStaticPreevalCode } from './prune';
+import { resolveExecuteOxcSideEffectProvenance } from './resolveExecuteOxcSideEffectProvenance';
 import { runtimeCallbackPlaceholder } from './staticExpression';
 import type { StaticExportResult } from './types';
 
@@ -58,73 +59,8 @@ export function* resolveStaticOxcPreevalValues(
   const evalStrategy = getEvalStrategy(this);
   if (evalStrategy === 'execute') {
     finalizeEvaltimeReplacements();
-    if (preevalResult.executeSideEffectImportsResolved) {
-      return false;
-    }
-
-    const executeDependencyNames = new Set(preevalResult.dependencyNames ?? []);
-    const executeSideEffectImportLocals = new Set(
-      preevalResult.staticSideEffectImportLocals ?? []
-    );
-    const executeSideEffectDependencies = new Set(
-      preevalResult.executeSideEffectDependencies ?? []
-    );
-    const executeMemo = new Map<string, StaticExportResult | null>();
-
     candidates = preevalResult.staticValueCandidates ?? candidates;
-    for (const candidate of candidates) {
-      if (
-        !executeDependencyNames.has(candidate.name) ||
-        candidate.imports.length === 0
-      ) {
-        continue;
-      }
-
-      const resolved = yield* resolveCandidateValue(
-        this,
-        candidate,
-        filename,
-        executeMemo
-      );
-      if (!resolved?.sideEffectImportLocals?.length) {
-        continue;
-      }
-
-      resolved.sideEffectImportLocals.forEach((local) =>
-        executeSideEffectImportLocals.add(local)
-      );
-      resolved.sideEffectDependencies?.forEach((dependency) =>
-        executeSideEffectDependencies.add(dependency)
-      );
-    }
-
-    preevalResult.staticImportLocals = [
-      ...new Set([
-        ...(preevalResult.staticImportLocals ?? []),
-        ...executeSideEffectImportLocals,
-      ]),
-    ];
-    preevalResult.staticSideEffectImportLocals = [
-      ...executeSideEffectImportLocals,
-    ];
-    preevalResult.executeSideEffectDependencies = [
-      ...executeSideEffectDependencies,
-    ];
-    preevalResult.executeSideEffectImportsResolved = true;
-
-    for (const dependency of executeSideEffectDependencies) {
-      const strippedDependency = stripQueryAndHash(dependency);
-      if (isAbsolute(strippedDependency)) {
-        this.services.cache.checkFreshness(dependency, strippedDependency);
-      }
-
-      this.entrypoint.addInvalidationDependency({
-        only: ['*'],
-        resolved: dependency,
-        source: dependency,
-      });
-      this.entrypoint.markInvalidateOnDependencyChange(dependency);
-    }
+    yield* resolveExecuteOxcSideEffectProvenance(this, candidates, filename);
 
     return false;
   }

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
@@ -36,14 +36,16 @@ export function* resolveStaticOxcPreevalValues(
   }
 
   let candidates = preevalResult.staticValueCandidates ?? [];
-  const evalDependencyNames = new Set(preevalResult.dependencyNames ?? []);
   const staticValueCache =
     preevalResult.staticValueCache ?? new Map<string, unknown>();
   const finalizeEvaltimeReplacements = (): void => {
     preevalResult.finalizeEvaltimeReplacements?.(staticValueCache);
   };
 
-  if (candidates.length === 0 && evalDependencyNames.size === 0) {
+  if (
+    candidates.length === 0 &&
+    (preevalResult.dependencyNames?.length ?? 0) === 0
+  ) {
     finalizeEvaltimeReplacements();
     return false;
   }
@@ -56,8 +58,77 @@ export function* resolveStaticOxcPreevalValues(
   const evalStrategy = getEvalStrategy(this);
   if (evalStrategy === 'execute') {
     finalizeEvaltimeReplacements();
+    if (preevalResult.executeSideEffectImportsResolved) {
+      return false;
+    }
+
+    const executeDependencyNames = new Set(preevalResult.dependencyNames ?? []);
+    const executeSideEffectImportLocals = new Set(
+      preevalResult.staticSideEffectImportLocals ?? []
+    );
+    const executeSideEffectDependencies = new Set(
+      preevalResult.executeSideEffectDependencies ?? []
+    );
+    const executeMemo = new Map<string, StaticExportResult | null>();
+
+    candidates = preevalResult.staticValueCandidates ?? candidates;
+    for (const candidate of candidates) {
+      if (
+        !executeDependencyNames.has(candidate.name) ||
+        candidate.imports.length === 0
+      ) {
+        continue;
+      }
+
+      const resolved = yield* resolveCandidateValue(
+        this,
+        candidate,
+        filename,
+        executeMemo
+      );
+      if (!resolved?.sideEffectImportLocals?.length) {
+        continue;
+      }
+
+      resolved.sideEffectImportLocals.forEach((local) =>
+        executeSideEffectImportLocals.add(local)
+      );
+      resolved.sideEffectDependencies?.forEach((dependency) =>
+        executeSideEffectDependencies.add(dependency)
+      );
+    }
+
+    preevalResult.staticImportLocals = [
+      ...new Set([
+        ...(preevalResult.staticImportLocals ?? []),
+        ...executeSideEffectImportLocals,
+      ]),
+    ];
+    preevalResult.staticSideEffectImportLocals = [
+      ...executeSideEffectImportLocals,
+    ];
+    preevalResult.executeSideEffectDependencies = [
+      ...executeSideEffectDependencies,
+    ];
+    preevalResult.executeSideEffectImportsResolved = true;
+
+    for (const dependency of executeSideEffectDependencies) {
+      const strippedDependency = stripQueryAndHash(dependency);
+      if (isAbsolute(strippedDependency)) {
+        this.services.cache.checkFreshness(dependency, strippedDependency);
+      }
+
+      this.entrypoint.addInvalidationDependency({
+        only: ['*'],
+        resolved: dependency,
+        source: dependency,
+      });
+      this.entrypoint.markInvalidateOnDependencyChange(dependency);
+    }
+
     return false;
   }
+  const evalDependencyNames = new Set(preevalResult.dependencyNames ?? []);
   const staticOnly = evalStrategy === 'static';
 
   // candidate name -> why it was rejected, populated by the resolvers below.


### PR DESCRIPTION
## Motivation

With `eval.strategy: "execute"`, an imported processor-produced class name can be inlined while its source import is removed. If that source module owns CSS artifacts, removing the import drops it from the bundler graph and the CSS is never emitted.

## Summary

- resolve imported execute values only to determine CSS side-effect provenance
- retain a bare side-effect import only when the processor source owns CSS artifacts
- include the resolved side-effect dependencies without replacing execute values with static values
- keep ordinary JavaScript imports shakeable and preserve execute-mode debug behavior

## Test plan

- `bun test src/__tests__/transform.static-import-values.test.ts --timeout 30000`
- `bun run lint`
- sequential type builds for `@wyw-in-js/shared`, `@wyw-in-js/processor-utils`, and `@wyw-in-js/transform`