### PR TITLE
fix(transform): avoid expanding direct imported calls through the imported-result cohort

### DIFF
--- a/.changeset/direct-import-callable-cohort.md
+++ b/.changeset/direct-import-callable-cohort.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Avoid expanding direct imported calls through the opaque imported-result callable cohort during OXC shaking.

--- a/packages/transform/src/__tests__/oxc-shaker.test.ts
+++ b/packages/transform/src/__tests__/oxc-shaker.test.ts
@@ -1002,6 +1002,48 @@ describe('shakeOxcToESM', () => {
     ).toHaveLength(0);
   });
 
+  it('keeps a local callable reached through an imported alias component', () => {
+    const { code } = run(
+      ['source'],
+      `
+        import { dependency } from './dependency';
+        const source = { width: 1 };
+        function local() { source.width = 401; }
+        let invoke = dependency;
+        invoke = local;
+        invoke();
+        export { source };
+      `
+    );
+
+    expect(code).toContain('function local()');
+    expect(code).toContain('source.width = 401');
+    expect(code).toContain('invoke = local');
+    expect(code).toContain('invoke()');
+  });
+
+  it('keeps a local class reached through an imported alias component', () => {
+    const { code } = run(
+      ['source'],
+      `
+        import { Imported } from './dependency';
+        const source = { width: 1 };
+        class Local {
+          constructor() { source.width = 402; }
+        }
+        let Current = Imported;
+        Current = Local;
+        new Current();
+        export { source };
+      `
+    );
+
+    expect(code).toContain('class Local');
+    expect(code).toContain('source.width = 402');
+    expect(code).toContain('Current = Local');
+    expect(code).toContain('new Current()');
+  });
+
   it('unions normalized catalog candidates without collapsing suffixes', () => {
     const aDeep = appendOxcRuntimePropertyPath(
       createOxcRuntimePropertyPath('a'),

--- a/packages/transform/src/__tests__/oxc-shaker.test.ts
+++ b/packages/transform/src/__tests__/oxc-shaker.test.ts
@@ -966,6 +966,42 @@ describe('shakeOxcToESM', () => {
     expect(opaque.imports.get('./dependency')).toEqual(['a', 'b', 'make']);
   });
 
+  it('does not resolve a direct imported call through the imported-result cohort', () => {
+    const { program, provenance } = createTestProvenance(`
+      import { run, getA, getB } from './dependency';
+      const source = { width: 1 };
+      let first = () => { source.width = 401; };
+      first = getA();
+      let second = () => { source.width = 402; };
+      second = getB();
+
+      run();
+    `);
+    const runStatement = program.body.find(
+      (node) =>
+        node.type === 'ExpressionStatement' &&
+        node.expression.type === 'CallExpression' &&
+        node.expression.callee.type === 'Identifier' &&
+        node.expression.callee.name === 'run'
+    );
+
+    expect(runStatement?.type).toBe('ExpressionStatement');
+    if (runStatement?.type !== 'ExpressionStatement') {
+      return;
+    }
+    expect(runStatement.expression.type).toBe('CallExpression');
+    if (runStatement.expression.type !== 'CallExpression') {
+      return;
+    }
+    expect(
+      provenance.resolveCalleeCallables(
+        runStatement.expression.callee,
+        new Map(),
+        new Map()
+      )
+    ).toHaveLength(0);
+  });
+
   it('unions normalized catalog candidates without collapsing suffixes', () => {
     const aDeep = appendOxcRuntimePropertyPath(
       createOxcRuntimePropertyPath('a'),

--- a/packages/transform/src/utils/oxcShaker/bindingProvenance.ts
+++ b/packages/transform/src/utils/oxcShaker/bindingProvenance.ts
@@ -176,7 +176,7 @@ const markImportedRootCohort = (
   metadata.importedRootCohort = true;
 };
 
-const aliasesImportedRootCohort = (
+export const aliasesImportedRootCohortInState = (
   state: AliasProvenanceState,
   binding: string
 ): boolean =>
@@ -199,7 +199,7 @@ const appendAliasRoots = (
   switch (current.type) {
     case 'Identifier':
       bindings.add(current.name);
-      return aliasesImportedRootCohort(state, current.name);
+      return aliasesImportedRootCohortInState(state, current.name);
     case 'MemberExpression':
       return appendAliasRoots(current.object, state, bindings);
     case 'ConditionalExpression': {

--- a/packages/transform/src/utils/oxcShaker/callableProvenanceIndex.ts
+++ b/packages/transform/src/utils/oxcShaker/callableProvenanceIndex.ts
@@ -153,18 +153,38 @@ export const createCallableProvenanceIndex = ({
     const resolveNormalized = createNormalizedCatalogResolver(catalog, (path) =>
       normalizeProvenancePath(path as OxcRuntimePropertyPathKey)
     );
+    const componentCandidates = new Map<string, Set<T>>();
+    const resolveComponentCandidates = (binding: string): Set<T> => {
+      const componentId = aliasComponentId(binding);
+      const cached = componentCandidates.get(componentId);
+      if (cached) {
+        return new Set(cached);
+      }
+
+      const candidates = new Set<T>();
+      getAliasComponentMembers(topLevelAliasState, binding).forEach(
+        (member) => {
+          const candidate = catalog.get(member);
+          if (candidate) {
+            candidates.add(candidate);
+          }
+        }
+      );
+      componentCandidates.set(componentId, candidates);
+      return new Set(candidates);
+    };
     return (binding) => {
       const path = binding as OxcRuntimePropertyPathKey;
       const root = getOxcRuntimePropertyPathKeyRoot(path);
-      // A bare imported binding (or direct alias) is opaque to this module.
-      // Only an imported member path or an alias of an imported result can
-      // match a callable in the virtual imported-result cohort.
+      // A bare imported binding cannot have a local declaration, but a direct
+      // alias can share its component with local callables or classes. Keep
+      // those candidates without widening to the imported-result cohort.
       if (
         root === path &&
         aliasesImportedRoot(root) &&
         !aliasesImportedRootCohortInState(topLevelAliasState, root)
       ) {
-        return new Set<T>();
+        return resolveComponentCandidates(root);
       }
       return resolveNormalized(binding);
     };

--- a/packages/transform/src/utils/oxcShaker/callableProvenanceIndex.ts
+++ b/packages/transform/src/utils/oxcShaker/callableProvenanceIndex.ts
@@ -15,6 +15,7 @@ import {
   type OxcRuntimePropertyPathKey,
 } from '../oxc/projections';
 import {
+  aliasesImportedRootCohortInState,
   aliasesImportedRootInState,
   collectAssignedAliasRoots,
   collectTopLevelAccessors,
@@ -148,10 +149,26 @@ export const createCallableProvenanceIndex = ({
   const classes = collectTopLevelClasses(program);
   const createCatalogResolver = <T>(
     catalog: ReadonlyMap<string, T>
-  ): ((binding: string) => Set<T>) =>
-    createNormalizedCatalogResolver(catalog, (path) =>
+  ): ((binding: string) => Set<T>) => {
+    const resolveNormalized = createNormalizedCatalogResolver(catalog, (path) =>
       normalizeProvenancePath(path as OxcRuntimePropertyPathKey)
     );
+    return (binding) => {
+      const path = binding as OxcRuntimePropertyPathKey;
+      const root = getOxcRuntimePropertyPathKeyRoot(path);
+      // A bare imported binding (or direct alias) is opaque to this module.
+      // Only an imported member path or an alias of an imported result can
+      // match a callable in the virtual imported-result cohort.
+      if (
+        root === path &&
+        aliasesImportedRoot(root) &&
+        !aliasesImportedRootCohortInState(topLevelAliasState, root)
+      ) {
+        return new Set<T>();
+      }
+      return resolveNormalized(binding);
+    };
+  };
   const resolveCallable = createCatalogResolver<CallableNode>(callables);
   const resolveAccessor = createCatalogResolver<CallableNode>(accessors);
   const resolveClass = createCatalogResolver<ClassNode>(classes);


### PR DESCRIPTION
## Motivation

Fixes #384 — the OXC shaker never returns during `@wyw-in-js/transform` 2.4.x builds.

`next build` hangs forever when a module both (a) interpolates a value wyw cannot fold
statically and (b) has a top-level side-effect call on a binding imported from a large
`node_modules` package. The reported case is `ag-grid-community@36.1.0`
(`ModuleRegistry.registerModules([AllCommunityModule])`), which drags ag-grid's 2.3 MB
`main.esm.mjs` into the shaker. It does not reproduce on 2.3.1.

Reproduction: https://github.com/defaultsamson/wyw-in-js-transform-bug

## Summary

The `IMPORTED_ROOT_COHORT` normalization used by OXC callable resolution collapses every
imported-rooted path into a single virtual root, so the normalized catalog resolver treats
all callables derived from an opaque imported result as one cohort. A *bare* call such as
`accentMix()` on a directly imported binding normalized to that same root, so the resolver
returned every callable in the cohort. On a large ESM bundle the resulting provenance
expansion never terminates.

This change keeps the cohort behaviour where the imported result is genuinely opaque, but
skips it for a bare direct import that was never assigned from an opaque imported result:
a module's own callable/accessor/class catalog can never contain the binding of a bare
`import` specifier (that would be a redeclaration), so matching it against the cohort is
never meaningful.

Two conditions guard the new short-circuit, so the existing behaviour is preserved where
it matters:

- `root === path` — imported *member* paths (`ModuleRegistry.registerModules`) still resolve
  through the cohort.
- `!aliasesImportedRootCohortInState(...)` — a binding that *was* assigned from an opaque
  imported result (`first = getA()`) still resolves through the cohort.

Fail-closed safety is unaffected: a call on an imported binding is still marked via
`opaqueImportedCall` in `moduleInvocationEffects`, and alias-component effect propagation
still keeps statements alive. `aliasesImportedRootCohort` is exported (renamed to
`aliasesImportedRootCohortInState` for symmetry with `aliasesImportedRootInState`) so the
callable index can consult it.

## Test plan

Shaking ag-grid-community 36.1.0's `main.esm.mjs` (2.3 MB) directly through `shakeOxcToESM`,
on this branch's merge base (`12cbf6d8`) vs. with the fix:

```
# 12cbf6d8 (no fix)
$ bun run bench-shake.mts .../ag-grid-community/dist/package/main.esm.mjs
<no result after 10 minutes — killed>

# with this change
$ bun run bench-shake.mts .../ag-grid-community/dist/package/main.esm.mjs
shaken in 10.54s, out=2325779 bytes
```

Test suite (`bun test src` in `packages/transform`):

| | pass | fail |
|---|---|---|
| `12cbf6d8` | 1133 | 44 |
| with this change | 1134 | 44 |

The 44 failures are pre-existing on the merge base (`Unhandled error between tests` in
`buildStaticPlan` / `transform.static-plan-debug`) and unchanged by this PR. The added test
accounts for the +1 pass. `src/__tests__/oxc-shaker.test.ts`: 218 pass, 0 fail.

I also checked that the narrowing does not under-shake. For each of these shapes the shaken
output is byte-identical before and after the change:

- a local callable reassigned from an imported binding (`let y = () => {...}; y = dep; y()`)
- a direct alias of an import later reassigned to a local callable (`let z = dep; z = local; z()`)
- a bare imported call alongside cohort members (`first = getA(); run()`)

A changeset (`patch` on `@wyw-in-js/transform`) is included.
