### PR TITLE
fix(transform): preserve static values after primitive call arguments

### DIFF
--- a/.changeset/calm-cats-guard.md
+++ b/.changeset/calm-cats-guard.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Treat opaque calls as capability-bounded during mutation analysis, keeping later static interpolations eligible when direct imported member arguments resolve to immutable primitives. Calls can still invalidate object-valued arguments; ambient writes through globals, closures, or the callee's own imports remain the application author's responsibility.

--- a/e2e/bun/src/classnames.ts
+++ b/e2e/bun/src/classnames.ts
@@ -1,0 +1,2 @@
+export const cx = (...values: string[]): string =>
+  values.filter(Boolean).join(' ');

--- a/e2e/bun/src/plugin.test.ts
+++ b/e2e/bun/src/plugin.test.ts
@@ -103,4 +103,19 @@ describe('Bun bundler', () => {
 
     expect(cssOutput).toMatch(/color:\s*(rebeccapurple|#639)/i);
   });
+
+  it('statically resolves interpolations declared after cx()', async () => {
+    await rm(outDir, { recursive: true, force: true });
+
+    const cssOutput = normalizeLineEndings(
+      await buildArtefact(
+        outDir,
+        { eval: { strategy: 'static' } },
+        'static-cx-order.ts'
+      )
+    );
+
+    expect(cssOutput).toContain('border-top: var(--borderSeparator)');
+    expect(cssOutput).toContain('border-top: var(--borderSeparatorDimmed)');
+  });
 });

--- a/e2e/bun/src/static-cx-order-tokens.ts
+++ b/e2e/bun/src/static-cx-order-tokens.ts
@@ -1,0 +1,9 @@
+export const textClasses = {
+  regular: 'regular',
+  small: 'small',
+};
+
+export const themeVars = {
+  borderSeparator: 'var(--borderSeparator)',
+  borderSeparatorDimmed: 'var(--borderSeparatorDimmed)',
+};

--- a/e2e/bun/src/static-cx-order.ts
+++ b/e2e/bun/src/static-cx-order.ts
@@ -4,6 +4,7 @@ import { cx } from './classnames';
 import { textClasses, themeVars } from './static-cx-order-tokens';
 
 export const text = cx(textClasses.regular, textClasses.small);
