### PR TITLE
fix(turbopack-loader): reuse resolved transform dependencies

### DIFF
--- a/.changeset/calm-turbopack-packages.md
+++ b/.changeset/calm-turbopack-packages.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/turbopack-loader': patch
+'@wyw-in-js/transform': patch
+---
+
+Preserve resolved transform dependency paths so the Turbopack loader can register them without resolving package specifiers a second time.

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -26,6 +26,7 @@ export {
   UnprocessedEntrypointError,
 } from './transform/actions/UnprocessedEntrypointError';
 export type {
+  DependencyResolution,
   Dependencies,
   ITransformFileResult,
   JSONArray,

--- a/packages/transform/src/transform/actions/types.ts
+++ b/packages/transform/src/transform/actions/types.ts
@@ -3,6 +3,7 @@ import type { RawSourceMap } from 'source-map';
 
 import type { WYWTransformDiagnostic } from '../../utils/TransformDiagnostics';
 import type { WYWTransformResultMetadata } from '../../utils/TransformMetadata';
+import type { DependencyResolution } from '../../types';
 
 export interface IExtracted {
   cssSourceMapText: string;
@@ -20,6 +21,7 @@ export interface IWorkflowActionLinariaResult
   extends IExtracted,
     IWorkflowActionNonLinariaResult {
   dependencies: string[];
+  dependencyResolutions?: DependencyResolution[];
   diagnostics?: WYWTransformDiagnostic[];
   metadata?: WYWTransformResultMetadata;
 }

--- a/packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts
@@ -33,6 +33,11 @@ describe('workflow metadata output', () => {
 
   it('omits metadata when outputMetadata is disabled', () => {
     const entrypoint = createEntrypoint(services, '/src/entry.tsx', [], code);
+    entrypoint.addDependency({
+      only: ['*'],
+      resolved: '/resolved/dep.ts',
+      source: '/dep.ts',
+    });
     entrypoint.setTransformResult({
       code,
       metadata: {
@@ -99,6 +104,12 @@ describe('workflow metadata output', () => {
     });
     expectIteratorReturnResult(finalResult);
     expect('metadata' in finalResult.value).toBe(false);
+    expect(finalResult.value).toMatchObject({
+      dependencies: ['/dep.ts'],
+      dependencyResolutions: [
+        { resolved: '/resolved/dep.ts', source: '/dep.ts' },
+      ],
+    });
   });
 
   it('returns normalized metadata when outputMetadata is enabled', () => {

--- a/packages/transform/src/transform/generators/workflow.ts
+++ b/packages/transform/src/transform/generators/workflow.ts
@@ -9,6 +9,15 @@ const isLoadedEntrypointWithoutArtifacts = (
   entrypoint.initialCode !== undefined &&
   entrypoint.only.includes('__wywPreval');
 
+const collectDependencyResolutions = (
+  entrypoint: IWorkflowAction['entrypoint'],
+  dependencies: readonly string[]
+) =>
+  dependencies.flatMap((source) => {
+    const resolved = entrypoint.dependencies.get(source)?.resolved;
+    return resolved ? [{ resolved, source }] : [];
+  });
+
 /**
  * The entry point for file processing. Sequentially calls `processEntrypoint`,
  * `evalFile`, `collect`, and `extract`. Returns the result of transforming
@@ -97,6 +106,10 @@ export function* workflow(
 
     const prevalPayload = evalStageResult;
     const { dependencies } = prevalPayload;
+    const dependencyResolutions = collectDependencyResolutions(
+      entrypoint,
+      dependencies
+    );
 
     // *** 3rd stage ***
 
@@ -152,6 +165,7 @@ export function* workflow(
       ...extractStageResult,
       code: collectStageResult.code ?? '',
       dependencies,
+      ...(dependencyResolutions.length > 0 ? { dependencyResolutions } : {}),
       ...(diagnostics.length > 0 ? { diagnostics } : {}),
       ...(metadata ? { metadata } : {}),
       replacements: [

--- a/packages/transform/src/types.ts
+++ b/packages/transform/src/types.ts
@@ -31,6 +31,11 @@ export type ParentEntrypoint = {
 
 export type Dependencies = string[];
 
+export type DependencyResolution = {
+  resolved: string;
+  source: string;
+};
+
 export interface ITransformFileResult {
   code: string;
   metadata: WYWTransformMetadata | null;
@@ -43,6 +48,7 @@ export type Result = {
   cssSourceMapText?: string;
   cssText?: string;
   dependencies?: string[];
+  dependencyResolutions?: DependencyResolution[];
   diagnostics?: WYWTransformDiagnostic[];
   metadata?: WYWTransformResultMetadata;
   replacements?: Replacement[];

--- a/packages/turbopack-loader/src/__tests__/loader.test.ts
+++ b/packages/turbopack-loader/src/__tests__/loader.test.ts
@@ -160,12 +160,14 @@ describe('turbopack-loader', () => {
     expect(emitted.code).toBe(':global(.a){color:red}');
   });
 
-  it('keeps CSS output when Turbopack cannot post-resolve a package dependency', async () => {
+  it('registers resolved transform dependencies without resolving them again', async () => {
     const { default: turbopackLoader } = await import('../index');
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-turbo-'));
     const resourcePath = path.join(tmpDir, 'entry.tsx');
     const depPath = path.join(tmpDir, 'dep.tsx');
+    const zodPath = path.join(tmpDir, 'node_modules', 'zod', 'index.js');
+    const motionPath = path.join(tmpDir, 'node_modules', 'motion', 'react.js');
     fs.writeFileSync(resourcePath, 'export const x = 1;\n');
     fs.writeFileSync(depPath, 'export const y = 1;\n');
 
@@ -174,7 +176,11 @@ describe('turbopack-loader', () => {
         code,
         sourceMap: null,
         cssText: '.a{color:red}',
-        dependencies: ['motion/react', './dep'],
+        dependencies: ['zod', 'motion/react', './dep'],
+        dependencyResolutions: [
+          { resolved: `${zodPath}?esm`, source: 'zod' },
+          { resolved: motionPath, source: 'motion/react' },
+        ],
       };
     });
 
@@ -199,12 +205,6 @@ describe('turbopack-loader', () => {
           getResolve: () => async (_context: string, request: string) => {
             resolveRequests.push(request);
 
-            if (request === 'motion/react') {
-              throw new Error(
-                "Unable to resolve module 'motion' with subpath '/react'"
-              );
-            }
-
             if (request === './dep') {
               return `${depPath}?compiled`;
             }
@@ -218,8 +218,53 @@ describe('turbopack-loader', () => {
       );
     });
 
-    expect(resolveRequests).toEqual(['motion/react', './dep']);
+    expect(resolveRequests).toEqual(['./dep']);
+    expect(addDependency).toHaveBeenCalledWith(zodPath);
+    expect(addDependency).toHaveBeenCalledWith(motionPath);
     expect(addDependency).toHaveBeenCalledWith(depPath);
     expect(emitted.code).toContain('import "./entry.wyw-in-js.module.css";');
+  });
+
+  it('keeps resolution failures fatal when the transform has no resolved path', async () => {
+    const { default: turbopackLoader } = await import('../index');
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-turbo-'));
+    const resourcePath = path.join(tmpDir, 'entry.tsx');
+    const resolutionError = new Error(
+      'Unable to resolve module "\'zod\'" in [project]/pages'
+    );
+    fs.writeFileSync(resourcePath, 'export const x = 1;\n');
+
+    transformMock.mockImplementation(async (_services, code) => {
+      return {
+        code,
+        sourceMap: null,
+        cssText: '.a{color:red}',
+        dependencies: ['zod'],
+      };
+    });
+
+    const runLoader = new Promise<void>((resolve, reject) => {
+      turbopackLoader.call(
+        {
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null) => {
+            if (err) reject(err);
+            else resolve();
+          },
+          emitWarning: jest.fn(),
+          getOptions: () => ({}),
+          getResolve: () => async () => {
+            throw resolutionError;
+          },
+          resourcePath,
+        } as any,
+        fs.readFileSync(resourcePath, 'utf8'),
+        null
+      );
+    });
+
+    await expect(runLoader).rejects.toBe(resolutionError);
   });
 });

--- a/packages/turbopack-loader/src/index.ts
+++ b/packages/turbopack-loader/src/index.ts
@@ -5,7 +5,11 @@ import type { RawSourceMap } from 'source-map';
 import type { LoaderContext, RawLoaderDefinitionFunction } from 'webpack';
 
 import { logger } from '@wyw-in-js/shared';
-import type { PluginOptions, Result } from '@wyw-in-js/transform';
+import type {
+  DependencyResolution,
+  PluginOptions,
+  Result,
+} from '@wyw-in-js/transform';
 import { transform, TransformCacheCollection } from '@wyw-in-js/transform';
 
 import { makeCssModuleGlobal } from './css-modules';
@@ -25,49 +29,6 @@ const stripQueryAndHash = (request: string) => {
   if (hashIdx === -1) return request.slice(0, queryIdx);
 
   return request.slice(0, Math.min(queryIdx, hashIdx));
-};
-
-const getPackageNameForSubpath = (request: string) => {
-  const fileRequest = stripQueryAndHash(request);
-  if (
-    fileRequest.startsWith('.') ||
-    path.isAbsolute(fileRequest) ||
-    path.win32.isAbsolute(fileRequest)
-  ) {
-    return null;
-  }
-
-  const parts = fileRequest.split('/');
-
-  if (fileRequest.startsWith('@')) {
-    const [scope, name] = parts;
-    if (parts.length <= 2 || scope.length <= 1 || !name) {
-      return null;
-    }
-
-    return `${scope}/${name}`;
-  }
-
-  if (fileRequest.startsWith('#') || parts.length <= 1 || !parts[0]) {
-    return null;
-  }
-
-  return parts[0];
-};
-
-const isTurbopackPackageSubpathResolveError = (
-  request: string,
-  error: unknown
-) => {
-  const packageName = getPackageNameForSubpath(request);
-
-  return (
-    packageName !== null &&
-    error instanceof Error &&
-    error.message.includes(
-      `Unable to resolve module '${packageName}' with subpath`
-    )
-  );
 };
 
 export type LoaderOptions = {
@@ -191,14 +152,20 @@ const turbopackLoader: Loader = function turbopackLoader(
     return result;
   };
 
-  const addResolvedDependency = async (dependency: string) => {
-    try {
-      await asyncResolve(dependency, this.resourcePath);
-    } catch (error) {
-      if (!isTurbopackPackageSubpathResolveError(dependency, error)) {
-        throw error;
+  const addResolvedDependency = async (
+    dependency: string,
+    dependencyResolutions: ReadonlyMap<string, string>
+  ) => {
+    const resolved = dependencyResolutions.get(dependency);
+    if (resolved) {
+      const filePath = stripQueryAndHash(resolved);
+      if (path.isAbsolute(filePath)) {
+        this.addDependency(filePath);
+        return;
       }
     }
+
+    await asyncResolve(dependency, this.resourcePath);
   };
 
   const transformServices = {
@@ -226,6 +193,11 @@ const turbopackLoader: Loader = function turbopackLoader(
 
       if (rawCssText.trim()) {
         let cssText = makeCssModuleGlobal(rawCssText);
+        const dependencyResolutions = new Map(
+          (result.dependencyResolutions ?? []).map(
+            ({ resolved, source }: DependencyResolution) => [source, resolved]
+          )
+        );
 
         if (sourceMap && typeof result.cssSourceMapText !== 'undefined') {
           cssText += `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
@@ -234,7 +206,9 @@ const turbopackLoader: Loader = function turbopackLoader(
         }
 
         await Promise.all(
-          (result.dependencies ?? []).map((dep) => addResolvedDependency(dep))
+          (result.dependencies ?? []).map((dep) =>
+            addResolvedDependency(dep, dependencyResolutions)
+          )
         );
 
         if (outputCss) {


### PR DESCRIPTION
## Summary

- expose source-to-resolved dependency paths in transform results
- use preserved absolute paths in the Turbopack loader instead of resolving package specifiers twice
- keep resolver errors fatal when no resolved path is available and remove Turbopack error-message matching

## Testing

- bun run --filter @wyw-in-js/turbopack-loader test
- bun run --filter @wyw-in-js/turbopack-loader lint
- bun run --filter @wyw-in-js/transform lint
- type and ESM builds for @wyw-in-js/transform and @wyw-in-js/turbopack-loader
- production npm run build in the issue reproduction with Next 16.3.1, zod, and zod/v4

Closes #392