### PR TITLE
fix(transform): include extracted rules in output metadata

### DIFF
--- a/.changeset/calm-cats-report.md
+++ b/.changeset/calm-cats-report.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Include extracted CSS rules in transform metadata.

--- a/packages/transform/src/__tests__/oxc-workflow.test.ts
+++ b/packages/transform/src/__tests__/oxc-workflow.test.ts
@@ -274,6 +274,7 @@ describe('explicit Oxc workflow', () => {
         cssText: expect.stringContaining('color: red'),
       })
     );
+    expect(result.metadata?.rules).toEqual(result.rules);
   });
 
   it('loads imported interpolation dependencies through the Oxc prepare path', async () => {

--- a/packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts
@@ -143,14 +143,7 @@ describe('workflow metadata output', () => {
             },
           ],
           replacements: [],
-          rules: {
-            '.entry_a': {
-              className: 'entry_a',
-              cssText: 'color:red;',
-              displayName: 'entry',
-              start: { column: 0, line: 1 },
-            },
-          },
+          rules: {},
         },
       })
     );
@@ -159,7 +152,14 @@ describe('workflow metadata output', () => {
       cssSourceMapText: '',
       cssText: '.entry_a{color:red;}',
       replacements: [],
-      rules: {},
+      rules: {
+        '.entry_a': {
+          className: 'entry_a',
+          cssText: 'color:red;',
+          displayName: 'entry',
+          start: { column: 0, line: 1 },
+        },
+      },
     });
     expectIteratorReturnResult(finalResult);
     expect(

--- a/packages/transform/src/transform/generators/workflow.ts
+++ b/packages/transform/src/transform/generators/workflow.ts
@@ -121,9 +121,6 @@ export function* workflow(
       };
     }
 
-    const metadata = options.pluginOptions.outputMetadata
-      ? toTransformResultMetadata(collectStageResult.metadata, dependencies)
-      : null;
     const diagnostics = collectTransformDiagnostics(
       entrypoint.name,
       collectStageResult.metadata.processors
@@ -140,6 +137,16 @@ export function* workflow(
       null
     );
     entrypoint.assertNotSuperseded();
+
+    const metadata = options.pluginOptions.outputMetadata
+      ? toTransformResultMetadata(
+          {
+            ...collectStageResult.metadata,
+            rules: extractStageResult.rules,
+          },
+          dependencies
+        )
+      : null;
 
     return {
       ...extractStageResult,


### PR DESCRIPTION
## Motivation

The extract stage produces the populated selector-keyed rules, but transform metadata is currently normalized before extraction from collect metadata, where `rules` is empty. Consumers that serialize `result.metadata`, including the Vite manifest writer, therefore receive `rules: {}`.

## Summary

- create public transform metadata after the extract stage
- populate `metadata.rules` from the extracted rules
- preserve existing metadata normalization for processors, dependencies, and replacements
- cover both the workflow boundary and a real Oxc transform

## Test plan

- `bun test packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts packages/transform/src/__tests__/oxc-workflow.test.ts`
- `bun run lint`
- `bun run build:esm`
- `bun run build:types`