+export const smallText = cx(textClasses.small);
 
 export const separator = css`
   border-top: ${themeVars.borderSeparator};

--- a/e2e/bun/src/static-cx-order.ts
+++ b/e2e/bun/src/static-cx-order.ts
@@ -1,0 +1,14 @@
+import { css } from '@wyw-in-js/template-tag-syntax';
+
+import { cx } from './classnames';
+import { textClasses, themeVars } from './static-cx-order-tokens';
+
+export const text = cx(textClasses.regular, textClasses.small);
+
+export const separator = css`
+  border-top: ${themeVars.borderSeparator};
+`;
+
+export const dimmedSeparator = css`
+  border-top: ${themeVars.borderSeparatorDimmed};
+`;

--- a/packages/transform/src/__tests__/transform.static-cx-declaration-order.test.ts
+++ b/packages/transform/src/__tests__/transform.static-cx-declaration-order.test.ts
@@ -1,0 +1,193 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { PluginOptions } from '../types';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver = () => async (what: string, importer: string) => {
+  if (what === 'test-css-processor') {
+    return processorFile;
+  }
+  if (what.startsWith('.')) {
+    const base = resolve(dirname(importer), what);
+    for (const ext of ['', '.ts', '.tsx', '.js']) {
+      if (existsSync(base + ext)) {
+        return base + ext;
+      }
+    }
+    return base;
+  }
+  return null;
+};
+
+const TOKENS = dedent`
+  export const themeVars = {
+    borderSeparator: 'var(--borderSeparator)',
+    borderSeparatorDimmed: 'var(--borderSeparatorDimmed)',
+  };
+  export const textClasses = { regular: 'regular', small: 'small' };
+`;
+
+const runStatic = async (source: string, tokens = TOKENS) => {
+  const root = mkdtempSync(join(tmpdir(), 'wyw-cx-order-'));
+  const entryFile = join(root, 'entry.tsx');
+  writeFileSync(join(root, 'tokens.ts'), tokens);
+  writeFileSync(entryFile, source);
+
+  try {
+    return await transform(
+      {
+        cache: new TransformCacheCollection(),
+        options: {
+          filename: entryFile,
+          root,
+          pluginOptions: {
+            configFile: false,
+            eval: { require: 'off', strategy: 'static' },
+            tagResolver: (tagSource: string, tag: string) =>
+              tagSource === 'test-css-processor' && tag === 'css'
+                ? processorFile
+                : null,
+          } as Partial<PluginOptions> as PluginOptions,
+        },
+      },
+      readFileSync(entryFile, 'utf8'),
+      createResolver()
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+const HEADER = dedent`
+  import { css, cx } from 'test-css-processor';
+  import { textClasses, themeVars } from './tokens';
+`;
+
+const FIRST = 'const a = css`border-top: ${themeVars.borderSeparator};`;';
+const SECOND =
+  'const b = css`border-top: ${themeVars.borderSeparatorDimmed};`;';
+const CX_WITH_CSS = 'const g = cx(textClasses.regular, css`min-height: 0;`);';
+const CX_WITHOUT_CSS = 'const g = cx(textClasses.regular, textClasses.small);';
+const PLAIN_CSS = 'const p = css`display: none;`;';
+const CX_LITERALS_ONLY = "const g = cx('one', 'two');";
+const CX_CSS_ONLY = 'const g = cx(css`min-height: 0;`);';
+const LOCAL_CALL_WITH_IMPORT = [
+  'const identity = (value) => value;',
+  'const g = identity(textClasses.regular);',
+].join('\n');
+
+const source = (...parts: string[]) =>
+  [HEADER, '', ...parts, '', 'export const all = [a, b];'].join('\n');
+
+describe('static eval of css tags declared after a module-level cx()', () => {
+  const expectResolved = (cssText: string) => {
+    expect(cssText).toContain('border-top:var(--borderSeparator)');
+    expect(cssText).toContain('border-top:var(--borderSeparatorDimmed)');
+  };
+
+  it('resolves both tags when no cx() is present', async () => {
+    const result = await runStatic(source(FIRST, SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves both tags when cx() comes last', async () => {
+    const result = await runStatic(source(FIRST, SECOND, CX_WITH_CSS));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves both tags when cx() comes first', async () => {
+    const result = await runStatic(source(CX_WITH_CSS, FIRST, SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves the tag that follows a cx() in the middle', async () => {
+    const result = await runStatic(source(FIRST, CX_WITH_CSS, SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves tags after a cx() that takes no css argument', async () => {
+    const result = await runStatic(source(CX_WITHOUT_CSS, FIRST, SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves a tag declared after both a plain css tag and a cx()', async () => {
+    const result = await runStatic(
+      source(PLAIN_CSS, CX_WITH_CSS, FIRST, SECOND)
+    );
+    expectResolved(result.cssText);
+  });
+
+  it('resolves when nothing interpolated follows the cx()', async () => {
+    const result = await runStatic(
+      source(FIRST, SECOND, CX_WITH_CSS, PLAIN_CSS)
+    );
+    expectResolved(result.cssText);
+  });
+
+  it('resolves after a cx() called with only literals', async () => {
+    const result = await runStatic(source(CX_LITERALS_ONLY, FIRST, SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves after a cx() called with only a css tag', async () => {
+    const result = await runStatic(source(CX_CSS_ONLY, FIRST, SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves after a local function called with an imported binding', async () => {
+    const result = await runStatic(
+      source(LOCAL_CALL_WITH_IMPORT, FIRST, SECOND)
+    );
+    expectResolved(result.cssText);
+  });
+
+  it('keeps an object-valued member argument hazardous', async () => {
+    const tokens = dedent`
+      export const themeVars = {
+        borderSeparator: 'var(--borderSeparator)',
+        borderSeparatorDimmed: 'var(--borderSeparatorDimmed)',
+      };
+      export const textClasses = {
+        regular: { value: 'regular' },
+        small: 'small',
+      };
+    `;
+
+    await expect(
+      runStatic(source(CX_WITHOUT_CSS, FIRST, SECOND), tokens)
+    ).rejects.toThrow('an earlier call may mutate an imported value');
+  });
+
+  it('keeps an accessor member argument hazardous', async () => {
+    const tokens = dedent`
+      export const themeVars = {
+        borderSeparator: 'var(--borderSeparator)',
+        borderSeparatorDimmed: 'var(--borderSeparatorDimmed)',
+      };
+      export const textClasses = {
+        get regular() {
+          themeVars.borderSeparator = 'changed';
+          return 'regular';
+        },
+        small: 'small',
+      };
+    `;
+
+    await expect(
+      runStatic(source(CX_WITHOUT_CSS, FIRST, SECOND), tokens)
+    ).rejects.toThrow('an earlier call may mutate an imported value');
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-imported-member-const.test.ts
+++ b/packages/transform/src/__tests__/transform.static-imported-member-const.test.ts
@@ -1,0 +1,142 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { PluginOptions } from '../types';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver = () => async (what: string, importer: string) => {
+  if (what === 'test-css-processor') {
+    return processorFile;
+  }
+  if (what.startsWith('.')) {
+    const base = resolve(dirname(importer), what);
+    for (const ext of ['', '.ts', '.tsx', '.js']) {
+      if (existsSync(base + ext)) {
+        return base + ext;
+      }
+    }
+    return base;
+  }
+  return null;
+};
+
+const TOKENS = dedent`
+  export const space = { s4: 4 };
+  export const themeVars = { sep: 'var(--sep)' };
+  export const textClasses = { regular: 'regular' };
+`;
+
+const runStatic = async (source: string) => {
+  const root = mkdtempSync(join(tmpdir(), 'wyw-member-const-'));
+  const entryFile = join(root, 'entry.ts');
+  writeFileSync(join(root, 'tokens.ts'), TOKENS);
+  writeFileSync(entryFile, source);
+
+  try {
+    return await transform(
+      {
+        cache: new TransformCacheCollection(),
+        options: {
+          filename: entryFile,
+          root,
+          pluginOptions: {
+            configFile: false,
+            eval: { require: 'off', strategy: 'static' },
+            tagResolver: (tagSource: string, tag: string) =>
+              tagSource === 'test-css-processor' && tag === 'css'
+                ? processorFile
+                : null,
+          } as Partial<PluginOptions> as PluginOptions,
+        },
+      },
+      readFileSync(entryFile, 'utf8'),
+      createResolver()
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+const HEADER = dedent`
+  import { css, cx } from 'test-css-processor';
+  import { space, textClasses, themeVars } from './tokens';
+`;
+
+const TEMPLATE_CONST = 'const helper = `0 1px 0 0 ${themeVars.sep}`;';
+const OBJECT_CONST = 'const helper = {boxShadow: `x ${themeVars.sep}`};';
+const MEMBER_CONST = 'const helper = themeVars.sep;';
+const LITERAL_CONST = "const helper = '0 1px';";
+const CX_CALL = 'export const g = cx(css`z-index: 800;`, textClasses.regular);';
+const INTERPOLATED = 'export const a = css`padding: ${space.s4}px;`;';
+
+const source = (...parts: string[]) => [HEADER, '', ...parts].join('\n');
+
+/**
+ * A module-level const that merely *reads* an imported member makes a later
+ * interpolation unresolvable once any `cx()` call sits between them.
+ *
+ * The const is not referenced by either tag and is never mutated; reading
+ * `themeVars.sep` into a local is enough. Replacing the initialiser with a
+ * literal, dropping the `cx()` call, or declaring the interpolated tag before
+ * the call all resolve, so the three ingredients are jointly required.
+ */
+describe('static eval with a module-level imported-member const', () => {
+  const expectResolved = (cssText: string) => {
+    expect(cssText).toContain('padding:4px');
+  };
+
+  it('resolves with a template-literal const before the cx() call', async () => {
+    const result = await runStatic(
+      source(TEMPLATE_CONST, CX_CALL, INTERPOLATED)
+    );
+    expectResolved(result.cssText);
+  });
+
+  it('resolves with an object const before the cx() call', async () => {
+    const result = await runStatic(source(OBJECT_CONST, CX_CALL, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves with a bare member const before the cx() call', async () => {
+    const result = await runStatic(source(MEMBER_CONST, CX_CALL, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+
+  // Controls: each drops one of the three ingredients and passes today.
+
+  it('resolves without the const', async () => {
+    const result = await runStatic(source(CX_CALL, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves without the cx() call', async () => {
+    const result = await runStatic(source(TEMPLATE_CONST, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves when the const initialiser is a literal', async () => {
+    const result = await runStatic(
+      source(LITERAL_CONST, CX_CALL, INTERPOLATED)
+    );
+    expectResolved(result.cssText);
+  });
+
+  it('resolves when the interpolated tag precedes the cx() call', async () => {
+    const result = await runStatic(
+      source(TEMPLATE_CONST, INTERPOLATED, CX_CALL)
+    );
+    expectResolved(result.cssText);
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-multiple-cx-calls.test.ts
+++ b/packages/transform/src/__tests__/transform.static-multiple-cx-calls.test.ts
@@ -1,0 +1,136 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { PluginOptions } from '../types';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver = () => async (what: string, importer: string) => {
+  if (what === 'test-css-processor') {
+    return processorFile;
+  }
+  if (what.startsWith('.')) {
+    const base = resolve(dirname(importer), what);
+    for (const ext of ['', '.ts', '.tsx', '.js']) {
+      if (existsSync(base + ext)) {
+        return base + ext;
+      }
+    }
+    return base;
+  }
+  return null;
+};
+
+const TOKENS = dedent`
+  export const space = { s6: 6, s10: 10 };
+  export const fontWeight = { medium: 500 };
+  export const themeVars = { fg: 'var(--fg)' };
+  export const textClasses = { regular: 'regular', small: 'small' };
+`;
+
+const runStatic = async (source: string) => {
+  const root = mkdtempSync(join(tmpdir(), 'wyw-multi-cx-'));
+  const entryFile = join(root, 'entry.ts');
+  writeFileSync(join(root, 'tokens.ts'), TOKENS);
+  writeFileSync(entryFile, source);
+
+  try {
+    return await transform(
+      {
+        cache: new TransformCacheCollection(),
+        options: {
+          filename: entryFile,
+          root,
+          pluginOptions: {
+            configFile: false,
+            eval: { require: 'off', strategy: 'static' },
+            tagResolver: (tagSource: string, tag: string) =>
+              tagSource === 'test-css-processor' && tag === 'css'
+                ? processorFile
+                : null,
+          } as Partial<PluginOptions> as PluginOptions,
+        },
+      },
+      readFileSync(entryFile, 'utf8'),
+      createResolver()
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+const HEADER = dedent`
+  import { css, cx } from 'test-css-processor';
+  import { fontWeight, space, textClasses, themeVars } from './tokens';
+`;
+
+const CX_FIRST =
+  'const t1 = cx(textClasses.regular, css`font-weight: ${fontWeight.medium};`);';
+const CX_SECOND =
+  'const t2 = cx(textClasses.small, css`color: ${themeVars.fg};`);';
+const CX_THIRD = 'const t3 = cx(textClasses.regular, css`z-index: 1;`);';
+const CX_NO_IMPORTED_ARG = [
+  'const t1 = cx(css`font-weight: 500;`);',
+  'const t2 = cx(css`color: red;`);',
+].join('\n');
+const INTERPOLATED =
+  'export const c = css`gap: ${space.s6}px; padding: ${space.s10}px;`;';
+
+const source = (...parts: string[]) => [HEADER, '', ...parts].join('\n');
+
+/**
+ * A second `cx(importedMember, css``)` at module scope re-poisons the static
+ * candidates that the first one leaves resolvable.
+ *
+ * One such call is handled: the imported member resolves to a string, so the
+ * capability-bounded guard discharges the hazard. Adding a second identical
+ * call makes every interpolation declared after it unresolvable again, so the
+ * count of failures tracks the tags that follow rather than the calls
+ * themselves.
+ */
+describe('static eval after multiple module-level cx() calls', () => {
+  const expectResolved = (cssText: string) => {
+    expect(cssText).toContain('gap:6px');
+    expect(cssText).toContain('padding:10px');
+  };
+
+  it('resolves after a single cx()', async () => {
+    const result = await runStatic(source(CX_FIRST, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves after two cx() calls', async () => {
+    const result = await runStatic(source(CX_FIRST, CX_SECOND, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves after three cx() calls', async () => {
+    const result = await runStatic(
+      source(CX_FIRST, CX_SECOND, CX_THIRD, INTERPOLATED)
+    );
+    expectResolved(result.cssText);
+  });
+
+  // Controls: these pass today and bound the defect.
+
+  it('resolves when the interpolated tag precedes both cx() calls', async () => {
+    const result = await runStatic(source(INTERPOLATED, CX_FIRST, CX_SECOND));
+    expectResolved(result.cssText);
+  });
+
+  it('resolves after two cx() calls that take no imported member', async () => {
+    const result = await runStatic(source(CX_NO_IMPORTED_ARG, INTERPOLATED));
+    expectResolved(result.cssText);
+  });
+});

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -63,6 +63,16 @@ export interface IPreevalResult {
       local: string;
       source: string;
     }>;
+    mutationGuards?: Array<{
+      importedFrom: string[];
+      imports: Array<{
+        imported: 'default' | string;
+        importLocal?: string;
+        local: string;
+        source: string;
+      }>;
+      source: string;
+    }>;
     name: string;
     source: string;
   }>;

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
@@ -6,6 +6,7 @@ import {
   evaluateOxcStaticExpression,
   isOxcStaticSerializableValue,
   lookupStaticBinding,
+  type OxcStaticImportReference,
   type OxcStaticValueCandidate,
 } from '../../../utils/collectOxcTemplateDependencies';
 import type { ITransformAction, SyncScenarioFor } from '../../types';
@@ -28,6 +29,48 @@ export type CandidateSideEffectProvenance = {
   dependencies: string[];
   importLocals: string[];
 };
+
+function* resolveCandidateImport(
+  action: ITransformAction,
+  filename: string,
+  item: OxcStaticImportReference,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const staticBindings = getStaticBindings(action);
+  let override = lookupStaticBinding(
+    staticBindings,
+    item.source,
+    item.imported
+  );
+  if (!override.found && staticBindings) {
+    const dep = yield* resolveDependency(
+      action,
+      filename,
+      item.source,
+      item.imported
+    );
+    if (dep?.resolved) {
+      override = lookupStaticBinding(
+        staticBindings,
+        dep.resolved,
+        item.imported
+      );
+    }
+  }
+  if (override.found) {
+    return { dependencies: [], value: override.value };
+  }
+
+  return yield* resolveImportValue(action, filename, item, new Set(), memo);
+}
+
+const isImmutablePrimitive = (value: unknown): boolean =>
+  value === null ||
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean' ||
+  typeof value === 'bigint' ||
+  typeof value === 'symbol';
 
 /**
  * Proves which imports must remain for CSS artifacts produced by the import
@@ -106,36 +149,10 @@ export function* resolveCandidateValue(
     // absolute path and try again — this lets the host key by
     // absolute file path so a single entry covers every relative
     // variant of the same module.
-    let override = lookupStaticBinding(
-      staticBindingsForCandidate,
-      item.source,
-      item.imported
-    );
-    if (!override.found && staticBindingsForCandidate) {
-      const dep = yield* resolveDependency(
-        action,
-        filename,
-        item.source,
-        item.imported
-      );
-      if (dep?.resolved) {
-        override = lookupStaticBinding(
-          staticBindingsForCandidate,
-          dep.resolved,
-          item.imported
-        );
-      }
-    }
-    if (override.found) {
-      env.set(item.local, override.value);
-      continue;
-    }
-
-    const resolved = yield* resolveImportValue(
+    const resolved = yield* resolveCandidateImport(
       action,
       filename,
       item,
-      new Set(),
       memo
     );
     if (!resolved) {
@@ -191,6 +208,47 @@ export function* resolveCandidateValue(
       sideEffectDependencies.add(dependency);
       sideEffectImportLocals.add(item.importLocal ?? item.local);
     });
+  }
+
+  for (const guard of candidate.mutationGuards ?? []) {
+    const guardEnv = new Map<string, unknown>();
+    let resolvedGuard = true;
+    for (const item of guard.imports) {
+      const resolved = yield* resolveCandidateImport(
+        action,
+        filename,
+        item,
+        memo
+      );
+      if (!resolved) {
+        resolvedGuard = false;
+        break;
+      }
+
+      guardEnv.set(item.local, resolved.value);
+      resolved.dependencies.forEach((dependency) =>
+        dependencies.add(dependency)
+      );
+    }
+
+    const guardValue = resolvedGuard
+      ? evaluateOxcStaticExpression(
+          guard.source,
+          filename,
+          guardEnv,
+          staticBindingsForCandidate
+        )
+      : undefined;
+    if (guardValue === undefined || !isImmutablePrimitive(guardValue)) {
+      debugStaticResolve(action, {
+        candidate: candidate.name,
+        filename,
+        phase: 'candidate',
+        reason: 'candidate-mutation-guard-unresolved',
+        status: 'rejected',
+      });
+      return reject('candidate-mutation-guard-unresolved');
+    }
   }
 
   if (candidateExpression === undefined) {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -45,6 +45,7 @@ export const getEvalStrategy = (action: ITransformAction) =>
 export type StaticRejectionReason =
   | 'candidate-import-unresolved'
   | 'candidate-callable-usage-unsupported'
+  | 'candidate-mutation-guard-unresolved'
   | 'candidate-expression-non-serializable'
   | 'candidate-expression-undefined'
   | 'runtime-callback'
@@ -53,6 +54,8 @@ export type StaticRejectionReason =
 const reasonExplanations: Record<StaticRejectionReason, string> = {
   'candidate-import-unresolved': "imported value isn't statically analyzable",
   'candidate-callable-usage-unsupported': 'depends on a runtime function call',
+  'candidate-mutation-guard-unresolved':
+    'an earlier call may mutate an imported value',
   'candidate-expression-non-serializable':
     'value is non-serializable at build time',
   'candidate-expression-undefined':

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/processorStaticExport.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/processorStaticExport.ts
@@ -56,6 +56,14 @@ type StaticCandidateResolution = {
   sideEffectDependencies: Set<string>;
 };
 
+const isImmutablePrimitive = (value: unknown): boolean =>
+  value === null ||
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean' ||
+  typeof value === 'bigint' ||
+  typeof value === 'symbol';
+
 const isProcessorArtifactValue = (
   value: unknown,
   processors: StaticProcessorInstance[],
@@ -167,6 +175,48 @@ function* resolvePreevalStaticValueCandidates(
       resolved.sideEffectDependencies?.forEach((dependency) =>
         sideEffectDependencies.add(dependency)
       );
+    }
+
+    if (!resolvedAll) {
+      continue;
+    }
+
+    for (const guard of candidate.mutationGuards ?? []) {
+      const guardEnv = new Map<string, unknown>();
+      for (const binding of guard.imports) {
+        const resolved = yield* resolvers.resolveImportValue(
+          action,
+          filename,
+          binding,
+          stack,
+          memo
+        );
+        if (!resolved) {
+          resolvedAll = false;
+          break;
+        }
+
+        guardEnv.set(binding.local, resolved.value);
+        resolved.dependencies.forEach((dependency) =>
+          dependencies.add(dependency)
+        );
+        resolved.sideEffectDependencies?.forEach((dependency) =>
+          sideEffectDependencies.add(dependency)
+        );
+      }
+
+      const guardValue = resolvedAll
+        ? evaluateOxcStaticExpression(
+            guard.source,
+            filename,
+            guardEnv,
+            getStaticBindings(action)
+          )
+        : undefined;
+      if (guardValue === undefined || !isImmutablePrimitive(guardValue)) {
+        resolvedAll = false;
+        break;
+      }
     }
 
     if (!resolvedAll) {

--- a/packages/transform/src/transform/static-plan/buildStaticPlan.ts
+++ b/packages/transform/src/transform/static-plan/buildStaticPlan.ts
@@ -297,6 +297,17 @@ export const buildStaticPlan = ({
         source: item.source,
       });
     });
+    candidate.mutationGuards?.forEach((guard) => {
+      guard.imports.forEach((item) => {
+        needs.push({
+          importer: filename,
+          kind: 'export',
+          name: item.imported,
+          reason: 'processor-static-interpolation',
+          source: item.source,
+        });
+      });
+    });
   });
 
   const staticValueNames = unique(

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -780,6 +780,55 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     }
   );
 
+  it('retains a conditional primitive guard for an imported member argument', () => {
+    const result = collectOxcTemplateDependencies(
+      dedent`
+        import { alias, source } from './tokens';
+
+        mutate(alias.className);
+        const template = tag\`${'${source.width}'}\`;
+      `,
+      filename,
+      true
+    );
+
+    expect(result.staticValueCandidates).toEqual([
+      expect.objectContaining({
+        imports: [
+          {
+            imported: 'source',
+            local: 'source',
+            source: './tokens',
+          },
+        ],
+        mutationGuards: [
+          {
+            importedFrom: ['./tokens'],
+            imports: [
+              {
+                imported: 'alias',
+                local: 'alias',
+                source: './tokens',
+              },
+            ],
+            source: 'alias.className',
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it('drops conditional guards after alias propagation', () => {
+    expectLastWidthTemplateFallback(dedent`
+      import { alias, source } from './tokens';
+
+      const localAlias = alias;
+      mutate(localAlias.className);
+      const { width } = source;
+      const template = tag\`${'${width}'}\`;
+    `);
+  });
+
   it('propagates a sibling-import escape from a synchronous IIFE', () => {
     expectLastWidthTemplateFallback(dedent`
       import { alias, source } from './tokens';

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.hazards.test.ts
@@ -818,6 +818,29 @@ describe('collectOxcTemplateDependencies mutation provenance', () => {
     ]);
   });
 
+  it('retains direct imported guards through an earlier opaque call result', () => {
+    const result = collectOxcTemplateDependencies(
+      dedent`
+        import { alias, source } from './tokens';
+
+        const first = mutate(alias.className);
+        mutate(alias.otherClassName);
+        const template = tag\`${'${source.width}'}\`;
+      `,
+      filename,
+      true
+    );
+
+    expect(result.staticValueCandidates).toEqual([
+      expect.objectContaining({
+        mutationGuards: [
+          expect.objectContaining({ source: 'alias.className' }),
+          expect.objectContaining({ source: 'alias.otherClassName' }),
+        ],
+      }),
+    ]);
+  });
+
   it('drops conditional guards after alias propagation', () => {
     expectLastWidthTemplateFallback(dedent`
       import { alias, source } from './tokens';

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -86,6 +86,11 @@ const collectStaticPlanFacts = (
     candidate.imports.forEach(({ imported: name, source }) => {
       importedNeeds.push({ name, source });
     });
+    candidate.mutationGuards?.forEach((guard) => {
+      guard.imports.forEach(({ imported: name, source }) => {
+        importedNeeds.push({ name, source });
+      });
+    });
   });
 
   return {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
@@ -47,13 +47,14 @@ import {
 } from './snapshotReplay';
 import {
   allocateExpressionName,
+  collectBindingMutationGuardsBefore,
   collectStaticBindingExpression,
+  collectStaticMutationGuardExpression,
   containsProcessorManagedExpression,
   declarationInitCode,
   declarationPatternCode,
   expressionHasNestedCallTimeUncertainty,
   getHoistedBindingName,
-  hasBindingMutationBefore,
   hasOpaqueDestructuringHazardBefore,
   hasReferencedRootMutationBefore,
   nestedDestructuringHasCallTimeUncertainty,
@@ -69,6 +70,7 @@ import type {
   OxcStaticImportReference,
   ProgramAnalysis,
   StaticBindings,
+  StaticLocalExpression,
   TemplateExtractionResult,
 } from './types';
 
@@ -442,6 +444,7 @@ const extractExpression = (
         importedFrom: [],
         kind: isFunction ? ValueType.FUNCTION : ValueType.LAZY,
         staticImports: [],
+        staticMutationGuards: [],
         staticValue: isStaticSerializableValue(evaluated)
           ? cloneStaticValue(evaluated)
           : undefined,
@@ -459,6 +462,7 @@ const extractExpression = (
   const staticImports: OxcStaticImportReference[] = [
     ...namespaceStatic.imports,
   ];
+  const staticMutationGuards: StaticLocalExpression[] = [];
   let hasNonStaticLocalReference = preserveRuntimeIdentity;
   let hasInlinableLocalReference = false;
   let hasSnapshotReplay = preserveRuntimeIdentity;
@@ -492,9 +496,25 @@ const extractExpression = (
 
     if (binding.importedFrom) {
       importedFrom.push(binding.importedFrom);
-      if (hasBindingMutationBefore(binding, start, ctx)) {
+      const mutationGuardExpressions = collectBindingMutationGuardsBefore(
+        binding,
+        start,
+        ctx
+      );
+      if (mutationGuardExpressions === null) {
         hasNonStaticLocalReference = true;
         return;
+      }
+      for (const guardExpression of mutationGuardExpressions) {
+        const guard = collectStaticMutationGuardExpression(
+          guardExpression,
+          ctx
+        );
+        if (!guard) {
+          hasNonStaticLocalReference = true;
+          return;
+        }
+        staticMutationGuards.push(guard);
       }
 
       if (binding.imported && binding.imported !== '*') {
@@ -624,6 +644,9 @@ const extractExpression = (
     hasInlinableLocalReference:
       !hasNonStaticLocalReference && hasInlinableLocalReference,
     staticImports: hasNonStaticLocalReference ? [] : staticImports,
+    staticMutationGuards: hasNonStaticLocalReference
+      ? []
+      : staticMutationGuards,
     staticValue: preservedStaticValue,
   };
 };
@@ -673,6 +696,7 @@ const extractExpressions = (
   analysis: Pick<
     ProgramAnalysis,
     | 'bindingIndex'
+    | 'rootMutationHazardGuardsByBinding'
     | 'rootMutationHazardsByBinding'
     | 'rootMutationsByBinding'
     | 'usedNames'
@@ -711,6 +735,8 @@ const extractExpressions = (
     ),
     program,
     replacements: [],
+    rootMutationHazardGuardsByBinding:
+      analysis.rootMutationHazardGuardsByBinding,
     rootMutationHazardsByBinding: analysis.rootMutationHazardsByBinding,
     rootMutationsByBinding: analysis.rootMutationsByBinding,
     staticBindings,
@@ -752,6 +778,7 @@ const extractExpressions = (
       kind,
       staticExpressionCode,
       staticImports,
+      staticMutationGuards,
       staticValue,
     } = extractExpression(
       expression,
@@ -786,8 +813,15 @@ const extractExpressions = (
           item
         );
       });
+      const uniqueMutationGuards = new Map<string, StaticLocalExpression>();
+      staticMutationGuards.forEach((guard) => {
+        uniqueMutationGuards.set(guard.source, guard);
+      });
       ctx.staticValueCandidates.push({
         imports: [...uniqueImports.values()],
+        ...(uniqueMutationGuards.size > 0
+          ? { mutationGuards: [...uniqueMutationGuards.values()] }
+          : {}),
         name: expName,
         source: staticExpressionCode ?? expressionCode,
       });
@@ -867,6 +901,8 @@ export const evaluateOxcStaticExpressionAt = (
     ),
     program,
     replacements: [],
+    rootMutationHazardGuardsByBinding:
+      analysis.rootMutationHazardGuardsByBinding,
     rootMutationHazardsByBinding: analysis.rootMutationHazardsByBinding,
     rootMutationsByBinding: analysis.rootMutationsByBinding,
     staticBindings,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -198,12 +198,20 @@ const collectRootMutationHazards = (
   processorManagedExpressionNodes: ReadonlySet<Node>,
   ignoredHazardNodes: ReadonlySet<Node>,
   ignoredHazardTreeNodes: ReadonlySet<Node>
-): Map<string, Node[]> => {
+): {
+  guardsByBinding: Map<string, Map<Node, readonly Expression[] | null>>;
+  hazards: Map<string, Node[]>;
+} => {
   const { bindingsByName } = bindingIndex;
   const hazards = new Map<string, Node[]>();
   const factPublished = 1;
   const factStrong = 2;
   const factsByBinding = new Map<string, Map<Node, number>>();
+  const guardExpressionsByBinding = new Map<
+    string,
+    Map<Node, Expression[] | null>
+  >();
+  const guardRevisionsByBinding = new Map<string, Map<Node, number>>();
   const getFacts = (key: string): Map<Node, number> => {
     const existing = factsByBinding.get(key);
     if (existing) {
@@ -212,6 +220,51 @@ const collectRootMutationHazards = (
     const created = new Map<Node, number>();
     factsByBinding.set(key, created);
     return created;
+  };
+  const getGuardRevision = (key: string, hazard: Node): number =>
+    guardRevisionsByBinding.get(key)?.get(hazard) ?? 0;
+  const mergeGuardState = (
+    guards: Map<Node, Expression[] | null>,
+    hazard: Node,
+    incoming: readonly Expression[] | null
+  ): boolean => {
+    const current = guards.get(hazard);
+    if (current === null) {
+      return false;
+    }
+
+    let changed = false;
+    if (incoming === null) {
+      guards.set(hazard, null);
+      changed = true;
+    } else if (current === undefined) {
+      guards.set(hazard, [...incoming]);
+      changed = true;
+    } else {
+      incoming.forEach((expression) => {
+        if (!current.includes(expression)) {
+          current.push(expression);
+          changed = true;
+        }
+      });
+    }
+
+    return changed;
+  };
+  const mergeGuardExpressions = (
+    key: string,
+    hazard: Node,
+    incoming: readonly Expression[] | null
+  ): boolean => {
+    const guards = guardExpressionsByBinding.get(key) ?? new Map();
+    const changed = mergeGuardState(guards, hazard, incoming);
+    if (changed) {
+      guardExpressionsByBinding.set(key, guards);
+      const revisions = guardRevisionsByBinding.get(key) ?? new Map();
+      revisions.set(hazard, (revisions.get(hazard) ?? 0) + 1);
+      guardRevisionsByBinding.set(key, revisions);
+    }
+    return changed;
   };
 
   const modeledMutations = new Set<Node>(
@@ -320,20 +373,25 @@ const collectRootMutationHazards = (
 
   const collectDeferredReferencePolicy =
     createDeferredReferencePolicyCollector(bindingIndex);
-  const collectEagerReferenceKeys = (node: Node): string[] => {
+  const collectEagerReferences = (node: Node) => {
     const { ignoredStarts } = collectDeferredReferencePolicy(node);
     const projection = getProcessorProjection(node);
-    return collectMutationReferenceKeys(
-      node,
-      bindingIndex,
-      [
-        ignoredHazardTreeReferenceStarts,
-        ignoredStarts,
-        ...(projection ? [projection.referenceStarts] : []),
-      ],
-      toReferenceKey
+    const excludedStarts = [
+      ignoredHazardTreeReferenceStarts,
+      ignoredStarts,
+      ...(projection ? [projection.referenceStarts] : []),
+    ];
+    return getReferences(node, bindingIndex).filter((reference) =>
+      excludedStarts.every((starts) => !starts.has(reference.start))
     );
   };
+  const collectEagerReferenceKeys = (node: Node): string[] => [
+    ...new Set(
+      collectEagerReferences(node).map(({ binding, name }) =>
+        toReferenceKey(binding, name)
+      )
+    ),
+  ];
 
   const collectAliasReferenceKeys = (
     node: Node,
@@ -463,7 +521,8 @@ const collectRootMutationHazards = (
   const addHazard = (
     name: string,
     hazard: Node,
-    canAffectSiblingImport = false
+    canAffectSiblingImport = false,
+    mutationGuard?: Expression
   ): void => {
     const facts = getFacts(name);
     const current = facts.get(hazard) ?? 0;
@@ -476,15 +535,23 @@ const collectRootMutationHazards = (
       hazard,
       current | factPublished | (canAffectSiblingImport ? factStrong : 0)
     );
+    if (canAffectSiblingImport) {
+      mergeGuardExpressions(
+        name,
+        hazard,
+        mutationGuard ? [mutationGuard] : null
+      );
+    }
   };
 
   const addReferences = (
     node: Node,
     hazard: Node,
-    canAffectSiblingImport = false
+    canAffectSiblingImport = false,
+    mutationGuard?: Expression
   ): void => {
     collectEagerReferenceKeys(node).forEach((key) => {
-      addHazard(key, hazard, canAffectSiblingImport);
+      addHazard(key, hazard, canAffectSiblingImport, mutationGuard);
     });
   };
 
@@ -554,15 +621,42 @@ const collectRootMutationHazards = (
     }
 
     if (node.type === 'CallExpression') {
-      // Any object passed to unknown code, or used as a method receiver, can
-      // be mutated. Pure calls are intentionally rejected here rather than
-      // risking a stale static snapshot.
+      // Opaque calls use a capability-bounded effect model: callees may mutate
+      // objects reachable through their arguments or receiver, while ambient
+      // writes through globals, closures, or the callee's own imports are
+      // outside the static guarantee and remain the author's responsibility.
       // References inside nested processor-managed expressions are projected
       // out by addReferences because the outer invocation receives their
       // evaltime replacements, not their original interpolation inputs.
-      // Starting at the invocation keeps an inline IIFE body eager while the
-      // deferred-reference policy still skips callback arguments.
-      addReferences(node, node, true);
+      // Preserve invocation context while collecting hard references. In
+      // particular, an inline IIFE callee is eager only when the traversal
+      // starts at this CallExpression. Direct non-spread arguments retain
+      // their exact expression as a conditional proof; their precise
+      // reference starts are excluded from the hard pass below.
+      const guardedReferenceStarts = new Set<number>();
+      node.arguments.forEach((argument) => {
+        if (argument.type === 'SpreadElement') {
+          return;
+        }
+        collectEagerReferences(argument).forEach((reference) => {
+          guardedReferenceStarts.add(reference.start);
+          addHazard(
+            toReferenceKey(reference.binding, reference.name),
+            node,
+            true,
+            argument
+          );
+        });
+      });
+      collectEagerReferences(node).forEach((reference) => {
+        if (!guardedReferenceStarts.has(reference.start)) {
+          addHazard(
+            toReferenceKey(reference.binding, reference.name),
+            node,
+            true
+          );
+        }
+      });
       addExecutionUnknownAliasHazard(node.callee, node);
       node.arguments.forEach((argument) => {
         addExecutionUnknownAliasHazard(argument, node);
@@ -871,18 +965,25 @@ const collectRootMutationHazards = (
   // published hazard membership is tracked separately from modeled mutation
   // seeds. The indexes let each new fact or promotion visit only adjacent
   // links instead of rescanning the complete alias graph.
-  type WorkItem = { change: Node; key: string; strong: boolean };
+  type WorkItem = {
+    change: Node;
+    guardRevision: number;
+    key: string;
+    strong: boolean;
+  };
   const worklist: WorkItem[] = [];
   mutations.forEach((changes, key) => {
     const facts = getFacts(key);
     changes.forEach((change) => {
       facts.set(change, (facts.get(change) ?? 0) | factStrong);
+      mergeGuardExpressions(key, change, null);
     });
   });
   factsByBinding.forEach((facts, key) => {
     facts.forEach((state, change) => {
       worklist.push({
         change,
+        guardRevision: getGuardRevision(key, change),
         key,
         strong: (state & factStrong) !== 0,
       });
@@ -900,18 +1001,31 @@ const collectRootMutationHazards = (
     bucket.push(change);
     hazards.set(key, bucket);
   };
-  const addFact = (key: string, change: Node, sibling: boolean): void => {
+  const addFact = (
+    key: string,
+    change: Node,
+    sibling: boolean,
+    guards: readonly Expression[] | null = null
+  ): void => {
     const facts = getFacts(key);
-    const state = facts.get(change);
-    publishHazard(key, change);
-    if (state === undefined) {
-      facts.set(change, factPublished | (sibling ? factStrong : 0));
-      worklist.push({ change, key, strong: sibling });
-      return;
+    const state = facts.get(change) ?? 0;
+    if ((state & factPublished) === 0) {
+      const bucket = hazards.get(key) ?? [];
+      bucket.push(change);
+      hazards.set(key, bucket);
     }
-    if ((state & factStrong) === 0 && sibling) {
-      facts.set(change, state | factPublished | factStrong);
-      worklist.push({ change, key, strong: true });
+    const next = state | factPublished | (sibling ? factStrong : 0);
+    facts.set(change, next);
+    const guardsChanged = sibling
+      ? mergeGuardExpressions(key, change, guards)
+      : false;
+    if (state === 0 || next !== state || guardsChanged) {
+      worklist.push({
+        change,
+        guardRevision: getGuardRevision(key, change),
+        key,
+        strong: (next & factStrong) !== 0,
+      });
     }
   };
   const endpointIsStrong = (keys: readonly string[], change: Node): boolean => {
@@ -942,12 +1056,15 @@ const collectRootMutationHazards = (
 
   type ImportGroup = {
     bindings: string[];
-    broadcasted: Set<Node>;
+    guardsByChange: Map<Node, Expression[] | null>;
   };
   const importGroupsByBinding = new Map<string, ImportGroup[]>();
   const importGroups: ImportGroup[] = [];
   importedBindingsBySource.forEach((bindings) => {
-    const group = { bindings, broadcasted: new Set<Node>() };
+    const group = {
+      bindings,
+      guardsByChange: new Map<Node, Expression[] | null>(),
+    };
     importGroups.push(group);
     bindings.forEach((binding) => {
       const groups = importGroupsByBinding.get(binding) ?? [];
@@ -963,6 +1080,7 @@ const collectRootMutationHazards = (
     const current = factsByBinding.get(item.key)?.get(item.change);
     if (
       current === undefined ||
+      item.guardRevision !== getGuardRevision(item.key, item.change) ||
       (!item.strong && (current & factStrong) !== 0)
     ) {
       continue;
@@ -1010,12 +1128,20 @@ const collectRootMutationHazards = (
       const importGroupsForBinding = importGroupsByBinding.get(item.key);
       if (importGroupsForBinding) {
         for (const importGroup of importGroupsForBinding) {
-          if (importGroup.broadcasted.has(item.change)) {
+          const guards =
+            guardExpressionsByBinding.get(item.key)?.get(item.change) ?? null;
+          if (
+            !mergeGuardState(importGroup.guardsByChange, item.change, guards)
+          ) {
             continue;
           }
-          importGroup.broadcasted.add(item.change);
+          // A later alias path may still promote a conditional group state to
+          // an unconditional one. Only a real group-state change re-broadcasts
+          // the fact; sibling work items with the same state stay O(1).
+          const groupGuards =
+            importGroup.guardsByChange.get(item.change) ?? null;
           for (const binding of importGroup.bindings) {
-            addFact(binding, item.change, true);
+            addFact(binding, item.change, true, groupGuards);
           }
         }
       }
@@ -1025,8 +1151,8 @@ const collectRootMutationHazards = (
   // Imported mutation/sibling facts conservatively affect unknown aliases,
   // but this final publication is intentionally weak and does not re-enter the
   // worklist.
-  importGroups.forEach(({ broadcasted }) => {
-    broadcasted.forEach((change) =>
+  importGroups.forEach(({ guardsByChange }) => {
+    guardsByChange.forEach((_guards, change) =>
       publishHazard(unknownAliasMutationBinding, change)
     );
   });
@@ -1040,7 +1166,7 @@ const collectRootMutationHazards = (
     }
   });
 
-  return hazards;
+  return { guardsByBinding: guardExpressionsByBinding, hazards };
 };
 
 export const collectProgramMutationAnalysis = (
@@ -1052,12 +1178,20 @@ export const collectProgramMutationAnalysis = (
   hasEffectiveMutationHazardSeed: boolean
 ): Pick<
   ProgramAnalysis,
-  'rootMutationHazardsByBinding' | 'rootMutationsByBinding'
+  | 'rootMutationHazardGuardsByBinding'
+  | 'rootMutationHazardsByBinding'
+  | 'rootMutationsByBinding'
 > => {
   const rootMutationsByBinding = collectRootMutations(program);
-  const rootMutationHazardsByBinding =
+  const mutationHazards =
     rootMutationsByBinding.size === 0 && !hasEffectiveMutationHazardSeed
-      ? new Map<string, Node[]>()
+      ? {
+          guardsByBinding: new Map<
+            string,
+            Map<Node, readonly Expression[] | null>
+          >(),
+          hazards: new Map<string, Node[]>(),
+        }
       : collectRootMutationHazards(
           program,
           rootMutationsByBinding,
@@ -1068,8 +1202,9 @@ export const collectProgramMutationAnalysis = (
         );
 
   return {
+    rootMutationHazardGuardsByBinding: mutationHazards.guardsByBinding,
     rootMutationHazardsByBinding: sealMutationTimelineMap(
-      rootMutationHazardsByBinding
+      mutationHazards.hazards
     ),
     rootMutationsByBinding: sealMutationTimelineMap(rootMutationsByBinding),
   };

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -199,7 +199,7 @@ const collectRootMutationHazards = (
   ignoredHazardNodes: ReadonlySet<Node>,
   ignoredHazardTreeNodes: ReadonlySet<Node>
 ): {
-  guardsByBinding: Map<string, Map<Node, readonly Expression[] | null>>;
+  guardsByBinding: Map<string, Map<Node, Expression[] | null>>;
   hazards: Map<string, Node[]>;
 } => {
   const { bindingsByName } = bindingIndex;
@@ -1186,10 +1186,7 @@ export const collectProgramMutationAnalysis = (
   const mutationHazards =
     rootMutationsByBinding.size === 0 && !hasEffectiveMutationHazardSeed
       ? {
-          guardsByBinding: new Map<
-            string,
-            Map<Node, readonly Expression[] | null>
-          >(),
+          guardsByBinding: new Map<string, Map<Node, Expression[] | null>>(),
           hazards: new Map<string, Node[]>(),
         }
       : collectRootMutationHazards(

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/mutationAnalysis.ts
@@ -15,7 +15,10 @@ import {
 } from '../oxc/assignmentTargets';
 import { getOxcNodeChildren } from '../oxc/ast';
 import { collectOxcPatternBindingNames } from '../oxc/patterns';
-import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
+import {
+  isOxcFunctionLike,
+  unwrapOxcRuntimeExpression,
+} from '../oxc/runtimeSemantics';
 import {
   findResolvedReferences as getReferences,
   resolveBindingInIndex,
@@ -417,6 +420,26 @@ const collectRootMutationHazards = (
         binding.declaredAt < node.start ||
         node.end <= binding.declaredAt
     );
+  const collectCapturedResultAliasReferenceKeys = (node: Node): string[] => {
+    const expression = unwrapOxcRuntimeExpression(node, true);
+    if (expression.type !== 'CallExpression') {
+      return collectCapturedAliasReferenceKeys(node);
+    }
+
+    const sources = expression.arguments.flatMap((argument) =>
+      collectCapturedAliasReferenceKeys(argument)
+    );
+    const callee = unwrapOxcRuntimeExpression(expression.callee, true);
+    if (callee.type === 'MemberExpression') {
+      sources.push(...collectCapturedAliasReferenceKeys(callee.object));
+    }
+
+    // An opaque call result may alias argument or receiver capabilities. Other
+    // return provenance is represented by unprovenResult; including the callee
+    // itself here connects separate calls through an earlier result and can
+    // turn a guarded primitive argument hazard into an unconditional one.
+    return [...new Set(sources)];
+  };
 
   const containsUnprovenAlias = (node: Node): boolean => {
     const projection = getProcessorProjection(node);
@@ -865,7 +888,7 @@ const collectRootMutationHazards = (
       aliasLinks.push({
         declaredAt: node.end,
         executionOwner: getExecutionOwner(bindingIndex, node),
-        sources: collectCapturedAliasReferenceKeys(node.right),
+        sources: collectCapturedResultAliasReferenceKeys(node.right),
         targets: collectReferenceKeys(node.left),
         unprovenResult: containsUnprovenAlias(node.right),
       });
@@ -888,7 +911,7 @@ const collectRootMutationHazards = (
     const sources = [
       ...new Set(
         sourceExpressions.flatMap((expression) =>
-          collectCapturedAliasReferenceKeys(expression)
+          collectCapturedResultAliasReferenceKeys(expression)
         )
       ),
     ];
@@ -1028,6 +1051,27 @@ const collectRootMutationHazards = (
       });
     }
   };
+  const getAliasPropagationGuards = (
+    key: string,
+    change: Node
+  ): readonly Expression[] | null => {
+    const guards = guardExpressionsByBinding.get(key)?.get(change);
+    if (!guards || guards.length === 0) {
+      return null;
+    }
+
+    return guards.every((guard) => {
+      const references = getReferences(guard, bindingIndex);
+      return (
+        references.length > 0 &&
+        references.every(
+          ({ binding }) => binding?.isRoot && binding.importedFrom
+        )
+      );
+    })
+      ? guards
+      : null;
+  };
   const endpointIsStrong = (keys: readonly string[], change: Node): boolean => {
     for (const key of keys) {
       if (((factsByBinding.get(key)?.get(change) ?? 0) & factStrong) !== 0) {
@@ -1085,6 +1129,10 @@ const collectRootMutationHazards = (
     ) {
       continue;
     }
+    const aliasPropagationGuards = getAliasPropagationGuards(
+      item.key,
+      item.change
+    );
 
     const targetLinks = linksByTarget.get(item.key);
     if (targetLinks) {
@@ -1101,7 +1149,7 @@ const collectRootMutationHazards = (
         }
         const strong = endpointIsStrong(link.targets, item.change);
         for (const source of link.sources) {
-          addFact(source, item.change, strong);
+          addFact(source, item.change, strong, aliasPropagationGuards);
         }
       }
     }
@@ -1119,7 +1167,7 @@ const collectRootMutationHazards = (
         }
         const strong = endpointIsStrong(link.sources, item.change);
         for (const target of link.targets) {
-          addFact(target, item.change, strong);
+          addFact(target, item.change, strong, aliasPropagationGuards);
         }
       }
     }

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/scopeAnalysis.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/scopeAnalysis.ts
@@ -226,6 +226,10 @@ const programDefaultMutationHazards = new WeakMap<
   Program,
   ProgramAnalysis['rootMutationHazardsByBinding']
 >();
+const programDefaultMutationHazardGuards = new WeakMap<
+  Program,
+  ProgramAnalysis['rootMutationHazardGuardsByBinding']
+>();
 const MAX_PROGRAM_ANALYSIS_VARIANTS = 4;
 const programAnalysisVariants = new WeakMap<
   Program,
@@ -609,6 +613,10 @@ export const analyzeProgram = (
     mutationHazardIgnoreLookup || mutationHazardIgnoreTreeLookup
       ? undefined
       : programDefaultMutationHazards.get(program);
+  const cachedDefaultMutationHazardGuards =
+    mutationHazardIgnoreLookup || mutationHazardIgnoreTreeLookup
+      ? undefined
+      : programDefaultMutationHazardGuards.get(program);
   const needsRequestTraversal =
     mutationHazardIgnoreLookup !== null ||
     mutationHazardIgnoreTreeLookup !== null ||
@@ -624,6 +632,7 @@ export const analyzeProgram = (
   }
 
   let rootMutationHazardsByBinding = cachedDefaultMutationHazards;
+  let rootMutationHazardGuardsByBinding = cachedDefaultMutationHazardGuards;
   let rootMutationsByBinding = programRootMutations.get(program);
   if (!rootMutationHazardsByBinding) {
     const mutationAnalysis = collectProgramMutationAnalysis(
@@ -636,12 +645,18 @@ export const analyzeProgram = (
     );
     rootMutationHazardsByBinding =
       mutationAnalysis.rootMutationHazardsByBinding;
+    rootMutationHazardGuardsByBinding =
+      mutationAnalysis.rootMutationHazardGuardsByBinding;
     rootMutationsByBinding ??= mutationAnalysis.rootMutationsByBinding;
     if (!programRootMutations.has(program)) {
       programRootMutations.set(program, rootMutationsByBinding);
     }
     if (!mutationHazardIgnoreLookup && !mutationHazardIgnoreTreeLookup) {
       programDefaultMutationHazards.set(program, rootMutationHazardsByBinding);
+      programDefaultMutationHazardGuards.set(
+        program,
+        rootMutationHazardGuardsByBinding
+      );
     }
   }
 
@@ -652,6 +667,7 @@ export const analyzeProgram = (
   Object.freeze(request.result.templateLiterals);
   const analysis: ProgramAnalysis = {
     bindingIndex: scopeFacts.bindingIndex,
+    rootMutationHazardGuardsByBinding: rootMutationHazardGuardsByBinding!,
     rootMutationHazardsByBinding,
     rootMutationsByBinding: rootMutationsByBinding!,
     targetExpressions,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticLocalPlanning.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticLocalPlanning.ts
@@ -8,7 +8,10 @@ import {
   collectOxcPatternRuntimeExpressions,
   collectOxcPatternShorthandProperties,
 } from '../oxc/patterns';
-import { isOxcFunctionLike } from '../oxc/runtimeSemantics';
+import {
+  isOxcFunctionLike,
+  unwrapOxcRuntimeExpression,
+} from '../oxc/runtimeSemantics';
 import { toOxcBindingIdentity } from './bindingIdentity';
 import { findResolvedReferences as getReferences } from './bindingResolution';
 import {
@@ -166,6 +169,46 @@ export const hasBindingMutationBefore = (
       (hazard) => !isKnownPureStaticCall(hazard, ctx)
     )
   );
+};
+
+export const collectBindingMutationGuardsBefore = (
+  binding: Binding,
+  referenceStart: number,
+  ctx: ExtractionContext
+): readonly Expression[] | null => {
+  const bindingKey = toMutationBindingKey(binding);
+  if (
+    hasTimelineStartBefore(
+      getMutationTimeline(ctx.rootMutationsByBinding, bindingKey),
+      referenceStart
+    )
+  ) {
+    return null;
+  }
+
+  const guardedExpressions = new Set<Expression>();
+  const hasUnconditionalHazard = someHazardTimelineEndAtOrBefore(
+    getHazardTimelineAt(bindingKey, referenceStart, ctx),
+    referenceStart,
+    ctx,
+    (hazard) => {
+      if (isKnownPureStaticCall(hazard, ctx)) {
+        return false;
+      }
+
+      const guards = ctx.rootMutationHazardGuardsByBinding
+        .get(bindingKey)
+        ?.get(hazard);
+      if (!guards || guards.length === 0) {
+        return true;
+      }
+
+      guards.forEach((expression) => guardedExpressions.add(expression));
+      return false;
+    }
+  );
+
+  return hasUnconditionalHazard ? null : [...guardedExpressions];
 };
 
 export const hasOpaqueDestructuringHazardBefore = (
@@ -396,6 +439,40 @@ function collectStaticLocalExpression(
         : ctx.code.slice(expression.start, expression.end),
   };
 }
+
+const isStaticMutationGuardProjection = (node: Node): boolean => {
+  const expression = unwrapOxcRuntimeExpression(node, false);
+  if (expression.type === 'Identifier') {
+    return true;
+  }
+  if (expression.type !== 'MemberExpression' || expression.optional) {
+    return false;
+  }
+
+  if (!isStaticMutationGuardProjection(expression.object)) {
+    return false;
+  }
+  if (!expression.computed) {
+    return expression.property.type === 'Identifier';
+  }
+
+  return (
+    expression.property.type === 'Literal' &&
+    (typeof expression.property.value === 'string' ||
+      typeof expression.property.value === 'number')
+  );
+};
+
+export const collectStaticMutationGuardExpression = (
+  expression: Expression,
+  ctx: ExtractionContext
+): StaticLocalExpression | null => {
+  const unwrapped = unwrapOxcRuntimeExpression(expression, false);
+  return unwrapped.type === 'MemberExpression' &&
+    isStaticMutationGuardProjection(expression)
+    ? collectStaticLocalExpression(expression, ctx)
+    : null;
+};
 
 function collectStaticDestructuringProjection(
   binding: Binding,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/types.ts
@@ -104,6 +104,7 @@ export type OxcStaticValue = {
 export type OxcStaticValueCandidate = {
   imports: OxcStaticImportReference[];
   inlineConstants?: Record<string, unknown>;
+  mutationGuards?: StaticLocalExpression[];
   name: string;
   source: string;
 };
@@ -126,6 +127,7 @@ export type ExtractedExpression = {
   kind: ValueType.FUNCTION | ValueType.LAZY;
   staticExpressionCode?: string;
   staticImports: OxcStaticImportReference[];
+  staticMutationGuards: StaticLocalExpression[];
   staticValue?: unknown;
 };
 
@@ -135,8 +137,14 @@ export type StaticLocalExpression = {
   source: string;
 };
 
+export type MutationHazardGuardMap = ReadonlyMap<
+  string,
+  ReadonlyMap<Node, readonly Expression[] | null>
+>;
+
 export type ProgramAnalysis = {
   bindingIndex: BindingIndex;
+  rootMutationHazardGuardsByBinding: MutationHazardGuardMap;
   rootMutationHazardsByBinding: MutationTimelineMap;
   rootMutationsByBinding: MutationTimelineMap<
     AssignmentExpression | UpdateExpression
@@ -161,6 +169,7 @@ export type ExtractionContext = {
   processorManagedExpressionSpans: Set<string>;
   program: Program;
   replacements: Replacement[];
+  rootMutationHazardGuardsByBinding: MutationHazardGuardMap;
   rootMutationHazardsByBinding: MutationTimelineLookup;
   rootMutationsByBinding: MutationTimelineMap<
     AssignmentExpression | UpdateExpression


### PR DESCRIPTION
## Summary

- treat opaque calls as capability-bounded during mutation analysis
- keep later static candidates eligible when direct imported member arguments resolve to immutable primitives
- keep object-valued, accessor, spread, alias, constructor, and unresolved cases fail-closed
- preserve eager invocation semantics for inline IIFEs
- add focused unit coverage, Bun end-to-end coverage, and a patch changeset

## Effect model

Opaque callees may mutate objects reachable through their arguments or receiver. Ambient writes through globals, closures, or the callee's own imports are outside the static guarantee and remain the application author's responsibility.

## Test plan

- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/transform build:esm`
- `bun run --filter @wyw-in-js/e2e-bun test`
