### PR TITLE
fix(transform): bound OXC invocation analysis

### DIFF
--- a/.changeset/bright-shakers-wait.md
+++ b/.changeset/bright-shakers-wait.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Bound OXC invocation analysis and conservatively retain statement-local effects when callable provenance exceeds its work budget.

--- a/packages/transform/src/__tests__/oxc-shaker.test.ts
+++ b/packages/transform/src/__tests__/oxc-shaker.test.ts
@@ -3904,6 +3904,116 @@ describe('shakeOxcToESM', () => {
     }
   );
 
+  it('widens a shared call graph without widening later statements', () => {
+    const depth = 20;
+    const callables = ['function level0(value) { value.width = 400; }'];
+    for (let index = 1; index <= depth; index += 1) {
+      callables.push(
+        `function level${index}(value) { ` +
+          `level${index - 1}(value); level${index - 1}(value); }`
+      );
+    }
+
+    const { code, width } = runSourceWidth(`
+      const source = { width: 304 };
+      const hardTarget = { width: 320 };
+      const dead = { width: 330 };
+      ${callables.join('\n')}
+      function mutateCapturedSource() { source.width = 401; }
+      class BaseWriter {
+        constructor() { source.width = 402; }
+      }
+      class Writer extends BaseWriter {}
+      const holder = {
+        get value() { source.width = 403; return source.width; }
+      };
+      function makeWriter() {
+        return () => { source.width = 404; };
+      }
+      function readSource() { return source; }
+      function mutateDead() { dead.width = 500; }
+      (level${depth}(hardTarget), mutateCapturedSource());
+      new Writer();
+      holder.value;
+      makeWriter()();
+      readSource();
+      mutateDead();
+      export { source };
+    `);
+
+    expect(code).toContain('function level0(value)');
+    expect(code).toContain(`level${depth}(hardTarget)`);
+    expect(code).toContain('mutateCapturedSource()');
+    expect(code).toContain('class Writer extends BaseWriter');
+    expect(code).toContain('holder.value');
+    expect(code).toContain('makeWriter()()');
+    expect(code).not.toContain('readSource');
+    expect(code).not.toContain('mutateDead');
+    expect(code).not.toContain('dead');
+    expect(width).toBe(404);
+  });
+
+  it('widens broad callable provenance without losing later effects', () => {
+    const declarations = Array.from(
+      { length: 900 },
+      (_value, index) => `const value${index} = { width: ${index} };`
+    );
+    const values = Array.from(
+      { length: 900 },
+      (_value, index) => `value${index}`
+    );
+
+    const { code, width } = runSourceWidth(`
+      const source = { width: 304 };
+      ${declarations.join('\n')}
+      function mutate(items) {
+        const alias = items;
+        const forwarded = alias;
+        forwarded[0].width = 400;
+      }
+      function mutateLater() {
+        source.width = 401;
+      }
+      mutate([source, ${values.join(', ')}]);
+      mutateLater();
+      export { source };
+    `);
+
+    expect(code).toContain('mutate([source, value0');
+    expect(code).toContain('forwarded[0].width = 400');
+    expect(code).toContain('mutateLater()');
+    expect(width).toBe(401);
+  });
+
+  it('keeps imported effects reached after the invocation budget is spent', () => {
+    const depth = 20;
+    const callables = ['function level0(value) { value.width = 400; }'];
+    for (let index = 1; index <= depth; index += 1) {
+      callables.push(
+        `function level${index}(value) { ` +
+          `level${index - 1}(value); level${index - 1}(value); }`
+      );
+    }
+
+    const { code, imports } = run(
+      ['__wywPreval'],
+      `
+        import { mutate, source } from './tokens';
+        const hardTarget = { width: 320 };
+        ${callables.join('\n')}
+        function wrapper() { mutate(source); }
+        level${depth}(hardTarget);
+        wrapper();
+        export const __wywPreval = { source };
+      `
+    );
+
+    expect(code).toContain('function wrapper()');
+    expect(code).toContain('mutate(source)');
+    expect(code).toContain('wrapper()');
+    expect(imports.get('./tokens')).toEqual(['mutate', 'source']);
+  });
+
   it('keeps an imported callable alias invoked inside a local wrapper', () => {
     const { code, imports } = run(
       ['__wywPreval'],

--- a/packages/transform/src/utils/oxcShaker/callableProvenanceIndex.ts
+++ b/packages/transform/src/utils/oxcShaker/callableProvenanceIndex.ts
@@ -210,7 +210,12 @@ export const createCallableProvenanceIndex = ({
     externalReferencesByStatement.set(statement, references);
     return references;
   };
-  const collectReachableFactoryReferences = (binding: string): Set<string> => {
+  const reachableBindingReferences = new Map<string, Set<string>>();
+  const collectReachableBindingReferences = (binding: string): Set<string> => {
+    const cached = reachableBindingReferences.get(binding);
+    if (cached) {
+      return cached;
+    }
     const references = new Set<string>();
     const visited = new Set<string>();
     const pending = [binding];
@@ -234,6 +239,7 @@ export const createCallableProvenanceIndex = ({
         });
       });
     }
+    reachableBindingReferences.set(binding, references);
     return references;
   };
   const callableCaptureRoots = new Map<CallableNode, Set<string>>();
@@ -246,7 +252,7 @@ export const createCallableProvenanceIndex = ({
     }
     const roots = collectExternalReferences(callable);
     [...roots].forEach((root) => {
-      collectReachableFactoryReferences(root).forEach((reference) =>
+      collectReachableBindingReferences(root).forEach((reference) =>
         roots.add(reference)
       );
     });
@@ -320,7 +326,7 @@ export const createCallableProvenanceIndex = ({
       }
       const factoryBinding = getCalleeBinding(current.callee);
       if (factoryBinding) {
-        collectReachableFactoryReferences(factoryBinding).forEach((root) =>
+        collectReachableBindingReferences(factoryBinding).forEach((root) =>
           roots.bindings.add(root)
         );
       }
@@ -739,47 +745,61 @@ export const createCallableProvenanceIndex = ({
 
     return new Set();
   };
+  // A null result asks invocation analysis to use its conservative capture
+  // summary instead of materializing more alias roots.
   const collectCallableAliases = (
     callable: CallableNode,
     args: readonly (Node | null)[],
-    callerAliases: AliasEnvironment
-  ): Map<string, Set<string>> => {
+    callerAliases: AliasEnvironment,
+    consumeWork: (work: number) => boolean
+  ): Map<string, Set<string>> | null => {
     const aliases = new Map<string, Set<string>>();
     const addBindingRoots = (
       pattern: Node,
       roots: ReadonlySet<string>
-    ): boolean => {
+    ): boolean | null => {
       let changed = false;
-      collectPatternNames(pattern).forEach((binding) => {
+      for (const binding of collectPatternNames(pattern)) {
+        if (!consumeWork(Math.max(1, roots.size))) {
+          return null;
+        }
         const previous = aliases.get(binding);
         if (!previous) {
           aliases.set(binding, new Set(roots));
           changed = true;
-          return;
-        }
-        roots.forEach((root) => {
-          if (!previous.has(root)) {
-            previous.add(root);
-            changed = true;
+        } else {
+          for (const root of roots) {
+            if (!previous.has(root)) {
+              previous.add(root);
+              changed = true;
+            }
           }
-        });
-      });
+        }
+      }
       return changed;
     };
 
-    callable.params.forEach((parameter, index) => {
+    for (let index = 0; index < callable.params.length; index += 1) {
+      const parameter = callable.params[index]!;
       const argument = args[index];
       const roots =
         argument && argument.type !== 'SpreadElement'
           ? collectContextualRoots(argument, callerAliases, false)
           : new Set<string>();
-      if (parameter.type === 'AssignmentPattern') {
-        collectContextualRoots(parameter.right, aliases).forEach((root) =>
-          roots.add(root)
-        );
+      if (!consumeWork(Math.max(1, roots.size))) {
+        return null;
       }
-      addBindingRoots(parameter, roots);
-    });
+      if (parameter.type === 'AssignmentPattern') {
+        const defaultRoots = collectContextualRoots(parameter.right, aliases);
+        if (!consumeWork(Math.max(1, defaultRoots.size))) {
+          return null;
+        }
+        defaultRoots.forEach((root) => roots.add(root));
+      }
+      if (addBindingRoots(parameter, roots) === null) {
+        return null;
+      }
+    }
 
     const { assignmentPairs } = getCallableSyntaxFacts(callable.body);
 
@@ -787,11 +807,20 @@ export const createCallableProvenanceIndex = ({
     let passes = assignmentPairs.length + 1;
     while (changed && passes > 0) {
       passes -= 1;
-      changed = assignmentPairs
-        .map(({ pattern, value }) =>
-          addBindingRoots(pattern, collectContextualRoots(value, aliases))
-        )
-        .some(Boolean);
+      changed = false;
+      for (const { pattern, value } of assignmentPairs) {
+        const roots = collectContextualRoots(value, aliases);
+        if (!consumeWork(Math.max(1, roots.size))) {
+          return null;
+        }
+        const added = addBindingRoots(pattern, roots);
+        if (added === null) {
+          return null;
+        }
+        if (added) {
+          changed = true;
+        }
+      }
     }
 
     return aliases;

--- a/packages/transform/src/utils/oxcShaker/moduleInvocationEffects.ts
+++ b/packages/transform/src/utils/oxcShaker/moduleInvocationEffects.ts
@@ -37,11 +37,40 @@ type ModuleInvocationEffects = {
   opaqueImportedCall: boolean;
 };
 
+export type ModuleInvocationAnalysisState = {
+  consumeWork: (work: number) => boolean;
+  isExhausted: () => boolean;
+};
+
+// Work shared by the whole module prevents many individually expensive
+// statements from multiplying the same callable/alias expansion cost.
+const MAX_MODULE_INVOCATION_WORK = 8192;
+// This bounded leaf check avoids widening tiny, obviously effect-free calls
+// after the module budget is spent without starting another unbounded pass.
+const MAX_TRIVIAL_CALLABLE_SIZE = 64;
+
+export const createModuleInvocationAnalysisState =
+  (): ModuleInvocationAnalysisState => {
+    let remainingWork = MAX_MODULE_INVOCATION_WORK;
+    return {
+      consumeWork: (work) => {
+        if (work <= remainingWork) {
+          remainingWork -= work;
+          return true;
+        }
+        remainingWork = -1;
+        return false;
+      },
+      isExhausted: () => remainingWork < 0,
+    };
+  };
+
 export const collectModuleInvocationEffects = (
   node: Node,
   provenance: CallableProvenanceIndex,
   isReceiverOperationProvenInert: (operation: ReceiverOperation) => boolean,
-  resolveReceiverOperationRoots: (binding: string) => ReadonlySet<string>
+  resolveReceiverOperationRoots: (binding: string) => ReadonlySet<string>,
+  analysisState: ModuleInvocationAnalysisState
 ): ModuleInvocationEffects => {
   if (!hasModuleInvocationCandidate(node)) {
     return {
@@ -75,7 +104,10 @@ export const collectModuleInvocationEffects = (
     effectOrigins.add(binding);
   };
   let opaqueImportedCall = false;
+  let widened = false;
+  const { consumeWork } = analysisState;
   const emptyAliases: AliasEnvironment = new Map();
+  const activeCallableAliases = new Map<CallableNode, AliasEnvironment>();
   const hasImportedCallee = (
     candidates: ReadonlySet<string>,
     aliases: AliasEnvironment
@@ -83,6 +115,27 @@ export const collectModuleInvocationEffects = (
     [...candidates].some((binding) =>
       [...resolveAliasBinding(binding, aliases)].some(aliasesImportedRoot)
     );
+  const addFallbackRoot = (
+    binding: string,
+    aliases: AliasEnvironment
+  ): void => {
+    resolveAliasBinding(binding, aliases).forEach((root) => {
+      addEffectOrigin(root);
+      if (aliasesImportedRoot(root)) {
+        opaqueImportedCall = true;
+      }
+    });
+  };
+  const addCallableFallbackRoots = (
+    callable: CallableNode,
+    aliases: AliasEnvironment
+  ): void => {
+    // Arguments are recorded before descent. Captures cover effects that do
+    // not flow through those arguments, including transitive local wrappers.
+    collectInlineCallableCaptureRoots(callable).forEach((root) =>
+      addFallbackRoot(root, aliases)
+    );
+  };
 
   const addResultPaths = (
     binding: OxcRuntimePropertyPathKey,
@@ -510,9 +563,52 @@ export const collectModuleInvocationEffects = (
     if (visiting.has(callable)) {
       return;
     }
+    if (widened) {
+      addCallableFallbackRoots(callable, callerAliases);
+      return;
+    }
+    if (
+      analysisState.isExhausted() &&
+      callable.params.length === 0 &&
+      callable.body.end - callable.body.start <= MAX_TRIVIAL_CALLABLE_SIZE
+    ) {
+      const facts = getCallableSyntaxFacts(callable.body);
+      if (
+        facts.mutationBindings.size === 0 &&
+        !hasModuleInvocationCandidate(callable.body)
+      ) {
+        return;
+      }
+    }
+    const widenFrom = (): void => {
+      widened = true;
+      const affected = new Set(visiting).add(callable);
+      affected.forEach((active) => {
+        const aliases =
+          active === callable
+            ? callerAliases
+            : activeCallableAliases.get(active) ?? emptyAliases;
+        addCallableFallbackRoots(active, aliases);
+      });
+    };
+    if (!consumeWork(1)) {
+      widenFrom();
+      return;
+    }
     visiting.add(callable);
 
-    const aliases = collectCallableAliases(callable, args, callerAliases);
+    const aliases = collectCallableAliases(
+      callable,
+      args,
+      callerAliases,
+      consumeWork
+    );
+    if (!aliases) {
+      widenFrom();
+      visiting.delete(callable);
+      return;
+    }
+    activeCallableAliases.set(callable, aliases);
     const facts = getCallableSyntaxFacts(callable.body);
     const {
       accessors: scopedAccessors,
@@ -646,6 +742,7 @@ export const collectModuleInvocationEffects = (
       }
     });
 
+    activeCallableAliases.delete(callable);
     visiting.delete(callable);
   };
 
@@ -661,6 +758,9 @@ export const collectModuleInvocationEffects = (
   ): void => {
     if (visitingClasses.has(classNode)) {
       return;
+    }
+    if (!widened && !consumeWork(1)) {
+      widened = true;
     }
     visitingClasses.add(classNode);
 
@@ -926,5 +1026,10 @@ export const collectModuleInvocationEffects = (
     }
   });
 
-  return { bindings, callableResultPaths, effectOrigins, opaqueImportedCall };
+  return {
+    bindings,
+    callableResultPaths,
+    effectOrigins,
+    opaqueImportedCall,
+  };
 };

--- a/packages/transform/src/utils/oxcShaker/statementGraph.ts
+++ b/packages/transform/src/utils/oxcShaker/statementGraph.ts
@@ -26,7 +26,10 @@ import {
   splitExportedVariableDeclaration,
   type Replacement,
 } from './moduleRewrites';
-import { collectModuleInvocationEffects } from './moduleInvocationEffects';
+import {
+  collectModuleInvocationEffects,
+  createModuleInvocationAnalysisState,
+} from './moduleInvocationEffects';
 import {
   isPattern,
   isProvenNonAbruptPatternEvaluation,
@@ -563,6 +566,7 @@ const buildShakerProgramFacts = (
     return roots;
   };
 
+  const invocationAnalysisState = createModuleInvocationAnalysisState();
   statements.forEach((statement) => {
     if ([...statement.mutations].some(callableProvenance.aliasesImportedRoot)) {
       importedEffects.add(statement);
@@ -611,7 +615,8 @@ const buildShakerProgramFacts = (
             resolveStableInitializer(statement, name),
         }),
       (binding) =>
-        resolveReceiverOperationRoots(binding, statement, receiverRootDemands)
+        resolveReceiverOperationRoots(binding, statement, receiverRootDemands),
+      invocationAnalysisState
     );
     if (invocation.opaqueImportedCall) {
       importedEffects.add(statement);


### PR DESCRIPTION
## Summary

- cap callable provenance and invocation expansion with a module-wide work budget
- fall back conservatively at the current statement while preserving argument, capture, constructor, accessor, returned-closure, and imported effects
- cache transitive binding references and keep tiny effect-free leaves precise after the budget is exhausted
- add regression coverage for shared call DAGs, broad provenance, and later imported effects

## Motivation

#390 fixes the imported-root cohort expansion that caused #384. This follow-up guards the remaining general case: local callable DAGs can still multiply invocation analysis exponentially even without imports.

## Verification

- `bun run --filter @wyw-in-js/transform test` — 1612 passed, 1 skipped, 1 todo
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform build:esm`
- targeted ESLint
- `bun run --filter @wyw-in-js/transform perf:shaker-scaling`
- direct shaker run on the 2.3 MB `ag-grid-community@36.1.0` ESM bundle