### PR TITLE
fix(webpack-loader): emit CSS under Rspack on Windows

### DIFF
--- a/.changeset/windows-rspack-css-cache.md
+++ b/.changeset/windows-rspack-css-cache.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/webpack-loader': patch
+---
+
+Keep extracted CSS available when Rspack loads the webpack loader and outputCssLoader in separate module graphs, and when Windows reports the same file with different path spellings.

--- a/.changeset/windows-rspack-css-cache.md
+++ b/.changeset/windows-rspack-css-cache.md
@@ -2,4 +2,4 @@
 '@wyw-in-js/webpack-loader': patch
 ---
 
-Keep extracted CSS available when Rspack loads the webpack loader and outputCssLoader in separate module graphs, and when Windows reports the same file with different path spellings.
+Keep extracted CSS available when Webpack or Rspack rebuilds generated CSS from persistent cache, when Rspack evaluates loaders in separate or parallel module graphs, when multiple object cache providers process the same resource, and when Windows reports the same file with different path spellings.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,7 +124,7 @@ jobs:
       # - Linux + Node 24: representative adapter checks for Node runtime drift:
       #   webpack, rollup, esbuild, next-webpack, next-turbopack.
       # - Windows + Node 22: representative platform checks:
-      #   vite/parcel smoke (already above), webpack, rollup, esbuild.
+      #   vite/parcel smoke (already above), webpack/rspack, rollup, esbuild.
       # This keeps CI cost bounded while still covering major adapters on
       # non-baseline runtime/platform lanes.
       - name: Webpack e2e (Node 24 lane)
@@ -150,6 +150,10 @@ jobs:
       - name: Webpack e2e (Windows lane)
         if: runner.os == 'Windows' && matrix.node-version == '22.x'
         run: bun run --filter @wyw-in-js/e2e-webpack test
+
+      - name: Rspack e2e (Windows lane)
+        if: runner.os == 'Windows' && matrix.node-version == '22.x'
+        run: bun run --filter @wyw-in-js/e2e-webpack test:rspack
 
       - name: Rollup e2e (Windows lane)
         if: runner.os == 'Windows' && matrix.node-version == '22.x'

--- a/bun.lock
+++ b/bun.lock
@@ -191,6 +191,7 @@
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
       "devDependencies": {
+        "@rspack/core": "^1.7.11",
         "@wyw-in-js/webpack-loader": "workspace:*",
         "picocolors": "^1.0.0",
         "prettier": "^3.2.5",

--- a/e2e/webpack/package.json
+++ b/e2e/webpack/package.json
@@ -5,6 +5,7 @@
     "@wyw-in-js/template-tag-syntax": "workspace:*"
   },
   "devDependencies": {
+    "@rspack/core": "^1.7.11",
     "@wyw-in-js/webpack-loader": "workspace:*",
     "picocolors": "^1.0.0",
     "prettier": "^3.2.5",
@@ -12,6 +13,7 @@
   },
   "private": true,
   "scripts": {
-    "test": "node ./scripts/test.mjs"
+    "test": "node ./scripts/test.mjs",
+    "test:rspack": "node ./scripts/test.mjs --rspack"
   }
 }

--- a/e2e/webpack/scripts/css-extra-dependency-loader.cjs
+++ b/e2e/webpack/scripts/css-extra-dependency-loader.cjs
@@ -1,0 +1,5 @@
+module.exports = function cssExtraDependencyLoader(source) {
+  const { dependency } = this.getOptions();
+  this.addDependency(dependency);
+  return source;
+};

--- a/e2e/webpack/scripts/test.mjs
+++ b/e2e/webpack/scripts/test.mjs
@@ -1,29 +1,56 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
+import { execFile } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
 
 import colors from 'picocolors';
 import prettier from 'prettier';
 
 const require = createRequire(import.meta.url);
-const webpack = require('webpack');
+const useRspack = process.argv.includes('--rspack');
+const bundler = useRspack ? require('@rspack/core').rspack : require('webpack');
+const bundlerName = useRspack ? 'Rspack' : 'Webpack';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PKG_DIR = path.resolve(__dirname, '..');
+const CSS_DEPENDENCY_LOADER = path.resolve(
+  __dirname,
+  'css-extra-dependency-loader.cjs'
+);
+const execFileAsync = promisify(execFile);
 
 const normalizeLineEndings = (value) =>
   value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
