### PR TITLE
Update repository URLs after organization transfer

### DIFF
--- a/apps/website/theme.config.js
+++ b/apps/website/theme.config.js
@@ -6,9 +6,9 @@ export default {
   primaryHue: 210,
   primarySaturation: 100,
   docsRepositoryBase:
-    'https://github.com/Anber/wyw-in-js/tree/main/apps/website',
+    'https://github.com/wyw-in-js/wyw-in-js/tree/main/apps/website',
   project: {
-    link: 'https://github.com/Anber/wyw-in-js',
+    link: 'https://github.com/wyw-in-js/wyw-in-js',
   },
   useNextSeoProps() {
     return {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "",
   "version": "2.0.0-alpha.0",
   "author": "Anton Evzhakov",
-  "bugs": "https://github.com/Anber/wyw-in-js/issues",
+  "bugs": "https://github.com/wyw-in-js/wyw-in-js/issues",
   "devDependencies": {
     "@babel/core": "^7.23.5",
     "@babel/eslint-parser": "^7.23.3",
@@ -62,11 +62,11 @@
   "exports": {
     "./*.md": "./*.md"
   },
-  "homepage": "https://github.com/Anber/wyw-in-js#readme",
+  "homepage": "https://github.com/wyw-in-js/wyw-in-js#readme",
   "keywords": [],
   "license": "MIT",
   "private": true,
-  "repository": "git@github.com:Anber/wyw-in-js.git",
+  "repository": "git@github.com:wyw-in-js/wyw-in-js.git",
   "packageManager": "bun@1.3.5",
   "scripts": {
     "build": "turbo run build:esm build:types --filter \"./packages/*\"",

--- a/packages/shared/src/findPackageJSON.ts
+++ b/packages/shared/src/findPackageJSON.ts
@@ -90,7 +90,7 @@ export function findPackageJSON(
     }
 
     if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-      // See https://github.com/Anber/wyw-in-js/issues/43
+      // See https://github.com/wyw-in-js/wyw-in-js/issues/43
       // `require` can't resolve ESM-only packages. We can use the `resolve`
       // package here, but it does not solve all cases because `pkgName`
       // can be an alias and should be resolved by a bundler. However, we can't use


### PR DESCRIPTION
Update canonical GitHub URLs from Anber/wyw-in-js to wyw-in-js/wyw-in-js after transferring the repository.