-const runBuild = async () => {
+const runBuild = async (
+  entry,
+  { cacheDirectory, dependency, parallelLoader = false } = {}
+) => {
   const outDir = path.resolve(PKG_DIR, 'dist');
   await fs.rm(outDir, { recursive: true, force: true });
+
+  const experiments = {};
+  if (useRspack && cacheDirectory) {
+    experiments.cache = {
+      type: 'persistent',
+      storage: {
+        type: 'filesystem',
+        directory: cacheDirectory,
+      },
+    };
+  }
+  if (useRspack && parallelLoader) {
+    experiments.parallelLoader = true;
+  }
 
   const config = {
     mode: 'development',
     context: PKG_DIR,
-    entry: path.resolve(PKG_DIR, 'src', 'index.js'),
+    entry,
     output: {
       path: outDir,
       filename: 'bundle.js',
@@ -33,10 +60,25 @@ const runBuild = async () => {
       rules: [
         {
           test: /\.js$/,
-          use: [{ loader: '@wyw-in-js/webpack-loader' }],
+          use: [
+            {
+              loader: '@wyw-in-js/webpack-loader',
+              ...(parallelLoader ? { options: {}, parallel: true } : {}),
+            },
+          ],
         },
         {
           test: /\.wyw-in-js\.css$/,
+          ...(dependency
+            ? {
+                use: [
+                  {
+                    loader: CSS_DEPENDENCY_LOADER,
+                    options: { dependency },
+                  },
+                ],
+              }
+            : {}),
           type: 'asset/resource',
           generator: {
             filename: '[name][ext]',
@@ -47,30 +89,48 @@ const runBuild = async () => {
     resolve: {
       extensions: ['.js'],
     },
-    cache: false,
+    cache: cacheDirectory
+      ? useRspack
+        ? true
+        : {
+            type: 'filesystem',
+            cacheDirectory,
+            buildDependencies: {
+              config: [__filename, CSS_DEPENDENCY_LOADER],
+            },
+          }
+      : false,
+    ...(Object.keys(experiments).length > 0 ? { experiments } : {}),
     stats: 'errors-only',
   };
 
-  await new Promise((resolve, reject) => {
-    webpack(config, (err, stats) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      if (stats?.hasErrors()) {
-        reject(new Error(stats.toString({ all: false, errors: true })));
-        return;
-      }
-      resolve();
+  return new Promise((resolve, reject) => {
+    const compiler = bundler(config);
+    compiler.run((err, stats) => {
+      const buildError =
+        err ??
+        (stats?.hasErrors()
+          ? new Error(stats.toString({ all: false, errors: true }))
+          : undefined);
+      const statsJson = stats?.toJson({
+        all: false,
+        cachedModules: true,
+        modules: true,
+      });
+
+      compiler.close((closeError) => {
+        const error = buildError ?? closeError;
+        if (error) {
+          reject(new Error(`${bundlerName} build failed`, { cause: error }));
+          return;
+        }
+        resolve(statsJson);
+      });
     });
   });
 };
 
-const main = async () => {
-  console.log(colors.blue('Package directory:'), PKG_DIR);
-
-  await runBuild();
-
+const readCssOutput = async () => {
   const outDir = path.resolve(PKG_DIR, 'dist');
   const entries = await fs.readdir(outDir);
   const cssFiles = entries.filter((file) => file.endsWith('.wyw-in-js.css'));
@@ -79,27 +139,28 @@ const main = async () => {
     throw new Error('No .wyw-in-js.css assets were emitted');
   }
 
-  const cssOutputRaw = (
+  return (
     await Promise.all(
       cssFiles
         .sort((a, b) => a.localeCompare(b))
         .map((file) => fs.readFile(path.resolve(outDir, file), 'utf8'))
     )
   ).join('\n');
+};
 
-  const cssOutput = await prettier.format(
-    normalizeLineEndings(cssOutputRaw),
-    {
-      parser: 'css',
-    }
-  );
+const assertFixture = async () => {
+  const cssOutputRaw = await readCssOutput();
+
+  const cssOutput = await prettier.format(normalizeLineEndings(cssOutputRaw), {
+    parser: 'css',
+  });
 
   const cssFixture = normalizeLineEndings(
     await fs.readFile(path.resolve(PKG_DIR, 'fixture.css'), 'utf8')
   );
 
   if (cssOutput !== cssFixture) {
-    console.log(colors.red('Output CSS:'));
+    console.log(colors.red(`${bundlerName} output CSS:`));
     console.log(cssOutput);
     console.log(colors.red('Expected CSS:'));
     console.log(cssFixture);
@@ -107,9 +168,137 @@ const main = async () => {
   }
 };
 
-main().then(
+const assertPosixBackslashPath = async () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const sourcePath = path.resolve(
+    PKG_DIR,
+    'src',
+    `back\\slash-${process.pid}.js`
+  );
+  await fs.writeFile(
+    sourcePath,
+    "import { css } from '@wyw-in-js/template-tag-syntax';\nexport const cls = css`color: rebeccapurple;`;\n"
+  );
+
+  try {
+    await runBuild(sourcePath);
+    const cssOutput = await readCssOutput();
+    if (!cssOutput.replace(/\s/g, '').includes('color:rebeccapurple')) {
+      throw new Error('CSS was not emitted for a POSIX path with a backslash');
+    }
+  } finally {
+    await fs.rm(sourcePath, { force: true });
+  }
+};
+
+const flattenModules = (modules = []) =>
+  modules.flatMap((module) => [
+    module,
+    ...flattenModules(module.modules ?? []),
+  ]);
+
+const assertSelectiveCacheReuse = (stats) => {
+  const modules = flattenModules(stats?.modules);
+  const parentModules = modules.filter(
+    (module) =>
+      module.name === './src/index.js' || module.name === './src/alias.js'
+  );
+  const cssModules = modules.filter((module) =>
+    module.name?.includes('.wyw-in-js.css')
+  );
+
+  if (!parentModules.some((module) => !module.built)) {
+    throw new Error(
+      `Expected a cached parent JS module, got ${JSON.stringify(parentModules)}`
+    );
+  }
+  if (!cssModules.some((module) => module.built && !module.cached)) {
+    throw new Error(
+      `Expected a rebuilt virtual CSS module, got ${JSON.stringify(cssModules)}`
+    );
+  }
+};
+
+const getArg = (name) =>
+  process.argv
+    .find((arg) => arg.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+
+const runPersistentCacheChild = async () => {
+  const cacheDirectory = getArg('--cache-directory');
+  const dependency = getArg('--dependency');
+  if (!cacheDirectory || !dependency) {
+    throw new Error('Persistent cache child arguments are missing');
+  }
+
+  const entry = path.resolve(PKG_DIR, 'src', 'index.js');
+  const stats = await runBuild(entry, { cacheDirectory, dependency });
+  await assertFixture();
+
+  if (process.argv.includes('--expect-selective-cache')) {
+    assertSelectiveCacheReuse(stats);
+  }
+};
+
+const assertPersistentCache = async () => {
+  const tempDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'wyw-webpack-cache-')
+  );
+  const cacheDirectory = path.resolve(tempDir, 'cache');
+  const dependency = path.resolve(tempDir, 'css-pipeline.config');
+  const commonArgs = [
+    __filename,
+    ...(useRspack ? ['--rspack'] : []),
+    '--persistent-cache-child',
+    `--cache-directory=${cacheDirectory}`,
+    `--dependency=${dependency}`,
+  ];
+
+  try {
+    await fs.writeFile(dependency, 'first\n');
+    await execFileAsync(process.execPath, commonArgs, { cwd: PKG_DIR });
+
+    await fs.writeFile(dependency, 'second version\n');
+    await execFileAsync(
+      process.execPath,
+      [...commonArgs, '--expect-selective-cache'],
+      { cwd: PKG_DIR }
+    );
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+};
+
+const assertRspackParallelLoader = async () => {
+  if (!useRspack) return;
+
+  const entry = path.resolve(PKG_DIR, 'src', 'index.js');
+  await runBuild(entry, { parallelLoader: true });
+  await assertFixture();
+};
+
+const main = async () => {
+  console.log(colors.blue('Package directory:'), PKG_DIR);
+
+  const entry = path.resolve(PKG_DIR, 'src', 'index.js');
+  await runBuild(entry);
+  await assertFixture();
+
+  await assertPosixBackslashPath();
+  await assertPersistentCache();
+  await assertRspackParallelLoader();
+};
+
+const run = process.argv.includes('--persistent-cache-child')
+  ? runPersistentCacheChild
+  : main;
+
+run().then(
   () => {
-    console.log(colors.green('✅ Webpack E2E test passed'));
+    console.log(colors.green(`✅ ${bundlerName} E2E test passed`));
     process.exit(0);
   },
   (error) => {

--- a/packages/webpack-loader/src/__tests__/cache-module-graphs.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache-module-graphs.test.ts
@@ -1,0 +1,28 @@
+describe('webpack-loader cache module graphs', () => {
+  it('shares cache providers across independently evaluated module graphs', async () => {
+    const firstModule = '../cache.ts?graph=first';
+    const secondModule = '../cache.ts?graph=second';
+    const first = await import(firstModule);
+    const second = await import(secondModule);
+
+    expect(first.registerCacheProvider).not.toBe(second.registerCacheProvider);
+    expect(first.memoryCache).not.toBe(second.memoryCache);
+
+    const compiler = {};
+    const cacheProviderToken = 'provider-a';
+    first.registerCacheProvider(
+      first.memoryCache,
+      cacheProviderToken,
+      compiler
+    );
+
+    expect(
+      await second.getCacheInstance(undefined, compiler, cacheProviderToken)
+    ).toBe(first.memoryCache);
+
+    second.clearCacheProviderRegistry(compiler);
+    expect(
+      await first.getCacheInstance(undefined, compiler, cacheProviderToken)
+    ).not.toBe(first.memoryCache);
+  });
+});

--- a/packages/webpack-loader/src/__tests__/cache-provider.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache-provider.test.ts
@@ -136,4 +136,92 @@ describe('webpack-loader cacheProvider', () => {
       } as any);
     });
   });
+
+  it('emits CSS when outputCssLoader sees a Windows path variant of the source file', async () => {
+    transformMock.mockResolvedValue({
+      code: 'module.exports = 1;',
+      sourceMap: null,
+      cssText: '.title{color:blue}',
+      cssSourceMapText: '',
+      dependencies: [],
+    });
+
+    const { default: webpackLoader } = await import('../index');
+    const { default: outputCssLoader } = await import('../outputCssLoader');
+
+    const writerPath = 'D:\\work\\app\\commonStyle.ts';
+    const readerPath = 'D:/work/app/commonStyle.ts';
+    let emittedRequest = '';
+
+    await new Promise<void>((resolve, reject) => {
+      webpackLoader.call(
+        {
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null, code?: string) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+
+            const match = String(code).match(/require\(([^)]+)\);/);
+            if (!match) {
+              reject(new Error('Expected loader to emit a require() call'));
+              return;
+            }
+
+            emittedRequest = match[1].trim();
+            resolve();
+          },
+          context: process.cwd(),
+          emitWarning: jest.fn(),
+          getDependencies: () => [],
+          getOptions: () => ({}),
+          getResolve: () =>
+            jest.fn(
+              (
+                _ctx: string,
+                _token: string,
+                cb: (err: any, res: any) => void
+              ) => cb(null, null)
+            ),
+          resourcePath: writerPath,
+          rootContext: process.cwd(),
+          utils: {
+            contextify: (_ctx: string, request: string) => request,
+          },
+        } as any,
+        'module.exports = 1;',
+        null
+      );
+    });
+
+    const request = JSON.parse(emittedRequest);
+    const query = request.split('?', 2)[1].split('!', 1)[0];
+    const params = new URLSearchParams(query);
+
+    expect(request).toContain('D:/work/app/commonStyle.ts');
+    expect(params.get('cacheProviderId')).toBeTruthy();
+
+    await new Promise<void>((resolve, reject) => {
+      outputCssLoader.call({
+        addDependency: jest.fn(),
+        async: jest.fn(),
+        callback: (err: Error | null, css?: string) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          expect(css).toContain('.title{color:blue}');
+          resolve();
+        },
+        getOptions: () => ({
+          cacheProvider: params.get('cacheProvider') || undefined,
+          cacheProviderId: params.get('cacheProviderId') || undefined,
+        }),
+        resourcePath: readerPath,
+      } as any);
+    });
+  });
 });

--- a/packages/webpack-loader/src/__tests__/cache-provider.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache-provider.test.ts
@@ -42,13 +42,149 @@ class TestCache {
   }
 }
 
+const createHook = <TArgs extends unknown[]>() => {
+  const handlers: Array<(...args: TArgs) => void> = [];
+
+  return {
+    call: (...args: TArgs) => {
+      handlers.forEach((handler) => handler(...args));
+    },
+    tap: (_name: string, handler: (...args: TArgs) => void) => {
+      handlers.push(handler);
+    },
+  };
+};
+
+const createCompiler = (cache: false | { type: 'filesystem' } = false) => ({
+  getCache: jest.fn(),
+  hooks: {
+    done: createHook<[unknown]>(),
+    failed: createHook<[Error]>(),
+    shutdown: createHook<[]>(),
+    watchClose: createHook<[]>(),
+  },
+  options: { cache },
+});
+
+const getOutputLoaderOptions = (request: string) => {
+  const outputLoaderRequest = request.split('!=!', 2)[1].split('!', 1)[0];
+  const queryIndex = outputLoaderRequest.indexOf('?');
+  const params = new URLSearchParams(
+    queryIndex === -1 ? '' : outputLoaderRequest.slice(queryIndex + 1)
+  );
+
+  return {
+    cacheProvider: params.get('cacheProvider') || undefined,
+    cacheProviderToken: params.get('cacheProviderToken') || undefined,
+    outputCssPayload: params.get('outputCssPayload') || undefined,
+  };
+};
+
+const runWebpackLoader = async ({
+  cacheProvider,
+  compiler,
+  dependencies = [],
+  loaderIdent = 'default',
+  resourcePath,
+}: {
+  cacheProvider?: TestCache;
+  compiler: ReturnType<typeof createCompiler>;
+  dependencies?: string[];
+  loaderIdent?: string;
+  resourcePath: string;
+}) => {
+  const { default: webpackLoader } = await import('../index');
+  let emittedRequest = '';
+
+  await new Promise<void>((resolve, reject) => {
+    webpackLoader.call(
+      {
+        _compiler: compiler,
+        addDependency: jest.fn(),
+        async: jest.fn(),
+        callback: (err: Error | null, code?: string) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          const match = String(code).match(/require\(([^)]+)\);/);
+          if (!match) {
+            reject(new Error('Expected loader to emit a require() call'));
+            return;
+          }
+
+          emittedRequest = JSON.parse(match[1].trim());
+          resolve();
+        },
+        context: process.cwd(),
+        emitWarning: jest.fn(),
+        getDependencies: () => dependencies,
+        getOptions: () => (cacheProvider ? { cacheProvider } : {}),
+        getResolve: () =>
+          jest.fn(
+            (_ctx: string, _token: string, cb: (err: any, res: any) => void) =>
+              cb(null, null)
+          ),
+        loaderIndex: 0,
+        loaders: [{ ident: loaderIdent }],
+        request: `/abs/webpack-loader.js??${loaderIdent}!${resourcePath}`,
+        resourcePath,
+        rootContext: process.cwd(),
+        utils: {
+          contextify: (_ctx: string, request: string) => request,
+        },
+      } as any,
+      'module.exports = 1;',
+      null
+    );
+  });
+
+  return emittedRequest;
+};
+
+const runOutputCssLoader = async ({
+  addDependency = jest.fn(),
+  compiler,
+  options,
+  resourcePath,
+}: {
+  addDependency?: ReturnType<typeof jest.fn>;
+  compiler: ReturnType<typeof createCompiler>;
+  options: ReturnType<typeof getOutputLoaderOptions>;
+  resourcePath: string;
+}) => {
+  const { default: outputCssLoader } = await import('../outputCssLoader');
+
+  return new Promise<string>((resolve, reject) => {
+    outputCssLoader.call({
+      _compiler: compiler,
+      addDependency,
+      async: jest.fn(),
+      callback: (err: Error | null, css?: string) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve(css ?? '');
+      },
+      getOptions: () => options,
+      resourcePath,
+    } as any);
+  });
+};
+
 describe('webpack-loader cacheProvider', () => {
   beforeEach(() => {
     transformMock.mockReset();
   });
 
-  it('passes object cacheProvider via cacheProviderId so outputCssLoader reads from same instance', async () => {
+  it('reads an object cacheProvider through compiler-scoped state', async () => {
     const cacheProvider = new TestCache();
+    const compiler = createCompiler();
+    const resourcePath = '/abs/entry.jsx';
+    const getSpy = jest.spyOn(cacheProvider, 'get');
 
     transformMock.mockResolvedValue({
       code: 'module.exports = 1;',
@@ -58,86 +194,144 @@ describe('webpack-loader cacheProvider', () => {
       dependencies: [],
     });
 
-    const { default: webpackLoader } = await import('../index');
-    const { default: outputCssLoader } = await import('../outputCssLoader');
-
-    const resourcePath = '/abs/entry.jsx';
-    let emittedRequest = '';
-
-    await new Promise<void>((resolve, reject) => {
-      webpackLoader.call(
-        {
-          addDependency: jest.fn(),
-          async: jest.fn(),
-          callback: (err: Error | null, code?: string) => {
-            if (err) {
-              reject(err);
-              return;
-            }
-
-            const match = String(code).match(/require\(([^)]+)\);/);
-            if (!match) {
-              reject(new Error('Expected loader to emit a require() call'));
-              return;
-            }
-
-            emittedRequest = match[1].trim();
-
-            resolve();
-          },
-          context: process.cwd(),
-          emitWarning: jest.fn(),
-          getDependencies: () => [],
-          getOptions: () => ({ cacheProvider }),
-          getResolve: () =>
-            jest.fn(
-              (
-                _ctx: string,
-                _token: string,
-                cb: (err: any, res: any) => void
-              ) => cb(null, null)
-            ),
-          resourcePath,
-          rootContext: process.cwd(),
-          utils: {
-            contextify: (_ctx: string, request: string) => request,
-          },
-        } as any,
-        'module.exports = 1;',
-        null
-      );
+    const request = await runWebpackLoader({
+      cacheProvider,
+      compiler,
+      resourcePath,
+    });
+    const options = getOutputLoaderOptions(request);
+    const css = await runOutputCssLoader({
+      compiler,
+      options,
+      resourcePath,
     });
 
-    const request = JSON.parse(emittedRequest);
-    const query = request.split('?', 2)[1].split('!', 1)[0];
-    const params = new URLSearchParams(query);
-    const cacheProviderId = params.get('cacheProviderId');
+    expect(options.cacheProviderToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(options.outputCssPayload).toBeUndefined();
+    expect(getSpy).toHaveBeenCalledWith(resourcePath);
+    expect(css).toContain('.title{color:red}');
 
-    expect(cacheProviderId).toBeTruthy();
-
-    await new Promise<void>((resolve, reject) => {
-      outputCssLoader.call({
-        addDependency: jest.fn(),
-        async: jest.fn(),
-        callback: (err: Error | null, css?: string) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-
-          expect(css).toContain('.title{color:red}');
-          resolve();
-        },
-        getOptions: () => ({
-          cacheProvider: params.get('cacheProvider') || undefined,
-          cacheProviderId: cacheProviderId ?? undefined,
-        }),
-        resourcePath,
-      } as any);
-    });
+    compiler.hooks.shutdown.call();
+    await expect(
+      runOutputCssLoader({ compiler, options, resourcePath })
+    ).rejects.toThrow(`CSS cache entry not found for ${resourcePath}`);
   });
 
-  it('emits CSS when outputCssLoader sees a Windows path variant of the source file', async () => {
+  it('keeps object providers isolated for the same resource', async () => {
+    const firstCacheProvider = new TestCache();
+    const secondCacheProvider = new TestCache();
+    const compiler = createCompiler();
+    const resourcePath = '/abs/entry.jsx';
+
+    transformMock
+      .mockResolvedValueOnce({
+        code: 'module.exports = 1;',
+        sourceMap: null,
+        cssText: '.title{color:red}',
+        cssSourceMapText: '',
+        dependencies: [],
+      })
+      .mockResolvedValueOnce({
+        code: 'module.exports = 2;',
+        sourceMap: null,
+        cssText: '.title{color:blue}',
+        cssSourceMapText: '',
+        dependencies: [],
+      });
+
+    const firstRequest = await runWebpackLoader({
+      cacheProvider: firstCacheProvider,
+      compiler,
+      loaderIdent: 'first',
+      resourcePath,
+    });
+    const secondRequest = await runWebpackLoader({
+      cacheProvider: secondCacheProvider,
+      compiler,
+      loaderIdent: 'second',
+      resourcePath,
+    });
+    const firstOptions = getOutputLoaderOptions(firstRequest);
+    const secondOptions = getOutputLoaderOptions(secondRequest);
+
+    expect(firstOptions.cacheProviderToken).not.toBe(
+      secondOptions.cacheProviderToken
+    );
+    await expect(
+      runOutputCssLoader({
+        compiler,
+        options: firstOptions,
+        resourcePath,
+      })
+    ).resolves.toContain('.title{color:red}');
+    await expect(
+      runOutputCssLoader({
+        compiler,
+        options: secondOptions,
+        resourcePath,
+      })
+    ).resolves.toContain('.title{color:blue}');
+  });
+
+  it('uses an exact payload when two provider objects reuse an ident', async () => {
+    const compiler = createCompiler();
+    const resourcePath = '/abs/entry.jsx';
+
+    transformMock
+      .mockResolvedValueOnce({
+        code: 'module.exports = 1;',
+        sourceMap: null,
+        cssText: '.title{color:red}',
+        cssSourceMapText: '',
+        dependencies: [],
+      })
+      .mockResolvedValueOnce({
+        code: 'module.exports = 2;',
+        sourceMap: null,
+        cssText: '.title{color:blue}',
+        cssSourceMapText: '',
+        dependencies: [],
+      });
+
+    const firstRequest = await runWebpackLoader({
+      cacheProvider: new TestCache(),
+      compiler,
+      loaderIdent: 'reused',
+      resourcePath,
+    });
+    const secondRequest = await runWebpackLoader({
+      cacheProvider: new TestCache(),
+      compiler,
+      loaderIdent: 'reused',
+      resourcePath,
+    });
+    const firstOptions = getOutputLoaderOptions(firstRequest);
+    const secondOptions = getOutputLoaderOptions(secondRequest);
+
+    expect(firstOptions.cacheProviderToken).toBeTruthy();
+    expect(secondOptions.cacheProviderToken).toBeUndefined();
+    expect(secondOptions.outputCssPayload).toBeTruthy();
+    await expect(
+      runOutputCssLoader({
+        compiler,
+        options: firstOptions,
+        resourcePath,
+      })
+    ).resolves.toContain('.title{color:red}');
+    await expect(
+      runOutputCssLoader({
+        compiler,
+        options: secondOptions,
+        resourcePath,
+      })
+    ).resolves.toContain('.title{color:blue}');
+  });
+
+  it('emits CSS when outputCssLoader sees a Windows path variant', async () => {
+    const compiler = createCompiler();
+    const writerPath = 'D:\\work\\app\\commonStyle.ts';
+    const readerPath = 'D:/work/app/commonStyle.ts';
+
     transformMock.mockResolvedValue({
       code: 'module.exports = 1;',
       sourceMap: null,
@@ -146,82 +340,81 @@ describe('webpack-loader cacheProvider', () => {
       dependencies: [],
     });
 
-    const { default: webpackLoader } = await import('../index');
-    const { default: outputCssLoader } = await import('../outputCssLoader');
-
-    const writerPath = 'D:\\work\\app\\commonStyle.ts';
-    const readerPath = 'D:/work/app/commonStyle.ts';
-    let emittedRequest = '';
-
-    await new Promise<void>((resolve, reject) => {
-      webpackLoader.call(
-        {
-          addDependency: jest.fn(),
-          async: jest.fn(),
-          callback: (err: Error | null, code?: string) => {
-            if (err) {
-              reject(err);
-              return;
-            }
-
-            const match = String(code).match(/require\(([^)]+)\);/);
-            if (!match) {
-              reject(new Error('Expected loader to emit a require() call'));
-              return;
-            }
-
-            emittedRequest = match[1].trim();
-            resolve();
-          },
-          context: process.cwd(),
-          emitWarning: jest.fn(),
-          getDependencies: () => [],
-          getOptions: () => ({}),
-          getResolve: () =>
-            jest.fn(
-              (
-                _ctx: string,
-                _token: string,
-                cb: (err: any, res: any) => void
-              ) => cb(null, null)
-            ),
-          resourcePath: writerPath,
-          rootContext: process.cwd(),
-          utils: {
-            contextify: (_ctx: string, request: string) => request,
-          },
-        } as any,
-        'module.exports = 1;',
-        null
-      );
+    const request = await runWebpackLoader({
+      compiler,
+      resourcePath: writerPath,
+    });
+    const css = await runOutputCssLoader({
+      compiler,
+      options: getOutputLoaderOptions(request),
+      resourcePath: readerPath,
     });
 
-    const request = JSON.parse(emittedRequest);
-    const query = request.split('?', 2)[1].split('!', 1)[0];
-    const params = new URLSearchParams(query);
+    expect(request).toContain(writerPath);
+    expect(getOutputLoaderOptions(request).cacheProviderToken).toBeUndefined();
+    expect(css).toContain('.title{color:blue}');
+  });
 
-    expect(request).toContain('D:/work/app/commonStyle.ts');
-    expect(params.get('cacheProviderId')).toBeTruthy();
+  it('falls back to a self-contained payload after a process restart', async () => {
+    const dependency = '/abs/theme.ts';
+    const firstCompiler = createCompiler({ type: 'filesystem' });
+    const secondCompiler = createCompiler({ type: 'filesystem' });
+    const resourcePath = '/abs/entry.jsx';
 
-    await new Promise<void>((resolve, reject) => {
-      outputCssLoader.call({
-        addDependency: jest.fn(),
-        async: jest.fn(),
-        callback: (err: Error | null, css?: string) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-
-          expect(css).toContain('.title{color:blue}');
-          resolve();
-        },
-        getOptions: () => ({
-          cacheProvider: params.get('cacheProvider') || undefined,
-          cacheProviderId: params.get('cacheProviderId') || undefined,
-        }),
-        resourcePath: readerPath,
-      } as any);
+    transformMock.mockResolvedValue({
+      code: 'module.exports = 1;',
+      sourceMap: null,
+      cssText: '.title{color:green}',
+      cssSourceMapText: '',
+      dependencies: [],
     });
+
+    const request = await runWebpackLoader({
+      compiler: firstCompiler,
+      dependencies: [dependency],
+      resourcePath,
+    });
+    const options = getOutputLoaderOptions(request);
+    const addDependency = jest.fn();
+    const css = await runOutputCssLoader({
+      addDependency,
+      compiler: secondCompiler,
+      options,
+      resourcePath,
+    });
+
+    expect(options.outputCssPayload).toBeTruthy();
+    expect(options.outputCssPayload).not.toContain(dependency);
+    expect(addDependency).not.toHaveBeenCalled();
+    expect(css).toContain('.title{color:green}');
+  });
+
+  it('prefers the exact persistent payload over newer runtime state', async () => {
+    const cacheProvider = new TestCache();
+    const compiler = createCompiler({ type: 'filesystem' });
+    const resourcePath = '/abs/entry.jsx';
+
+    transformMock.mockResolvedValue({
+      code: 'module.exports = 1;',
+      sourceMap: null,
+      cssText: '.title{color:green}',
+      cssSourceMapText: '',
+      dependencies: [],
+    });
+
+    const request = await runWebpackLoader({
+      cacheProvider,
+      compiler,
+      resourcePath,
+    });
+    await cacheProvider.set(resourcePath, '.title{color:wrong}');
+
+    await expect(
+      runOutputCssLoader({
+        compiler,
+        options: getOutputLoaderOptions(request),
+        resourcePath,
+      })
+    ).resolves.toContain('.title{color:green}');
   });
 });

--- a/packages/webpack-loader/src/__tests__/cache.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache.test.ts
@@ -1,26 +1,87 @@
 import {
+  clearCacheProviderRegistry,
+  decodeOutputCssPayload,
+  encodeOutputCssPayload,
   getCacheInstance,
   memoryCache,
   registerCacheProvider,
   toCacheKey,
+  toWebpackRequestPath,
 } from '../cache';
 
-const CACHE_STATE_KEY = Symbol.for('@wyw-in-js/webpack-loader.cache');
-
 describe('webpack-loader cache keys', () => {
-  it('normalizes Windows path variants and query/hash suffixes', () => {
+  it('normalizes Windows path variants', () => {
     expect(toCacheKey('D:\\work\\app\\commonStyle.ts')).toBe(
       'd:/work/app/commonStyle.ts'
     );
     expect(toCacheKey('D:/work/app/commonStyle.ts')).toBe(
       'd:/work/app/commonStyle.ts'
     );
-    expect(toCacheKey('d:/work/app/commonStyle.ts?wyw=wyw-in-js.css')).toBe(
+    expect(toCacheKey('\\\\?\\D:\\work\\app\\commonStyle.ts')).toBe(
       'd:/work/app/commonStyle.ts'
     );
-    expect(toCacheKey('D:\\work\\app\\commonStyle.ts#hash')).toBe(
+    expect(toCacheKey('\\\\?\\UNC\\server\\share\\commonStyle.ts')).toBe(
+      '//server/share/commonStyle.ts'
+    );
+    expect(toCacheKey('//?/D:/work/app/commonStyle.ts', 'win32')).toBe(
       'd:/work/app/commonStyle.ts'
     );
+    expect(toCacheKey('//?/UNC/server/share/commonStyle.ts', 'win32')).toBe(
+      '//server/share/commonStyle.ts'
+    );
+    expect(toCacheKey('//server/share/commonStyle.ts', 'win32')).toBe(
+      '//server/share/commonStyle.ts'
+    );
+    expect(toCacheKey('//?/D:/literal', 'linux')).toBe('//?/D:/literal');
+    expect(toCacheKey('//server/share/commonStyle.ts', 'linux')).toBe(
+      '//server/share/commonStyle.ts'
+    );
+  });
+
+  it('normalizes extended Windows paths before using them in requests', () => {
+    expect(toWebpackRequestPath('\\\\?\\D:\\work\\app\\commonStyle.ts')).toBe(
+      'D:\\work\\app\\commonStyle.ts'
+    );
+    expect(
+      toWebpackRequestPath('//?/D:/work/app/commonStyle.ts', 'win32')
+    ).toBe('D:/work/app/commonStyle.ts');
+    expect(
+      toWebpackRequestPath('\\\\?\\UNC\\server\\share\\commonStyle.ts')
+    ).toBe('\\\\server\\share\\commonStyle.ts');
+    expect(
+      toWebpackRequestPath('//?/UNC/server/share/commonStyle.ts', 'win32')
+    ).toBe('\\\\server\\share\\commonStyle.ts');
+    expect(toWebpackRequestPath('\\\\server\\share\\commonStyle.ts')).toBe(
+      '\\\\server\\share\\commonStyle.ts'
+    );
+    expect(toWebpackRequestPath('//server/share/commonStyle.ts', 'win32')).toBe(
+      '\\\\server\\share\\commonStyle.ts'
+    );
+    expect(toWebpackRequestPath('//server/share/commonStyle.ts', 'linux')).toBe(
+      '//server/share/commonStyle.ts'
+    );
+    expect(toWebpackRequestPath('//?/D:/literal', 'linux')).toBe(
+      '//?/D:/literal'
+    );
+  });
+
+  it('rejects extended Windows paths that cannot be safely denamespaced', () => {
+    expect(() =>
+      toWebpackRequestPath('\\\\?\\Volume{1234}\\work\\entry.ts')
+    ).toThrow('Unsupported Windows extended path namespace');
+    expect(() =>
+      toWebpackRequestPath('\\\\?\\D:\\work\\trailing.\\entry.ts')
+    ).toThrow('Unsupported Windows extended path with trailing dot or space');
+    expect(() =>
+      toCacheKey('\\\\?\\UNC\\server\\share\\trailing \\entry.ts')
+    ).toThrow('Unsupported Windows extended path with trailing dot or space');
+  });
+
+  it('preserves backslashes in POSIX paths', () => {
+    const posixPath = '/work/app/common\\Style.ts';
+
+    expect(toCacheKey(posixPath)).toBe(posixPath);
+    expect(toWebpackRequestPath(posixPath)).toBe(posixPath);
   });
 
   it('reads CSS written with a different Windows path representation', async () => {
@@ -29,29 +90,44 @@ describe('webpack-loader cache keys', () => {
     await memoryCache.set('D:\\work\\app\\commonStyle.ts', cssText);
 
     expect(await memoryCache.get('D:/work/app/commonStyle.ts')).toBe(cssText);
+    expect(await memoryCache.get('d:\\work\\app\\commonStyle.ts')).toBe(
+      cssText
+    );
+  });
+
+  it('scopes registered cache providers to their compiler', async () => {
+    const firstCompiler = {};
+    const secondCompiler = {};
+    const cacheProviderToken = 'provider-a';
+
+    registerCacheProvider(memoryCache, cacheProviderToken, firstCompiler);
+
     expect(
-      await memoryCache.get('d:\\work\\app\\commonStyle.ts?wyw=wyw-in-js.css')
-    ).toBe(cssText);
+      await getCacheInstance(undefined, firstCompiler, cacheProviderToken)
+    ).toBe(memoryCache);
+    expect(
+      await getCacheInstance(undefined, secondCompiler, cacheProviderToken)
+    ).not.toBe(memoryCache);
+
+    clearCacheProviderRegistry(firstCompiler);
+    expect(
+      await getCacheInstance(undefined, firstCompiler, cacheProviderToken)
+    ).not.toBe(memoryCache);
   });
 
-  it('keeps the default memory cache on globalThis for isolated loader graphs', async () => {
-    const instance = await getCacheInstance(undefined);
-    const state = (
-      globalThis as typeof globalThis & {
-        [CACHE_STATE_KEY]?: { memoryCache: unknown };
-      }
-    )[CACHE_STATE_KEY];
+  it('round-trips the fallback CSS payload', () => {
+    const payload = {
+      cssText: '.title{color:red}'.repeat(100),
+    };
+    const encodedPayload = encodeOutputCssPayload(payload);
 
-    expect(instance).toBe(memoryCache);
-    expect(state?.memoryCache).toBe(memoryCache);
-  });
-
-  it('reuses a registered cache provider id across lookups', async () => {
-    const id = registerCacheProvider(memoryCache);
-    const again = registerCacheProvider(memoryCache);
-    const resolved = await getCacheInstance(undefined, id);
-
-    expect(again).toBe(id);
-    expect(resolved).toBe(memoryCache);
+    expect(decodeOutputCssPayload(encodedPayload)).toEqual(payload);
+    expect(encodedPayload.length).toBeLessThan(payload.cssText.length);
+    expect(() => decodeOutputCssPayload('not-versioned')).toThrow(
+      'Invalid output CSS payload'
+    );
+    expect(() => decodeOutputCssPayload('v1.not-compressed')).toThrow(
+      'Invalid output CSS payload'
+    );
   });
 });

--- a/packages/webpack-loader/src/__tests__/cache.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache.test.ts
@@ -1,0 +1,57 @@
+import {
+  getCacheInstance,
+  memoryCache,
+  registerCacheProvider,
+  toCacheKey,
+} from '../cache';
+
+const CACHE_STATE_KEY = Symbol.for('@wyw-in-js/webpack-loader.cache');
+
+describe('webpack-loader cache keys', () => {
+  it('normalizes Windows path variants and query/hash suffixes', () => {
+    expect(toCacheKey('D:\\work\\app\\commonStyle.ts')).toBe(
+      'd:/work/app/commonStyle.ts'
+    );
+    expect(toCacheKey('D:/work/app/commonStyle.ts')).toBe(
+      'd:/work/app/commonStyle.ts'
+    );
+    expect(toCacheKey('d:/work/app/commonStyle.ts?wyw=wyw-in-js.css')).toBe(
+      'd:/work/app/commonStyle.ts'
+    );
+    expect(toCacheKey('D:\\work\\app\\commonStyle.ts#hash')).toBe(
+      'd:/work/app/commonStyle.ts'
+    );
+  });
+
+  it('reads CSS written with a different Windows path representation', async () => {
+    const cssText = '.title{color:red}';
+
+    await memoryCache.set('D:\\work\\app\\commonStyle.ts', cssText);
+
+    expect(await memoryCache.get('D:/work/app/commonStyle.ts')).toBe(cssText);
+    expect(
+      await memoryCache.get('d:\\work\\app\\commonStyle.ts?wyw=wyw-in-js.css')
+    ).toBe(cssText);
+  });
+
+  it('keeps the default memory cache on globalThis for isolated loader graphs', async () => {
+    const instance = await getCacheInstance(undefined);
+    const state = (
+      globalThis as typeof globalThis & {
+        [CACHE_STATE_KEY]?: { memoryCache: unknown };
+      }
+    )[CACHE_STATE_KEY];
+
+    expect(instance).toBe(memoryCache);
+    expect(state?.memoryCache).toBe(memoryCache);
+  });
+
+  it('reuses a registered cache provider id across lookups', async () => {
+    const id = registerCacheProvider(memoryCache);
+    const again = registerCacheProvider(memoryCache);
+    const resolved = await getCacheInstance(undefined, id);
+
+    expect(again).toBe(id);
+    expect(resolved).toBe(memoryCache);
+  });
+});

--- a/packages/webpack-loader/src/cache.ts
+++ b/packages/webpack-loader/src/cache.ts
@@ -9,20 +9,71 @@ export interface ICache {
   setDependencies?: (key: string, value: string[]) => Promise<void>;
 }
 
-let cacheProviderSeq = 0;
-const cacheProviderIds = new WeakMap<ICache, string>();
-const cacheProvidersById = new Map<string, ICache>();
+const CACHE_STATE_KEY = Symbol.for('@wyw-in-js/webpack-loader.cache');
+
+const stripQueryAndHash = (request: string) => {
+  const queryIdx = request.indexOf('?');
+  const hashIdx = request.indexOf('#');
+
+  if (queryIdx === -1) {
+    return hashIdx === -1 ? request : request.slice(0, hashIdx);
+  }
+  if (hashIdx === -1) return request.slice(0, queryIdx);
+
+  return request.slice(0, Math.min(queryIdx, hashIdx));
+};
+
+/**
+ * Webpack/Rspack may report the same Windows file with different separators
+ * or drive-letter casing, and outputCssLoader may keep a query suffix.
+ * Normalize those variants so the main loader and outputCssLoader share a key.
+ */
+export const toCacheKey = (resourcePath: string): string => {
+  const posixPath = stripQueryAndHash(resourcePath).replace(/\\/g, '/');
+  return posixPath.replace(
+    /^([A-Z]):\//,
+    (_match, drive: string) => `${drive.toLowerCase()}:/`
+  );
+};
+
+type CacheModuleState = {
+  cacheProviderIds: WeakMap<ICache, string>;
+  cacheProviderSeq: number;
+  cacheProvidersById: Map<string, ICache>;
+  memoryCache: MemoryCache;
+};
+
+const getCacheModuleState = (): CacheModuleState => {
+  const registry = globalThis as typeof globalThis & {
+    [CACHE_STATE_KEY]?: CacheModuleState;
+  };
+
+  const existing = registry[CACHE_STATE_KEY];
+  if (existing) {
+    return existing;
+  }
+
+  const created: CacheModuleState = {
+    cacheProviderIds: new WeakMap(),
+    cacheProviderSeq: 0,
+    cacheProvidersById: new Map(),
+    memoryCache: new MemoryCache(),
+  };
+  registry[CACHE_STATE_KEY] = created;
+  return created;
+};
 
 export const registerCacheProvider = (cacheProvider: ICache): string => {
-  const knownId = cacheProviderIds.get(cacheProvider);
+  const state = getCacheModuleState();
+  const knownId = state.cacheProviderIds.get(cacheProvider);
   if (knownId) {
     return knownId;
   }
 
-  cacheProviderSeq += 1;
-  const id = `${cacheProviderSeq}`;
-  cacheProviderIds.set(cacheProvider, id);
-  cacheProvidersById.set(id, cacheProvider);
+  state.cacheProviderSeq += 1;
+  const id = `${state.cacheProviderSeq}`;
+  state.cacheProviderIds.set(cacheProvider, id);
+  state.cacheProvidersById.set(id, cacheProvider);
   return id;
 };
 
@@ -34,25 +85,25 @@ class MemoryCache implements ICache {
   private dependenciesCache: Map<string, string[]> = new Map();
 
   public get(key: string): Promise<string> {
-    return Promise.resolve(this.cache.get(key) ?? '');
+    return Promise.resolve(this.cache.get(toCacheKey(key)) ?? '');
   }
 
   public getDependencies(key: string): Promise<string[]> {
-    return Promise.resolve(this.dependenciesCache.get(key) ?? []);
+    return Promise.resolve(this.dependenciesCache.get(toCacheKey(key)) ?? []);
   }
 
   public set(key: string, value: string): Promise<void> {
-    this.cache.set(key, value);
+    this.cache.set(toCacheKey(key), value);
     return Promise.resolve();
   }
 
   public setDependencies(key: string, value: string[]): Promise<void> {
-    this.dependenciesCache.set(key, value);
+    this.dependenciesCache.set(toCacheKey(key), value);
     return Promise.resolve();
   }
 }
 
-export const memoryCache = new MemoryCache();
+export const memoryCache = getCacheModuleState().memoryCache;
 
 /**
  * return cache instance from `options.cacheProvider`
@@ -64,7 +115,8 @@ export const getCacheInstance = async (
   cacheProviderId?: string | undefined
 ): Promise<ICache> => {
   if (cacheProviderId) {
-    const cacheProviderInstance = cacheProvidersById.get(cacheProviderId);
+    const cacheProviderInstance =
+      getCacheModuleState().cacheProvidersById.get(cacheProviderId);
     if (!cacheProviderInstance) {
       throw new Error(`Invalid cache provider id: ${cacheProviderId}`);
     }
@@ -73,7 +125,7 @@ export const getCacheInstance = async (
   }
 
   if (!cacheProvider) {
-    return memoryCache;
+    return getCacheModuleState().memoryCache;
   }
   if (typeof cacheProvider === 'string') {
     return nodeRequire(cacheProvider);

--- a/packages/webpack-loader/src/cache.ts
+++ b/packages/webpack-loader/src/cache.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'module';
+import { deflateRawSync, inflateRawSync } from 'node:zlib';
 
 const nodeRequire = createRequire(import.meta.url);
 
@@ -9,72 +10,84 @@ export interface ICache {
   setDependencies?: (key: string, value: string[]) => Promise<void>;
 }
 
-const CACHE_STATE_KEY = Symbol.for('@wyw-in-js/webpack-loader.cache');
+// Rspack can evaluate the two loaders in separate module graphs. Keep shared
+// runtime state on the compiler instead of leaking cache providers globally.
+const COMPILER_CACHE_STATE_KEY = Symbol.for(
+  '@wyw-in-js/webpack-loader.compiler-cache.v3'
+);
 
-const stripQueryAndHash = (request: string) => {
-  const queryIdx = request.indexOf('?');
-  const hashIdx = request.indexOf('#');
+const isWindowsAbsolutePath = (
+  resourcePath: string,
+  platform: NodeJS.Platform = process.platform
+): boolean =>
+  /^[A-Za-z]:[\\/]/.test(resourcePath) ||
+  /^\\\\/.test(resourcePath) ||
+  (platform === 'win32' && /^\/\//.test(resourcePath));
 
-  if (queryIdx === -1) {
-    return hashIdx === -1 ? request : request.slice(0, hashIdx);
+// Webpack's contextify expects native Windows paths. Only remove the extended
+// namespace that would otherwise make `?` look like a request query delimiter.
+export const toWebpackRequestPath = (
+  filePath: string,
+  platform: NodeJS.Platform = process.platform
+): string => {
+  if (platform === 'win32' && /^\/\/[^?/]/.test(filePath)) {
+    return filePath.replace(/\//g, '\\');
   }
-  if (hashIdx === -1) return request.slice(0, queryIdx);
 
-  return request.slice(0, Math.min(queryIdx, hashIdx));
+  if (!isWindowsAbsolutePath(filePath, platform)) {
+    return filePath;
+  }
+
+  const namespacePrefix = /^(?:\\\\\?\\|\/\/\?\/)/.exec(filePath);
+  if (!namespacePrefix) {
+    return filePath;
+  }
+
+  const namespacedPath = filePath.slice(namespacePrefix[0].length);
+  if (
+    namespacedPath
+      .split(/[\\/]/)
+      .some((segment) => segment.length > 0 && /[. ]$/.test(segment))
+  ) {
+    throw new Error(
+      `Unsupported Windows extended path with trailing dot or space: ${filePath}`
+    );
+  }
+
+  const namespacedUnc = /^UNC[\\/](.*)$/i.exec(namespacedPath);
+  if (namespacedUnc) {
+    return `\\\\${namespacedUnc[1].replace(/\//g, '\\')}`;
+  }
+
+  if (/^[A-Za-z]:[\\/]/.test(namespacedPath)) {
+    return namespacedPath;
+  }
+
+  throw new Error(`Unsupported Windows extended path namespace: ${filePath}`);
 };
 
 /**
  * Webpack/Rspack may report the same Windows file with different separators
- * or drive-letter casing, and outputCssLoader may keep a query suffix.
- * Normalize those variants so the main loader and outputCssLoader share a key.
+ * or drive-letter casing. Normalize those variants so the main loader and
+ * outputCssLoader share a key without changing valid POSIX filenames.
  */
-export const toCacheKey = (resourcePath: string): string => {
-  const posixPath = stripQueryAndHash(resourcePath).replace(/\\/g, '/');
+export const toCacheKey = (
+  resourcePath: string,
+  platform: NodeJS.Platform = process.platform
+): string => {
+  if (!isWindowsAbsolutePath(resourcePath, platform)) {
+    return resourcePath;
+  }
+
+  const posixPath = toWebpackRequestPath(resourcePath, platform).replace(
+    /\\/g,
+    '/'
+  );
+
   return posixPath.replace(
     /^([A-Z]):\//,
     (_match, drive: string) => `${drive.toLowerCase()}:/`
   );
-};
-
-type CacheModuleState = {
-  cacheProviderIds: WeakMap<ICache, string>;
-  cacheProviderSeq: number;
-  cacheProvidersById: Map<string, ICache>;
-  memoryCache: MemoryCache;
-};
-
-const getCacheModuleState = (): CacheModuleState => {
-  const registry = globalThis as typeof globalThis & {
-    [CACHE_STATE_KEY]?: CacheModuleState;
-  };
-
-  const existing = registry[CACHE_STATE_KEY];
-  if (existing) {
-    return existing;
-  }
-
-  const created: CacheModuleState = {
-    cacheProviderIds: new WeakMap(),
-    cacheProviderSeq: 0,
-    cacheProvidersById: new Map(),
-    memoryCache: new MemoryCache(),
-  };
-  registry[CACHE_STATE_KEY] = created;
-  return created;
-};
-
-export const registerCacheProvider = (cacheProvider: ICache): string => {
-  const state = getCacheModuleState();
-  const knownId = state.cacheProviderIds.get(cacheProvider);
-  if (knownId) {
-    return knownId;
-  }
-
-  state.cacheProviderSeq += 1;
-  const id = `${state.cacheProviderSeq}`;
-  state.cacheProviderIds.set(cacheProvider, id);
-  state.cacheProvidersById.set(id, cacheProvider);
-  return id;
 };
 
 // memory cache, which is the default cache implementation in WYW-in-JS
@@ -103,7 +116,107 @@ class MemoryCache implements ICache {
   }
 }
 
-export const memoryCache = getCacheModuleState().memoryCache;
+type CompilerCacheState = {
+  cacheProvidersByToken: Map<string, ICache>;
+  memoryCache: ICache;
+};
+
+export const memoryCache = new MemoryCache();
+
+const localCacheState: CompilerCacheState = {
+  cacheProvidersByToken: new Map(),
+  memoryCache,
+};
+
+const getCompilerCacheState = (cacheHost?: object): CompilerCacheState => {
+  if (!cacheHost) {
+    return localCacheState;
+  }
+
+  const host = cacheHost as typeof cacheHost & {
+    [COMPILER_CACHE_STATE_KEY]?: CompilerCacheState;
+  };
+
+  const existing = host[COMPILER_CACHE_STATE_KEY];
+  if (existing) {
+    return existing;
+  }
+
+  const created: CompilerCacheState = {
+    cacheProvidersByToken: new Map(),
+    memoryCache: new MemoryCache(),
+  };
+  host[COMPILER_CACHE_STATE_KEY] = created;
+  return created;
+};
+
+export const registerCacheProvider = (
+  cacheProvider: ICache,
+  cacheProviderToken: string,
+  cacheHost?: object
+): boolean => {
+  const registry = getCompilerCacheState(cacheHost);
+  const existingCacheProvider =
+    registry.cacheProvidersByToken.get(cacheProviderToken);
+  if (existingCacheProvider && existingCacheProvider !== cacheProvider) {
+    return false;
+  }
+
+  registry.cacheProvidersByToken.set(cacheProviderToken, cacheProvider);
+  return true;
+};
+
+export const clearCacheProviderRegistry = (cacheHost: object): void => {
+  const host = cacheHost as typeof cacheHost & {
+    [COMPILER_CACHE_STATE_KEY]?: CompilerCacheState;
+  };
+  delete host[COMPILER_CACHE_STATE_KEY];
+};
+
+export type OutputCssPayload = {
+  cssText: string;
+};
+
+const OUTPUT_CSS_PAYLOAD_VERSION = 'v1.';
+
+export const encodeOutputCssPayload = (payload: OutputCssPayload): string =>
+  `${OUTPUT_CSS_PAYLOAD_VERSION}${deflateRawSync(
+    Buffer.from(JSON.stringify(payload))
+  ).toString('base64url')}`;
+
+export const decodeOutputCssPayload = (
+  encodedPayload: string
+): OutputCssPayload => {
+  if (!encodedPayload.startsWith(OUTPUT_CSS_PAYLOAD_VERSION)) {
+    throw new Error('Invalid output CSS payload');
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(
+      inflateRawSync(
+        Buffer.from(
+          encodedPayload.slice(OUTPUT_CSS_PAYLOAD_VERSION.length),
+          'base64url'
+        )
+      ).toString('utf8')
+    );
+  } catch {
+    throw new Error('Invalid output CSS payload');
+  }
+  if (
+    !payload ||
+    typeof payload !== 'object' ||
+    !('cssText' in payload) ||
+    typeof payload.cssText !== 'string'
+  ) {
+    throw new Error('Invalid output CSS payload');
+  }
+
+  return {
+    cssText: payload.cssText,
+  };
+};
 
 /**
  * return cache instance from `options.cacheProvider`
@@ -112,21 +225,9 @@ export const memoryCache = getCacheModuleState().memoryCache;
  */
 export const getCacheInstance = async (
   cacheProvider: string | ICache | undefined,
-  cacheProviderId?: string | undefined
+  cacheHost?: object,
+  cacheProviderToken?: string
 ): Promise<ICache> => {
-  if (cacheProviderId) {
-    const cacheProviderInstance =
-      getCacheModuleState().cacheProvidersById.get(cacheProviderId);
-    if (!cacheProviderInstance) {
-      throw new Error(`Invalid cache provider id: ${cacheProviderId}`);
-    }
-
-    return cacheProviderInstance;
-  }
-
-  if (!cacheProvider) {
-    return getCacheModuleState().memoryCache;
-  }
   if (typeof cacheProvider === 'string') {
     return nodeRequire(cacheProvider);
   }
@@ -137,5 +238,18 @@ export const getCacheInstance = async (
   ) {
     return cacheProvider;
   }
-  throw new Error(`Invalid cache provider: ${cacheProvider}`);
+  if (cacheProvider !== undefined) {
+    throw new Error(`Invalid cache provider: ${cacheProvider}`);
+  }
+
+  const registry = getCompilerCacheState(cacheHost);
+  if (cacheProviderToken) {
+    const registeredCacheProvider =
+      registry.cacheProvidersByToken.get(cacheProviderToken);
+    if (registeredCacheProvider) {
+      return registeredCacheProvider;
+    }
+  }
+
+  return registry.memoryCache;
 };

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -25,13 +25,15 @@ import {
 
 import { sharedState } from './WYWinJSDebugPlugin';
 import type { ICache } from './cache';
-import { getCacheInstance, registerCacheProvider } from './cache';
+import { getCacheInstance, registerCacheProvider, toCacheKey } from './cache';
 
 export { WYWinJSDebugPlugin } from './WYWinJSDebugPlugin';
 
 const outputCssLoader = fileURLToPath(
   new URL('./outputCssLoader.js', import.meta.url)
-);
+).replace(/\\/g, '/');
+
+const toWebpackRequestPath = (filePath: string) => filePath.replace(/\\/g, '/');
 
 const stripQueryAndHash = (request: string) => {
   const queryIdx = request.indexOf('?');
@@ -406,15 +408,13 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
             );
 
             const cacheInstance = await getCacheInstance(cacheProvider);
-            const cacheProviderId =
-              cacheProvider && typeof cacheProvider === 'object'
-                ? registerCacheProvider(cacheInstance)
-                : '';
+            const cacheProviderId = registerCacheProvider(cacheInstance);
+            const cacheKey = toCacheKey(this.resourcePath);
 
-            await cacheInstance.set(this.resourcePath, cssText);
+            await cacheInstance.set(cacheKey, cssText);
 
             await cacheInstance.setDependencies?.(
-              this.resourcePath,
+              cacheKey,
               this.getDependencies()
             );
 
@@ -426,11 +426,13 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
               wywQuery.push(`v=${encodeURIComponent(hashText(cssText))}`);
             }
 
-            const resourcePathWithQuery = `${this.resourcePath}?${wywQuery.join(
-              '&'
-            )}`;
+            const resourcePathWithQuery = `${toWebpackRequestPath(
+              this.resourcePath
+            )}?${wywQuery.join('&')}`;
 
-            const request = `${outputFileName}!=!${outputCssLoader}?cacheProvider=${encodeURIComponent(
+            const request = `${toWebpackRequestPath(
+              outputFileName
+            )}!=!${outputCssLoader}?cacheProvider=${encodeURIComponent(
               typeof cacheProvider === 'string' ? cacheProvider : ''
             )}&cacheProviderId=${encodeURIComponent(
               cacheProviderId

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -25,15 +25,20 @@ import {
 
 import { sharedState } from './WYWinJSDebugPlugin';
 import type { ICache } from './cache';
-import { getCacheInstance, registerCacheProvider, toCacheKey } from './cache';
+import {
+  clearCacheProviderRegistry,
+  encodeOutputCssPayload,
+  getCacheInstance,
+  registerCacheProvider,
+  toCacheKey,
+  toWebpackRequestPath,
+} from './cache';
 
 export { WYWinJSDebugPlugin } from './WYWinJSDebugPlugin';
 
-const outputCssLoader = fileURLToPath(
-  new URL('./outputCssLoader.js', import.meta.url)
-).replace(/\\/g, '/');
-
-const toWebpackRequestPath = (filePath: string) => filePath.replace(/\\/g, '/');
+const outputCssLoader = toWebpackRequestPath(
+  fileURLToPath(new URL('./outputCssLoader.js', import.meta.url))
+);
 
 const stripQueryAndHash = (request: string) => {
   const queryIdx = request.indexOf('?');
@@ -48,7 +53,9 @@ const stripQueryAndHash = (request: string) => {
 };
 
 const hashText = (text: string): string =>
-  crypto.createHash('sha256').update(text).digest('hex').slice(0, 12);
+  crypto.createHash('sha256').update(text).digest('hex');
+
+const shortHashText = (text: string): string => hashText(text).slice(0, 12);
 
 export type LoaderOptions = {
   cacheProvider?: string | ICache;
@@ -94,6 +101,46 @@ type CompilerLike = Compiler & {
 
 type LoaderContextWithCompiler = {
   _compiler?: CompilerLike;
+};
+
+const hasCompilerHooks = (
+  compiler: CompilerLike | undefined
+): compiler is CompilerLike => {
+  const hooks = compiler?.hooks;
+  return Boolean(
+    hooks &&
+      [hooks.done, hooks.failed, hooks.shutdown, hooks.watchClose].some(
+        (hook) => typeof hook?.tap === 'function'
+      )
+  );
+};
+
+const shouldSerializeOutputCssPayload = (
+  compiler: CompilerLike | undefined
+): boolean => {
+  if (!compiler || typeof compiler.getCache !== 'function') {
+    return true;
+  }
+
+  const webpackCache = compiler.options?.cache;
+  if (
+    webpackCache &&
+    typeof webpackCache === 'object' &&
+    webpackCache.type === 'filesystem'
+  ) {
+    return true;
+  }
+
+  const experiments = compiler.options?.experiments as
+    | { cache?: unknown }
+    | undefined;
+  const rspackCache = experiments?.cache;
+  return Boolean(
+    rspackCache &&
+      typeof rspackCache === 'object' &&
+      'type' in rspackCache &&
+      rspackCache.type === 'persistent'
+  );
 };
 
 type ResolverScope = {
@@ -182,9 +229,10 @@ const createResolverScope = (): ResolverScope => {
   };
 };
 
-const disposeCompilerState = (state: CompilerState) => {
+const disposeCompilerState = (compiler: CompilerLike, state: CompilerState) => {
   state.clearResolvers();
   disposeEvalBroker(state.cache);
+  clearCacheProviderRegistry(compiler);
 };
 
 const getCompilerState = (compiler: CompilerLike): CompilerState => {
@@ -199,7 +247,7 @@ const getCompilerState = (compiler: CompilerLike): CompilerState => {
   const state: CompilerState = {
     ...scope,
     clearResolvers: scope.dispose,
-    dispose: () => disposeCompilerState(state),
+    dispose: () => disposeCompilerState(compiler, state),
     hooksInstalled: false,
   };
 
@@ -314,7 +362,10 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
     });
 
   const { resourcePath } = this;
-  const { _compiler: compiler } = this as LoaderContextWithCompiler;
+  const { _compiler: loaderCompiler } = this as LoaderContextWithCompiler;
+  const compiler = hasCompilerHooks(loaderCompiler)
+    ? loaderCompiler
+    : undefined;
   const compilerState = compiler
     ? getCompilerState(compiler)
     : createInvocationScope();
@@ -351,7 +402,7 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
     key: asyncResolveKey,
   } = compilerState;
   const nativeResolverAlias = toNativeResolverAlias(
-    compiler?.options?.resolve?.alias
+    loaderCompiler?.options?.resolve?.alias
   );
 
   logger('loader %s', this.resourcePath);
@@ -407,36 +458,76 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
               ) ?? []
             );
 
-            const cacheInstance = await getCacheInstance(cacheProvider);
-            const cacheProviderId = registerCacheProvider(cacheInstance);
             const cacheKey = toCacheKey(this.resourcePath);
+            const cacheInstance = await getCacheInstance(
+              cacheProvider,
+              compiler
+            );
+            const currentLoader = this.loaders?.[this.loaderIndex];
+            let cacheProviderToken =
+              cacheProvider &&
+              typeof cacheProvider === 'object' &&
+              compiler &&
+              currentLoader?.ident
+                ? hashText(currentLoader.ident)
+                : undefined;
+            if (
+              cacheProviderToken &&
+              !registerCacheProvider(
+                cacheInstance,
+                cacheProviderToken,
+                compiler
+              )
+            ) {
+              // A reused ident cannot safely select between two provider
+              // objects. Keep the first registration valid and make this
+              // request self-contained instead.
+              cacheProviderToken = undefined;
+            }
+            const dependencies = [...this.getDependencies()].sort();
 
             await cacheInstance.set(cacheKey, cssText);
 
-            await cacheInstance.setDependencies?.(
-              cacheKey,
-              this.getDependencies()
-            );
+            await cacheInstance.setDependencies?.(cacheKey, dependencies);
 
             const wywQuery = [
               `wyw=${encodeURIComponent(extension.replace(/^\./, ''))}`,
             ];
 
             if (this.hot) {
-              wywQuery.push(`v=${encodeURIComponent(hashText(cssText))}`);
+              wywQuery.push(`v=${encodeURIComponent(shortHashText(cssText))}`);
             }
 
             const resourcePathWithQuery = `${toWebpackRequestPath(
               this.resourcePath
             )}?${wywQuery.join('&')}`;
 
+            const outputLoaderQuery = new URLSearchParams();
+            if (typeof cacheProvider === 'string') {
+              outputLoaderQuery.set('cacheProvider', cacheProvider);
+            }
+            if (cacheProviderToken) {
+              outputLoaderQuery.set('cacheProviderToken', cacheProviderToken);
+            }
+            if (
+              shouldSerializeOutputCssPayload(loaderCompiler) ||
+              (cacheProvider &&
+                typeof cacheProvider === 'object' &&
+                !cacheProviderToken)
+            ) {
+              outputLoaderQuery.set(
+                'outputCssPayload',
+                encodeOutputCssPayload({ cssText })
+              );
+            }
+            const outputLoaderOptions = outputLoaderQuery.toString();
+            const outputLoaderRequest = outputLoaderOptions
+              ? `${outputCssLoader}?${outputLoaderOptions}`
+              : outputCssLoader;
+
             const request = `${toWebpackRequestPath(
               outputFileName
-            )}!=!${outputCssLoader}?cacheProvider=${encodeURIComponent(
-              typeof cacheProvider === 'string' ? cacheProvider : ''
-            )}&cacheProviderId=${encodeURIComponent(
-              cacheProviderId
-            )}!${resourcePathWithQuery}`;
+            )}!=!${outputLoaderRequest}!${resourcePathWithQuery}`;
             const stringifiedRequest = JSON.stringify(
               this.utils.contextify(this.context || this.rootContext, request)
             );

--- a/packages/webpack-loader/src/outputCssLoader.ts
+++ b/packages/webpack-loader/src/outputCssLoader.ts
@@ -1,33 +1,50 @@
 import type webpack from 'webpack';
 
 import type { ICache } from './cache';
-import { getCacheInstance, toCacheKey } from './cache';
+import { decodeOutputCssPayload, getCacheInstance, toCacheKey } from './cache';
 
 export default async function outputCssLoader(
   this: webpack.LoaderContext<{
     cacheProvider: string | ICache | undefined;
-    cacheProviderId?: string | undefined;
+    cacheProviderToken?: string | undefined;
+    outputCssPayload?: string | undefined;
   }>
 ) {
   this.async();
-  const { cacheProvider, cacheProviderId } = this.getOptions();
+  const { cacheProvider, cacheProviderToken, outputCssPayload } =
+    this.getOptions();
 
   try {
-    const cacheInstance = await getCacheInstance(
-      cacheProvider,
-      cacheProviderId
-    );
+    // A serialized payload is tied to this exact module request. Prefer it to
+    // runtime state, which may belong to a later compilation after a restart.
+    // Transform dependencies stay on the cached parent module, so the payload
+    // does not need to duplicate machine-specific absolute paths.
+    if (outputCssPayload) {
+      const payload = decodeOutputCssPayload(outputCssPayload);
+      this.callback(null, payload.cssText);
+      return;
+    }
 
     const cacheKey = toCacheKey(this.resourcePath);
-    const result = await cacheInstance.get(cacheKey);
-    const dependencies =
-      (await cacheInstance.getDependencies?.(cacheKey)) ?? [];
+    const cacheInstance = await getCacheInstance(
+      cacheProvider,
+      this._compiler,
+      cacheProviderToken
+    );
+    const cachedCssText = await cacheInstance.get(cacheKey);
 
-    dependencies.forEach((dependency) => {
-      this.addDependency(dependency);
-    });
+    if (cachedCssText) {
+      const dependencies =
+        (await cacheInstance.getDependencies?.(cacheKey)) ?? [];
+      dependencies.forEach((dependency) => {
+        this.addDependency(dependency);
+      });
 
-    this.callback(null, result);
+      this.callback(null, cachedCssText);
+      return;
+    }
+
+    throw new Error(`CSS cache entry not found for ${this.resourcePath}`);
   } catch (err) {
     this.callback(err as Error);
   }

--- a/packages/webpack-loader/src/outputCssLoader.ts
+++ b/packages/webpack-loader/src/outputCssLoader.ts
@@ -1,7 +1,7 @@
 import type webpack from 'webpack';
 
 import type { ICache } from './cache';
-import { getCacheInstance } from './cache';
+import { getCacheInstance, toCacheKey } from './cache';
 
 export default async function outputCssLoader(
   this: webpack.LoaderContext<{
@@ -18,9 +18,10 @@ export default async function outputCssLoader(
       cacheProviderId
     );
 
-    const result = await cacheInstance.get(this.resourcePath);
+    const cacheKey = toCacheKey(this.resourcePath);
+    const result = await cacheInstance.get(cacheKey);
     const dependencies =
-      (await cacheInstance.getDependencies?.(this.resourcePath)) ?? [];
+      (await cacheInstance.getDependencies?.(cacheKey)) ?? [];
 
     dependencies.forEach((dependency) => {
       this.addDependency(dependency);


### PR DESCRIPTION
## Motivation

`@wyw-in-js/webpack-loader` generates Linaria class names under Rspack on Windows, but the final bundle contains no extracted CSS. The transform writes CSS into the in-memory cache, then injects `outputCssLoader`, which reads an empty value for the same-looking file.

This matches a Windows-only Rspack failure: Linux CI is fine, webpack is fine. Two things can miss the cache:

1. Rspack can evaluate `index.js` and `outputCssLoader.js` in separate module graphs, so the module-level `memoryCache` singleton is created twice.
2. Windows/`resourcePath` can differ by `\` vs `/`, drive-letter case, or a leftover query, so `Map.get` misses even when the paths look the same in logs.

## Summary

- Store the default memory cache and cache-provider registry on `globalThis` so isolated loader graphs share one instance.
- Always register the active cache provider and pass `cacheProviderId` into `outputCssLoader` (not only object providers).
- Normalize cache keys and webpack inline request paths so Windows path variants resolve to the same entry.
- Add unit and loader tests for path variants and the process-wide cache.

## Test plan

- [x] `bun test src` in `packages/webpack-loader` — 15 pass
- [ ] Rspack on Windows: a `css`/`styled` file should emit hashed selectors in the extracted CSS (not only class names in JS)
- [ ] Webpack build still emits CSS as before
- [ ] Linux/macOS Rspack or webpack build is unchanged
- [ ] HMR still busts CSS via `v=<hash>` when `this.hot` is set


Made with [Cursor](https://cursor.com)