### PR TITLE
feat(transform): add pipeline telemetry to the file reporter

### DIFF
--- a/.changeset/quiet-pipeline-telemetry.md
+++ b/.changeset/quiet-pipeline-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Add root-scoped pipeline counters to file reporter output without changing transform results.

--- a/packages/transform/src/__tests__/fileReporter.test.ts
+++ b/packages/transform/src/__tests__/fileReporter.test.ts
@@ -3,7 +3,15 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { createFileReporter } from '../debug/fileReporter';
+import {
+  beginPipelineShake,
+  finishPipelineShake,
+  recordPipelineCacheRequest,
+  recordPipelineProcessors,
+  runWithPipelineTelemetry,
+} from '../debug/pipelineTelemetry';
 import { EventEmitter } from '../utils/EventEmitter';
+import { parseOxcCached } from '../utils/parseOxc';
 
 const delay = (intervalMs: number) =>
   new Promise<void>((resolve) => {
@@ -156,6 +164,190 @@ describe('createFileReporter', () => {
       );
       expect(events[0].filename).toContain('foo.ts');
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes one pipeline telemetry summary per transform root', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    const reporter = createFileReporter({ dir });
+
+    try {
+      await runWithPipelineTelemetry(
+        reporter.emitter,
+        () => ({ filename: join(dir, 'root.ts') }),
+        async () => {
+          recordPipelineCacheRequest('entrypoints', 'get', true);
+          recordPipelineProcessors('preeval', false, 1, 1, 0, 0, 0);
+          const code = 'export const value: number = 1;';
+          parseOxcCached(join(dir, 'root.ts'), code, 'module');
+          parseOxcCached(join(dir, 'root.ts'), code, 'module');
+          const shakeToken = beginPipelineShake(
+            'export const unused = 1;',
+            ['unused'],
+            'preval'
+          );
+          finishPipelineShake(shakeToken, 'export {};', false);
+        }
+      );
+
+      reporter.onDone(dir);
+
+      const target = join(dir, 'pipeline-telemetry.jsonl');
+      await waitFor(() => hasJsonlLines(target, 2));
+
+      const events = readJsonl(target);
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          denominators: expect.any(Object),
+          schemaVersion: 1,
+          tupleEncoding: expect.objectContaining({
+            layouts: expect.objectContaining({
+              parseRevision: [
+                'revision',
+                'parserKeyIdOrString',
+                'bytes',
+                'requests',
+                'mask',
+                '...values',
+              ],
+            }),
+            masks: {
+              parseRevision: {
+                cacheHits: 2,
+                cacheMisses: 4,
+                errors: 8,
+                jsxFallbackAttempts: 32,
+                jsxFallbackRequests: 16,
+                kind: 1,
+              },
+              processor: {
+                definedProcessors: 1,
+                importCandidates: 2,
+                lookupAttempts: 4,
+                lookupHits: 8,
+                passes: 16,
+                reusedPlans: 32,
+                usages: 64,
+              },
+              shakeCall: { error: 1, generatedBytes: 2 },
+            },
+          }),
+          type: 'pipeline-telemetry-schema',
+        })
+      );
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          cache: [1, 1, 0, 0, 0, [0, 0, 0, 0, 0, []], [[1, 0, 1, 0, 1]], []],
+          root: expect.objectContaining({
+            filename: expect.stringContaining('root.ts'),
+            status: 'success',
+          }),
+          schemaVersion: 1,
+          type: 'pipeline-telemetry',
+        })
+      );
+      expect(events[1].parse).toEqual([
+        [2, 2, 0, 1, 1, 1, 62, 31, 0, 0, 0],
+        [[expect.any(String), 10, 31, 2, 6, 1, 1]],
+      ]);
+      expect(events[1].processors).toEqual([['preeval', 6, 1, 1]]);
+      expect(events[1].shakes).toEqual([
+        1,
+        1,
+        0,
+        10,
+        [
+          [
+            expect.any(String),
+            'preval',
+            ['unused'],
+            expect.any(String),
+            24,
+            2,
+            10,
+          ],
+        ],
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('flushes prior roots with an error root before onDone without duplicates', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    const reporter = createFileReporter({ dir });
+    const target = join(dir, 'pipeline-telemetry.jsonl');
+
+    try {
+      await runWithPipelineTelemetry(
+        reporter.emitter,
+        () => ({ filename: join(dir, 'success.ts') }),
+        async () => 1
+      );
+      await expect(
+        runWithPipelineTelemetry(
+          reporter.emitter,
+          () => ({ filename: join(dir, 'error.ts') }),
+          async () => {
+            throw new Error('transform failed');
+          }
+        )
+      ).rejects.toThrow('transform failed');
+
+      await waitFor(() => hasJsonlLines(target, 3));
+      expect(readJsonl(target).map((event) => event.root?.status)).toEqual([
+        undefined,
+        'success',
+        'error',
+      ]);
+
+      reporter.onDone(dir);
+      reporter.onDone(dir);
+      await delay(5);
+      expect(readJsonl(target)).toHaveLength(3);
+    } finally {
+      reporter.onDone(dir);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes every root exactly once across the telemetry chunk boundary', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    const reporter = createFileReporter({ dir });
+    const target = join(dir, 'pipeline-telemetry.jsonl');
+    const suffix = 'x'.repeat(130 * 1024);
+    const filenames = [`a-${suffix}`, `b-${suffix}`, `c-${suffix}`];
+
+    try {
+      for (const filename of filenames) {
+        // Preserve root emission order while exercising the shared writer.
+        // eslint-disable-next-line no-await-in-loop
+        await runWithPipelineTelemetry(
+          reporter.emitter,
+          () => ({ filename }),
+          async () => undefined
+        );
+      }
+
+      await waitFor(() => hasJsonlLines(target, 3));
+      expect(
+        readJsonl(target)
+          .slice(1)
+          .map((event) => event.root.filename)
+      ).toEqual(filenames.slice(0, 2));
+
+      reporter.onDone(dir);
+      reporter.onDone(dir);
+      await waitFor(() => hasJsonlLines(target, 4));
+      expect(
+        readJsonl(target)
+          .slice(1)
+          .map((event) => event.root.filename)
+      ).toEqual(filenames);
+    } finally {
+      reporter.onDone(dir);
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -360,11 +552,73 @@ describe('createFileReporter', () => {
     }
   });
 
-  it('returns a dummy reporter when no dir is provided', () => {
+  it('drops pipeline telemetry safely when its stream fails to open', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    mkdirSync(join(dir, 'pipeline-telemetry.jsonl'));
+
+    const warnings: unknown[][] = [];
+    // eslint-disable-next-line no-console
+    const originalWarn = console.warn;
+    // eslint-disable-next-line no-console
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      const reporter = createFileReporter({ dir });
+      await waitFor(() => warnings.length > 0);
+
+      await expect(
+        runWithPipelineTelemetry(
+          reporter.emitter,
+          () => ({ filename: join(dir, 'root.ts') }),
+          async () => 42
+        )
+      ).resolves.toBe(42);
+      reporter.emitter.single({
+        filename: join(dir, 'root.ts'),
+        phase: 'export',
+        reason: 'unsupported-expression',
+        status: 'rejected',
+        type: 'staticResolve',
+      });
+
+      expect(() => reporter.onDone(dir)).not.toThrow();
+      expect(() => reporter.onDone(dir)).not.toThrow();
+      const target = join(dir, 'static-resolve.jsonl');
+      await waitFor(() => hasJsonlLines(target, 1));
+
+      expect(readJsonl(target)).toHaveLength(1);
+      expect(warnings).toHaveLength(1);
+      expect(String(warnings[0][0])).toContain('pipeline-telemetry.jsonl');
+    } finally {
+      // eslint-disable-next-line no-console
+      console.warn = originalWarn;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a dummy reporter without evaluating telemetry metadata', async () => {
     const reporter = createFileReporter(false);
+    let metadataCalls = 0;
+
     expect(() =>
       reporter.emitter.single({ type: 'staticResolve' })
     ).not.toThrow();
+    await expect(
+      runWithPipelineTelemetry(
+        reporter.emitter,
+        () => {
+          metadataCalls += 1;
+          return { filename: '/project/root.ts' };
+        },
+        async () => {
+          recordPipelineCacheRequest('entrypoints', 'get', true);
+          return 42;
+        }
+      )
+    ).resolves.toBe(42);
+    expect(metadataCalls).toBe(0);
     expect(() => reporter.onDone('/')).not.toThrow();
   });
 });

--- a/packages/transform/src/__tests__/pipelineTelemetry.test.ts
+++ b/packages/transform/src/__tests__/pipelineTelemetry.test.ts
@@ -1,0 +1,1444 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TransformCacheCollection } from '../cache';
+import { EventEmitter } from '../utils/EventEmitter';
+import {
+  beginPipelineCleanup,
+  beginPipelineDangerousCode,
+  beginPipelineShake,
+  finishPipelineCleanup,
+  finishPipelineDangerousCode,
+  finishPipelineShake,
+  getPipelineCodeSha256Hex,
+  PIPELINE_TELEMETRY_SCHEMA,
+  recordPipelineCacheRequest,
+  recordPipelineCacheClear,
+  recordPipelineCacheSalt,
+  recordPipelineCleanupIteration,
+  recordPipelineDisposableRoot,
+  recordPipelineEntrypoint,
+  recordPipelineLateNoMetadata,
+  recordPipelineProcessors,
+  recordPipelineUncachedParse,
+  registerPipelineTelemetryJSONlReporter,
+  registerPipelineTelemetryReporter,
+  runWithoutPipelineTelemetry,
+  runWithPipelineTelemetry,
+  type PipelineTelemetryCompactSummary,
+  type PipelineTelemetrySummary,
+} from '../debug/pipelineTelemetry';
+import {
+  getCodeMeasurement,
+  measureCode,
+  setCodeMeasurement,
+} from '../debug/pipelineTelemetry.measurements';
+import {
+  createAccumulator,
+  releaseAccumulator,
+} from '../debug/pipelineTelemetry.state';
+import type { CodeMeasurementCache } from '../debug/pipelineTelemetry.types';
+import { transform } from '../transform';
+import { parseFile } from '../transform/Entrypoint.helpers';
+import { removeUnusedAfterReplacement } from '../utils/applyOxcProcessors/cleanup-after-replacement';
+import { parseOxcCached } from '../utils/parseOxc';
+
+const createEmitter = () =>
+  new EventEmitter(
+    () => {},
+    () => 0,
+    () => {}
+  );
+
+const revisionOf = (code: string): string =>
+  createHash('sha256').update(code).digest('base64url');
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const runTransform = async (
+  root: string,
+  filename: string,
+  code: string,
+  emitter: EventEmitter
+) =>
+  transform(
+    {
+      cache: new TransformCacheCollection(),
+      eventEmitter: emitter,
+      options: {
+        filename,
+        root,
+        pluginOptions: {
+          configFile: false,
+          tagResolver: (source, tag) =>
+            source === 'test-css-processor' && tag === 'css'
+              ? processorFile
+              : null,
+        },
+      },
+    },
+    code,
+    async (what) => {
+      if (what === 'test-css-processor') {
+        return processorFile;
+      }
+
+      throw new Error(`Unable to resolve ${JSON.stringify(what)}`);
+    }
+  );
+
+describe('pipeline telemetry boundary', () => {
+  it('reuses the exact SHA-256 digest across cache and telemetry encodings', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const code = 'export const greeting = "γειά 👋";';
+    const samples = ['plain ascii', 'nul\0byte', 'emoji 👋', '\ud800'];
+
+    expect(getPipelineCodeSha256Hex(code)).toBeUndefined();
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/digest.ts' }),
+      async () => {
+        const cache = new TransformCacheCollection<{
+          dependencies: Map<string, { resolved: string | null }>;
+          initialCode: string;
+        }>();
+        [...samples, code].forEach((content, index) => {
+          const filename = `/project/digest-${index}.ts`;
+          cache.add('entrypoints', filename, {
+            dependencies: new Map(),
+            initialCode: content,
+          });
+          expect(getPipelineCodeSha256Hex(content)).toBe(
+            createHash('sha256').update(content).digest('hex')
+          );
+          expect(cache.invalidateIfChanged(filename, content)).toBe(false);
+        });
+        parseFile(undefined, '/project/digest.ts', code);
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].parse.revisions).toEqual([
+      expect.objectContaining({
+        parsedBytes: Buffer.byteLength(code),
+        requestedBytes: Buffer.byteLength(code),
+        revision: revisionOf(code),
+      }),
+    ]);
+    expect(getPipelineCodeSha256Hex(code)).toBeUndefined();
+  });
+
+  it('keeps distinct revisions that collide in the numeric lookup fingerprint', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const first = 'a111m111z';
+    const second = 'a222m222z';
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/fingerprint.ts' }),
+      async () => {
+        recordPipelineUncachedParse(
+          '/project/first.ts',
+          first,
+          'module',
+          'ts',
+          false
+        );
+        recordPipelineUncachedParse(
+          '/project/second.ts',
+          second,
+          'module',
+          'ts',
+          false
+        );
+      }
+    );
+    unregister();
+
+    expect(summaries[0].parse.revisions).toEqual([
+      expect.objectContaining({ revision: revisionOf(first) }),
+      expect.objectContaining({ revision: revisionOf(second) }),
+    ]);
+  });
+
+  it('canonicalizes cached measurements created by different reporters', async () => {
+    const code = 'export const shared: number = 1;';
+    const firstFilename = '/project/first-shared.ts';
+    const secondFilename = '/project/second-shared.ts';
+
+    for (const filename of [firstFilename, secondFilename]) {
+      const emitter = createEmitter();
+      const unregister = registerPipelineTelemetryReporter(emitter, () => {});
+      // Keep the reporter identities and cache warmups deliberately separate.
+      // eslint-disable-next-line no-await-in-loop
+      await runWithPipelineTelemetry(
+        emitter,
+        () => ({ filename }),
+        async () => parseOxcCached(filename, code, 'module')
+      );
+      unregister();
+    }
+
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/current-root.ts' }),
+      async () => {
+        parseOxcCached(firstFilename, code, 'module');
+        parseOxcCached(secondFilename, code, 'module');
+      }
+    );
+    unregister();
+
+    expect(summaries[0].parse.revisions).toEqual([
+      expect.objectContaining({
+        cacheHits: 2,
+        cacheMisses: 0,
+        requests: 2,
+        revision: revisionOf(code),
+      }),
+    ]);
+  });
+
+  it('bounds and reuses shared code measurements across roots', () => {
+    const cache: CodeMeasurementCache = {
+      codeUnits: 0,
+      count: 0,
+      entries: new Map(),
+      evictionKeys: [][Symbol.iterator](),
+    };
+    cache.evictionKeys = cache.entries.keys();
+    const firstAccumulator = createAccumulator('/project/first.ts', cache);
+    let oldestCode = '';
+    let newestCode = '';
+    let newestMeasurement: { bytes: number; revision: string } | undefined;
+
+    for (let index = 0; index < 4_097; index += 1) {
+      const code = String.fromCharCode(
+        33 + Math.floor(index / 1_024),
+        97,
+        33 + (Math.floor(index / 32) % 32),
+        97,
+        33 + (index % 32)
+      );
+      const measurement = { bytes: 5, revision: `revision-${index}` };
+      setCodeMeasurement(firstAccumulator, code, measurement);
+      if (index === 0) oldestCode = code;
+      if (index === 4_096) {
+        newestCode = code;
+        newestMeasurement = measurement;
+      }
+    }
+    releaseAccumulator(firstAccumulator);
+
+    expect(cache).toMatchObject({
+      codeUnits: 4_096 * 5,
+      count: 4_096,
+    });
+    expect(cache.entries.size).toBe(4_096);
+
+    const secondAccumulator = createAccumulator('/project/second.ts', cache);
+    expect(getCodeMeasurement(secondAccumulator, oldestCode)).toBeUndefined();
+    expect(getCodeMeasurement(secondAccumulator, newestCode)).toBe(
+      newestMeasurement
+    );
+    const replacement = { bytes: 5, revision: 'replacement' };
+    setCodeMeasurement(secondAccumulator, newestCode, replacement);
+    expect(getCodeMeasurement(secondAccumulator, newestCode)).toBe(replacement);
+    expect(cache).toMatchObject({
+      codeUnits: 4_096 * 5,
+      count: 4_096,
+    });
+    releaseAccumulator(secondAccumulator);
+  });
+
+  it('upgrades a shared bytes-only measurement without changing retention', () => {
+    const entries: CodeMeasurementCache['entries'] = new Map();
+    const cache: CodeMeasurementCache = {
+      codeUnits: 0,
+      count: 0,
+      entries,
+      evictionKeys: entries.keys(),
+    };
+    const code = 'same';
+    const firstAccumulator = createAccumulator('/project/first.ts', cache);
+    setCodeMeasurement(firstAccumulator, code, { bytes: code.length });
+    releaseAccumulator(firstAccumulator);
+
+    const secondAccumulator = createAccumulator('/project/second.ts', cache);
+    expect(measureCode(secondAccumulator, code).revision).toBe(
+      revisionOf(code)
+    );
+    expect(cache).toMatchObject({
+      codeUnits: code.length,
+      count: 1,
+    });
+    expect(cache.entries.size).toBe(1);
+    releaseAccumulator(secondAccumulator);
+  });
+
+  it('does not evaluate root metadata when no internal reporter is registered', async () => {
+    let metadataCalls = 0;
+
+    await expect(
+      runWithPipelineTelemetry(
+        EventEmitter.dummy,
+        () => {
+          metadataCalls += 1;
+          throw new Error('disabled telemetry evaluated its payload');
+        },
+        async () => 42
+      )
+    ).resolves.toBe(42);
+
+    expect(metadataCalls).toBe(0);
+  });
+
+  it('keeps transform output and later roots intact when a JSONL sink throws', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-pipeline-telemetry-'));
+    const filename = join(root, 'plain.ts');
+    const code = 'export const answer: number = 42;';
+    const emitter = createEmitter();
+    let throwingSinkCalls = 0;
+    const unregisterThrowing = registerPipelineTelemetryJSONlReporter(
+      emitter,
+      root,
+      () => {
+        throwingSinkCalls += 1;
+        throw new Error('telemetry sink failed');
+      }
+    );
+
+    try {
+      const withoutReporter = await runTransform(
+        root,
+        filename,
+        code,
+        createEmitter()
+      );
+      const withThrowingReporter = await runTransform(
+        root,
+        filename,
+        code,
+        emitter
+      );
+      expect(withThrowingReporter).toEqual(withoutReporter);
+      expect(throwingSinkCalls).toBe(1);
+      unregisterThrowing();
+
+      const lines: string[] = [];
+      const statuses: string[] = [];
+      const unregisterWorking = registerPipelineTelemetryJSONlReporter(
+        emitter,
+        root,
+        (line, status) => {
+          lines.push(line);
+          statuses.push(status);
+        }
+      );
+      await runTransform(root, filename, code, emitter);
+      unregisterWorking();
+
+      expect(lines).toHaveLength(1);
+      expect(statuses).toEqual(['success']);
+      expect(JSON.parse(lines[0])).toMatchObject({
+        root: { filename: 'plain.ts', status: 'success' },
+      });
+    } finally {
+      unregisterThrowing();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('flushes a fresh summary after both successful and failed roots', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/first.ts' }),
+      async () => {
+        recordPipelineCacheRequest('entrypoints', 'get', true);
+      }
+    );
+
+    await expect(
+      runWithPipelineTelemetry(
+        emitter,
+        () => ({ filename: '/project/second.ts' }),
+        async () => {
+          recordPipelineCacheRequest('exports', 'has', false);
+          throw new Error('expected failure');
+        }
+      )
+    ).rejects.toThrow('expected failure');
+
+    unregister();
+
+    expect(summaries).toHaveLength(2);
+    expect(summaries[0]).toMatchObject({
+      cache: {
+        requests: 1,
+      },
+      root: {
+        filename: '/project/first.ts',
+        status: 'success',
+      },
+    });
+    expect(summaries[1]).toMatchObject({
+      cache: {
+        requests: 1,
+      },
+      root: {
+        filename: '/project/second.ts',
+        status: 'error',
+      },
+    });
+    expect(summaries[0].cache.byOperation).toEqual([
+      {
+        cache: 'entrypoints',
+        hits: 1,
+        misses: 0,
+        operation: 'get',
+        requests: 1,
+      },
+    ]);
+    expect(summaries[1].cache.byOperation).toEqual([
+      {
+        cache: 'exports',
+        hits: 0,
+        misses: 1,
+        operation: 'has',
+        requests: 1,
+      },
+    ]);
+  });
+
+  it('omits empty sections from compact summaries without dropping alternate denominators', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetryCompactSummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(
+      emitter,
+      (summary) => summaries.push(summary),
+      true
+    );
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/empty.ts' }),
+      async () => {}
+    );
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/salt.ts' }),
+      async () => recordPipelineCacheSalt(null, 'salt', 'migrate')
+    );
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/clear.ts' }),
+      async () => recordPipelineCacheClear('entrypoints', 'explicit', 0)
+    );
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/disposable.ts' }),
+      async () =>
+        recordPipelineDisposableRoot('/project/disposable.ts', 'collect')
+    );
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/processors.ts' }),
+      async () => recordPipelineProcessors('preeval', false, 3, 2, 1, 1, 4)
+    );
+    const compactParseCode = 'export const compact: number = 1;';
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/compact-parse.ts' }),
+      async () => {
+        parseOxcCached('/project/compact-parse.ts', compactParseCode, 'module');
+        parseOxcCached('/project/compact-parse.ts', compactParseCode, 'module');
+      }
+    );
+    unregister();
+
+    expect(summaries[0]).toEqual({
+      root: { filename: '/project/empty.ts', status: 'success' },
+      schemaVersion: 1,
+      type: 'pipeline-telemetry',
+    });
+    expect(summaries[1]).toEqual(
+      expect.objectContaining({
+        cache: expect.objectContaining({
+          requests: 0,
+          salt: {
+            calls: 1,
+            changes: [{ current: 'salt', outcome: 'migrate', previous: null }],
+            clears: 0,
+            disables: 0,
+            migrations: 1,
+            unchanged: 0,
+          },
+        }),
+      })
+    );
+    expect(summaries[2]).toEqual(
+      expect.objectContaining({
+        cache: expect.objectContaining({ clearRequests: 1, requests: 0 }),
+      })
+    );
+    expect(summaries[3]).toEqual(
+      expect.objectContaining({
+        entrypoints: expect.objectContaining({
+          disposableRoots: 1,
+          requests: 0,
+        }),
+      })
+    );
+    expect(summaries[4].processors).toEqual({
+      byPhase: [
+        {
+          definedProcessors: 1,
+          importCandidates: 3,
+          lookupAttempts: 2,
+          lookupHits: 1,
+          passes: 1,
+          phase: 'preeval',
+          reusedPlans: 0,
+          usages: 4,
+        },
+      ],
+    });
+    expect(summaries[5].parse?.revisions).toEqual([
+      {
+        bytes: Buffer.byteLength(compactParseCode),
+        cacheHits: 1,
+        cacheMisses: 1,
+        errors: 0,
+        jsxFallbackAttempts: 0,
+        jsxFallbackRequests: 0,
+        kind: 'cached',
+        parserAttempts: 1,
+        parserKey: 'oxc:module:ts:ts:r1:j0',
+        requests: 2,
+        revision: revisionOf(compactParseCode),
+      },
+    ]);
+  });
+
+  it('isolates interleaved roots that share one reporter', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstBarrier = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondBarrier = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const firstCode = 'export const first: number = 1;';
+    const secondCode = 'export const second: number = 2;';
+
+    const first = runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/a.ts' }),
+      async () => {
+        recordPipelineCacheRequest('entrypoints', 'get', true);
+        parseFile(undefined, '/project/a.ts', firstCode);
+        releaseSecond();
+        await firstBarrier;
+        recordPipelineCacheRequest('entrypoints', 'get', false);
+      }
+    );
+    const second = runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/b.ts' }),
+      async () => {
+        await secondBarrier;
+        recordPipelineCacheRequest('exports', 'has', false);
+        parseFile(undefined, '/project/b.ts', secondCode);
+        releaseFirst();
+      }
+    );
+
+    await Promise.all([first, second]);
+    unregister();
+
+    const byFilename = new Map(
+      summaries.map((summary) => [summary.root.filename, summary])
+    );
+    expect(byFilename.get('/project/a.ts')?.cache).toMatchObject({
+      hits: 1,
+      misses: 1,
+      requests: 2,
+    });
+    expect(byFilename.get('/project/b.ts')?.cache).toMatchObject({
+      hits: 0,
+      misses: 1,
+      requests: 1,
+    });
+    expect(byFilename.get('/project/a.ts')?.parse.revisions).toEqual([
+      expect.objectContaining({
+        requests: 1,
+        revision: revisionOf(firstCode),
+      }),
+    ]);
+    expect(byFilename.get('/project/b.ts')?.parse.revisions).toEqual([
+      expect.objectContaining({
+        requests: 1,
+        revision: revisionOf(secondCode),
+      }),
+    ]);
+  });
+
+  it('accounts for cached, fallback, and uncached parser work by exact revision', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const plainFilename = '/project/pipeline-telemetry-unicode.ts';
+    const plainCode = "export const message: string = '🙂';";
+    const jsxFilename = '/project/pipeline-telemetry-fallback.js';
+    const jsxCode = 'export const element = <span>🙂</span>;';
+    const uncachedFilename = '/project/pipeline-telemetry-uncached.ts';
+    const uncachedCode = "export const direct: string = '🚀';";
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: plainFilename }),
+      async () => {
+        parseOxcCached(plainFilename, plainCode, 'module');
+        parseOxcCached(plainFilename, plainCode, 'module');
+        parseOxcCached(jsxFilename, jsxCode, 'unambiguous');
+        parseOxcCached(jsxFilename, jsxCode, 'unambiguous');
+        parseFile(undefined, uncachedFilename, uncachedCode);
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    const [summary] = summaries;
+    const plainRevision = summary.parse.revisions.find(
+      ({ revision }) => revision === revisionOf(plainCode)
+    );
+    const jsxRevision = summary.parse.revisions.find(
+      ({ revision }) => revision === revisionOf(jsxCode)
+    );
+    const uncachedRevision = summary.parse.revisions.find(
+      ({ revision }) => revision === revisionOf(uncachedCode)
+    );
+    const plainBytes = Buffer.byteLength(plainCode);
+    const jsxBytes = Buffer.byteLength(jsxCode);
+    const uncachedBytes = Buffer.byteLength(uncachedCode);
+
+    expect(summary.parse).toMatchObject({
+      allRequests: 5,
+      cacheHits: 2,
+      cacheMisses: 2,
+      cachedRequests: 4,
+      errors: 0,
+      jsxFallbackAttempts: 1,
+      jsxFallbackRequests: 2,
+      parserAttempts: 4,
+      requestedBytes: plainBytes * 2 + jsxBytes * 2 + uncachedBytes,
+      uncachedRequests: 1,
+    });
+    expect(summary.parse.allRequests).toBe(
+      summary.parse.cachedRequests + summary.parse.uncachedRequests
+    );
+    expect(summary.parse.cachedRequests).toBe(
+      summary.parse.cacheHits + summary.parse.cacheMisses
+    );
+    expect(plainRevision).toEqual({
+      cacheHits: 1,
+      cacheMisses: 1,
+      errors: 0,
+      jsxFallbackAttempts: 0,
+      jsxFallbackRequests: 0,
+      kind: 'cached',
+      parsedBytes: plainBytes,
+      parserAttempts: 1,
+      parserKey: 'oxc:module:ts:ts:r1:j0',
+      requestedBytes: plainBytes * 2,
+      requests: 2,
+      revision: revisionOf(plainCode),
+    });
+    expect(jsxRevision).toEqual({
+      cacheHits: 1,
+      cacheMisses: 1,
+      errors: 0,
+      jsxFallbackAttempts: 1,
+      jsxFallbackRequests: 2,
+      kind: 'cached',
+      parsedBytes: jsxBytes * 2,
+      parserAttempts: 2,
+      parserKey: 'oxc:unambiguous:js:js:r1:j1',
+      requestedBytes: jsxBytes * 2,
+      requests: 2,
+      revision: revisionOf(jsxCode),
+    });
+    expect(uncachedRevision).toEqual({
+      cacheHits: 0,
+      cacheMisses: 0,
+      errors: 0,
+      jsxFallbackAttempts: 0,
+      jsxFallbackRequests: 0,
+      kind: 'uncached',
+      parsedBytes: uncachedBytes,
+      parserAttempts: 1,
+      parserKey: 'oxc:module:ts:ts:r1:j0',
+      requestedBytes: uncachedBytes,
+      requests: 1,
+      revision: revisionOf(uncachedCode),
+    });
+    expect(summary.parse.revisions).toHaveLength(3);
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain(plainCode);
+    expect(serialized).not.toContain(jsxCode);
+    expect(serialized).not.toContain(uncachedCode);
+  });
+
+  it('derives zero attempts for a cached JSX hit warmed outside the root', async () => {
+    const filename = '/project/pipeline-telemetry-warm-jsx.js';
+    const code = 'export const warmElement = <span>ready</span>;';
+    parseOxcCached(filename, code, 'module');
+
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename }),
+      async () => {
+        parseOxcCached(filename, code, 'module');
+      }
+    );
+    unregister();
+
+    expect(summaries[0].parse).toMatchObject({
+      cacheHits: 1,
+      cacheMisses: 0,
+      jsxFallbackAttempts: 0,
+      jsxFallbackRequests: 1,
+      parsedBytes: 0,
+      parserAttempts: 0,
+    });
+    expect(summaries[0].parse.revisions).toEqual([
+      expect.objectContaining({
+        cacheHits: 1,
+        cacheMisses: 0,
+        jsxFallbackAttempts: 0,
+        jsxFallbackRequests: 1,
+        parsedBytes: 0,
+        parserAttempts: 0,
+        requests: 1,
+      }),
+    ]);
+  });
+
+  it('accounts for cached, direct, and failed JSX fallback parse errors', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const cachedFilename = '/project/pipeline-telemetry-error.js';
+    const cachedCode =
+      'export const element = <span />; export const broken = ;';
+    const directFilename = '/project/pipeline-telemetry-error.ts';
+    const directCode = 'export const broken: number = ;';
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: cachedFilename }),
+      async () => {
+        expect(() =>
+          parseOxcCached(cachedFilename, cachedCode, 'module')
+        ).toThrow();
+        expect(() =>
+          parseFile(undefined, directFilename, directCode)
+        ).toThrow();
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].parse).toMatchObject({
+      allRequests: 2,
+      cacheHits: 0,
+      cacheMisses: 1,
+      cachedRequests: 1,
+      errors: 2,
+      jsxFallbackAttempts: 1,
+      jsxFallbackRequests: 1,
+      parserAttempts: 3,
+      uncachedRequests: 1,
+    });
+  });
+
+  it('keys parse revisions by the exact filename-derived Oxc language', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const languageCases = [
+      ['/project/x.js', 'js'],
+      ['/project/x.jsx', 'jsx'],
+      ['/project/x.ts', 'ts'],
+      ['/project/x.tsx', 'tsx'],
+      ['/project/x.mts', 'ts'],
+      ['/project/x.cts', 'ts'],
+      ['/project/x.d.ts', 'dts'],
+      ['/project/x.d.mts', 'dts'],
+      ['/project/x.d.cts', 'dts'],
+      ['/project/d.ts', 'ts'],
+      ['/project/.d.ts', 'ts'],
+      ['/project/index.d.css.ts', 'dts'],
+      ['/project/index.d.css.mts', 'ts'],
+      ['/project/.d.mts', 'ts'],
+      ['/project/X.TS', 'js'],
+      ['/project/x.ts?raw', 'js'],
+    ] as const;
+    const sharedCode = 'export const shared = 1;';
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/root.ts' }),
+      async () => {
+        languageCases.forEach(([filename], index) => {
+          recordPipelineUncachedParse(
+            filename,
+            `export const value${index} = ${index};`,
+            'module',
+            'js',
+            false
+          );
+        });
+        recordPipelineUncachedParse(
+          '/project/shared.mts',
+          sharedCode,
+          'module',
+          'js',
+          false
+        );
+        recordPipelineUncachedParse(
+          '/project/shared.cts',
+          sharedCode,
+          'module',
+          'js',
+          false
+        );
+        recordPipelineUncachedParse(
+          '/project/shared.tsx',
+          sharedCode,
+          'module',
+          'js',
+          false
+        );
+        recordPipelineUncachedParse(
+          '/project/shared.ts',
+          sharedCode,
+          'module',
+          'ts',
+          false
+        );
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    languageCases.forEach(([, language], index) => {
+      const code = `export const value${index} = ${index};`;
+      expect(
+        summaries[0].parse.revisions.find(
+          ({ revision }) => revision === revisionOf(code)
+        )?.parserKey
+      ).toBe(`oxc:module:${language}:js:r1:j0`);
+    });
+    expect(
+      summaries[0].parse.revisions
+        .filter(({ revision }) => revision === revisionOf(sharedCode))
+        .map(({ parserKey, requests }) => ({ parserKey, requests }))
+    ).toEqual([
+      { parserKey: 'oxc:module:ts:js:r1:j0', requests: 2 },
+      { parserKey: 'oxc:module:ts:ts:r1:j0', requests: 1 },
+      { parserKey: 'oxc:module:tsx:js:r1:j0', requests: 1 },
+    ]);
+  });
+
+  it('summarizes pipeline recorders with explicit denominator algebra', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const filename = '/project/recorders.ts';
+    const cleanupCode = 'const dead = 1;\nconst live = 2;';
+    const cleanupEnd = cleanupCode.indexOf('\n');
+    const shakeInput = 'export const unused = 1;';
+    const shakeOutput = 'export {};';
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename }),
+      async () => {
+        recordPipelineEntrypoint(true, true, 'created', ['z', 'a', 'z']);
+        recordPipelineEntrypoint(false, false, 'cached', ['*', 'ignored']);
+        recordPipelineEntrypoint(false, false, 'loop', ['loop']);
+        recordPipelineDisposableRoot(filename, 'preeval');
+
+        recordPipelineProcessors('preeval', false, 3, 2, 1, 1, 4);
+        recordPipelineProcessors('collect', true, 2, 1, 1, 2, 3);
+
+        const dangerousToken = beginPipelineDangerousCode(filename);
+        finishPipelineDangerousCode(dangerousToken);
+        recordPipelineLateNoMetadata(filename, ['z', 'a', 'z'], 'preeval');
+        recordPipelineLateNoMetadata(filename, ['a'], 'collect');
+
+        const shakeToken = beginPipelineShake(
+          shakeInput,
+          ['z', 'a', 'z'],
+          'preval'
+        );
+        finishPipelineShake(shakeToken, shakeOutput, false);
+
+        const cleanupToken = beginPipelineCleanup(filename);
+        recordPipelineCleanupIteration(
+          cleanupToken,
+          cleanupCode,
+          [{ start: 0, end: cleanupEnd }],
+          true,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        );
+        finishPipelineCleanup(cleanupToken, 'converged');
+
+        recordPipelineCacheRequest('entrypoints', 'get', true);
+        recordPipelineCacheRequest('exports', 'has', false);
+        recordPipelineCacheSalt(null, 'first', 'migrate');
+        recordPipelineCacheSalt('first', 'first', 'unchanged');
+        recordPipelineCacheSalt('first', 'second', 'clear');
+        recordPipelineCacheSalt('second', null, 'disable');
+        recordPipelineCacheClear('exports', 'salt-change', 3);
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    const [summary] = summaries;
+    expect(summary.entrypoints).toEqual({
+      byOnly: [
+        { count: 1, only: ['*'] },
+        { count: 1, only: ['a', 'z'] },
+        { count: 1, only: ['loop'] },
+      ],
+      cached: 1,
+      children: 2,
+      created: 1,
+      disposableRoots: 1,
+      disposableRootsByPhase: [{ count: 1, phase: 'preeval' }],
+      initialRoots: 1,
+      loops: 1,
+      onDemandRoots: 0,
+      requests: 3,
+      roots: 1,
+    });
+    expect(summary.entrypoints.requests).toBe(
+      summary.entrypoints.roots + summary.entrypoints.children
+    );
+    expect(summary.entrypoints.requests).toBe(
+      summary.entrypoints.created +
+        summary.entrypoints.cached +
+        summary.entrypoints.loops
+    );
+    expect(summary.processors).toEqual({
+      byPhase: [
+        {
+          definedProcessors: 2,
+          importCandidates: 2,
+          lookupAttempts: 1,
+          lookupHits: 1,
+          passes: 1,
+          phase: 'collect',
+          reusedPlans: 1,
+          usages: 3,
+        },
+        {
+          definedProcessors: 1,
+          importCandidates: 3,
+          lookupAttempts: 2,
+          lookupHits: 1,
+          passes: 1,
+          phase: 'preeval',
+          reusedPlans: 0,
+          usages: 4,
+        },
+      ],
+      totals: {
+        definedProcessors: 3,
+        importCandidates: 5,
+        lookupAttempts: 3,
+        lookupHits: 2,
+        passes: 2,
+        reusedPlans: 1,
+        usages: 7,
+      },
+    });
+    expect(summary.lateNoMetadata).toEqual({
+      count: 2,
+      dangerousCodeCalls: 1,
+      dangerousCodeMs: expect.any(Number),
+      events: [
+        {
+          filename,
+          only: ['a'],
+          phase: 'collect',
+        },
+        {
+          filename,
+          only: ['a', 'z'],
+          phase: 'preeval',
+        },
+      ],
+    });
+    expect(summary.lateNoMetadata.dangerousCodeMs).toBeGreaterThanOrEqual(0);
+    expect(summary.shakes).toEqual({
+      attempts: 1,
+      calls: [
+        {
+          error: false,
+          generatedBytes: Buffer.byteLength(shakeOutput),
+          inputBytes: Buffer.byteLength(shakeInput),
+          inputRevision: revisionOf(shakeInput),
+          mode: 'preval',
+          only: ['a', 'z'],
+          outputRevision: revisionOf(shakeOutput),
+        },
+      ],
+      errors: 0,
+      generatedBytes: Buffer.byteLength(shakeOutput),
+      successes: 1,
+    });
+    expect(summary.shakes.attempts).toBe(
+      summary.shakes.successes + summary.shakes.errors
+    );
+    const removedBytes = Buffer.byteLength(cleanupCode.slice(0, cleanupEnd));
+    expect(summary.cleanup).toEqual({
+      attemptedBytes: removedBytes,
+      attemptedIterations: 1,
+      attemptedRanges: 1,
+      calls: 1,
+      candidateRemovals: {
+        emptyBlocks: 6,
+        expressions: 5,
+        generatedHelpers: 3,
+        imports: 4,
+        scopedDeclarations: 1,
+        topLevelDeclarations: 2,
+      },
+      capHits: 0,
+      committedBytes: removedBytes,
+      committedIterations: 1,
+      committedRanges: 1,
+      converged: 1,
+      errors: 0,
+      rollbackBytes: 0,
+      rollbacks: 0,
+      stalled: 0,
+    });
+    expect(summary.cleanup.calls).toBe(
+      summary.cleanup.converged +
+        summary.cleanup.rollbacks +
+        summary.cleanup.capHits +
+        summary.cleanup.stalled +
+        summary.cleanup.errors
+    );
+    expect(summary.cache).toMatchObject({
+      clearEntries: 3,
+      clearReasons: [
+        {
+          cache: 'exports',
+          entries: 3,
+          reason: 'salt-change',
+          requests: 1,
+        },
+      ],
+      clearRequests: 1,
+      hits: 1,
+      misses: 1,
+      requests: 2,
+      salt: {
+        calls: 4,
+        changes: [
+          { current: 'first', outcome: 'migrate', previous: null },
+          { current: 'second', outcome: 'clear', previous: 'first' },
+          { current: null, outcome: 'disable', previous: 'second' },
+        ],
+        clears: 1,
+        disables: 1,
+        migrations: 1,
+        unchanged: 1,
+      },
+    });
+    expect(summary.cache.requests).toBe(
+      summary.cache.hits + summary.cache.misses
+    );
+    expect(PIPELINE_TELEMETRY_SCHEMA.denominators).toEqual({
+      cache:
+        'requests = get requests + has requests; each byOperation bucket has requests = hits + misses; salt.calls counts setKeySalt decisions, while salt.changes retains only transitions; clearRequests counts primary-cache clear/invalidate operations and clearEntries counts entries present before them',
+      cleanup:
+        'calls are cleanup invocations; attemptedIterations are loop bodies and committedIterations are candidate revisions accepted after parse; candidateRemovals are raw pre-merge ranges by collector and can overlap, while attempted/committed ranges and bytes use merged ranges; outcomes partition calls',
+      entrypoints:
+        'requests are completed Entrypoint.innerCreate decisions; requests = roots + children = created + cached + loops; byOnly counts the effective merged entrypoint.only list; initialRoots means a root request with loadedCode, while onDemandRoots has no loadedCode; disposable roots are events rather than unique filenames; calls that throw before a decision are not counted',
+      lateNoMetadata:
+        'count is late no-metadata short-circuit events; events retain each phase/only occurrence, while dangerousCodeCalls and dangerousCodeMs include each distinct affected filename once',
+      parse:
+        'allRequests = cachedRequests + uncachedRequests; cachedRequests = cacheHits + cacheMisses; every miss or uncached request has one primary parse and at most one JSX fallback, so parserAttempts are derived as cacheMisses + jsxFallbackAttempts for cached revisions and requests + jsxFallbackAttempts for uncached revisions; requestedBytes count each logical request input, parsedBytes count input bytes per physical parseSync attempt, errors count failed logical requests, and JSX fallback requests/attempts separate logical need from physical fallback parses; compact revision records store source bytes once',
+      processors:
+        'passes are applyOxcProcessors invocations that reach a recorded import/usage analysis result; lookupAttempts exclude side-effect imports and candidates without a local binding; reused plans skip import lookup but still count usages',
+      shakes:
+        'attempts are core prepareOxcCodeImpl shake calls; attempts = successes + errors',
+    });
+  });
+
+  it('partitions unexpected cleanup failures into the error outcome', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const filename = '/project/cleanup-error.ts';
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename }),
+      async () => {
+        expect(() =>
+          removeUnusedAfterReplacement(
+            'export const broken = ;',
+            filename,
+            new Set(),
+            new Set(),
+            new Set()
+          )
+        ).toThrow();
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].cleanup).toMatchObject({
+      calls: 1,
+      capHits: 0,
+      converged: 0,
+      errors: 1,
+      rollbacks: 0,
+      stalled: 0,
+    });
+  });
+
+  it('restores the parent root after a nested telemetry root completes', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/outer.ts' }),
+      async () => {
+        recordPipelineCacheRequest('entrypoints', 'get', true);
+        await runWithPipelineTelemetry(
+          emitter,
+          () => ({ filename: '/project/inner.ts' }),
+          async () => {
+            recordPipelineCacheRequest('exports', 'has', false);
+          }
+        );
+        recordPipelineCacheRequest('entrypoints', 'get', false);
+      }
+    );
+    unregister();
+
+    const byFilename = new Map(
+      summaries.map((summary) => [summary.root.filename, summary])
+    );
+    expect(byFilename.get('/project/outer.ts')?.cache).toMatchObject({
+      hits: 1,
+      misses: 1,
+      requests: 2,
+    });
+    expect(byFilename.get('/project/inner.ts')?.cache).toMatchObject({
+      hits: 0,
+      misses: 1,
+      requests: 1,
+    });
+  });
+
+  it('does not attribute work from an unregistered nested transform boundary', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/outer.ts' }),
+      async () => {
+        recordPipelineCacheRequest('entrypoints', 'get', true);
+        await runWithoutPipelineTelemetry(async () => {
+          recordPipelineCacheRequest('exports', 'has', false);
+        });
+        recordPipelineCacheRequest('entrypoints', 'get', false);
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].cache).toMatchObject({
+      hits: 1,
+      misses: 1,
+      requests: 2,
+    });
+    expect(summaries[0].cache.byOperation).toEqual([
+      {
+        cache: 'entrypoints',
+        hits: 1,
+        misses: 1,
+        operation: 'get',
+        requests: 2,
+      },
+    ]);
+  });
+
+  it('ignores detached work from a flushed root while another root is active', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    let releaseDetached!: () => void;
+    const detachedBarrier = new Promise<void>((resolve) => {
+      releaseDetached = resolve;
+    });
+    let detachedWork!: Promise<void>;
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/flushed.ts' }),
+      async () => {
+        recordPipelineCacheRequest('entrypoints', 'get', true);
+        recordPipelineCacheSalt(null, 'old-root', 'migrate');
+        detachedWork = detachedBarrier.then(() => {
+          recordPipelineCacheRequest('exports', 'has', false);
+          recordPipelineCacheSalt('old-root', 'late-write', 'clear');
+        });
+      }
+    );
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename: '/project/current.ts' }),
+      async () => {
+        releaseDetached();
+        await detachedWork;
+        recordPipelineCacheRequest('exports', 'get', true);
+      }
+    );
+    unregister();
+
+    const byFilename = new Map(
+      summaries.map((summary) => [summary.root.filename, summary])
+    );
+    expect(byFilename.get('/project/flushed.ts')?.cache).toMatchObject({
+      requests: 1,
+      salt: { calls: 1 },
+    });
+    expect(byFilename.get('/project/current.ts')?.cache).toMatchObject({
+      requests: 1,
+      salt: { calls: 0 },
+    });
+  });
+
+  it('flushes an error summary when option setup fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-pipeline-telemetry-'));
+    const filename = join(root, 'invalid-options.ts');
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+
+    try {
+      await expect(
+        transform(
+          {
+            eventEmitter: emitter,
+            options: {
+              filename,
+              root,
+              pluginOptions: {
+                configFile: false,
+                eval: { resolver: 'invalid' } as never,
+              },
+            },
+          },
+          'export const value = 1;',
+          async () => null
+        )
+      ).rejects.toThrow('Unsupported eval.resolver');
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0]).toMatchObject({
+        root: { filename, status: 'error' },
+      });
+      expect(summaries[0].entrypoints.requests).toBe(0);
+      expect(summaries[0].parse.allRequests).toBe(0);
+    } finally {
+      unregister();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('collects stage counters from a real transform without metadata', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-pipeline-telemetry-'));
+    const filename = join(root, 'plain.ts');
+    const code = 'export const answer: number = 42;';
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+
+    try {
+      const result = await runTransform(root, filename, code, emitter);
+
+      expect(result).toMatchObject({ code });
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0]).toMatchObject({
+        entrypoints: {
+          children: 0,
+          created: 1,
+          disposableRoots: 1,
+          initialRoots: 1,
+          requests: 1,
+          roots: 1,
+        },
+        lateNoMetadata: { count: 1, dangerousCodeCalls: 1 },
+        root: { filename, status: 'success' },
+        shakes: { attempts: 0, errors: 0, successes: 0 },
+      });
+      expect(
+        summaries[0].lateNoMetadata.dangerousCodeMs
+      ).toBeGreaterThanOrEqual(0);
+      expect(summaries[0].parse.cachedRequests).toBeGreaterThan(0);
+      expect(summaries[0].parse.errors).toBe(0);
+      expect(summaries[0].processors.byPhase).toEqual([
+        expect.objectContaining({
+          importCandidates: 0,
+          lookupAttempts: 0,
+          passes: 1,
+          phase: 'preeval',
+          usages: 0,
+        }),
+      ]);
+      expect(summaries[0].cache.salt).toMatchObject({
+        calls: 1,
+        migrations: 1,
+      });
+    } finally {
+      unregister();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('collects processor, shaker, and cleanup counters from a real transform', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-pipeline-telemetry-'));
+    const filename = join(root, 'styles.ts');
+    const code = [
+      "import { css } from 'test-css-processor';",
+      'export const red = css`color: red;`;',
+      'export const blue = css`color: blue;`;',
+    ].join('\n');
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+
+    try {
+      const result = await runTransform(root, filename, code, emitter);
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('color:blue');
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].root).toEqual({ filename, status: 'success' });
+      expect(summaries[0].processors.byPhase).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            importCandidates: 1,
+            lookupAttempts: 1,
+            lookupHits: 1,
+            phase: 'preeval',
+            usages: 2,
+          }),
+          expect.objectContaining({
+            definedProcessors: 0,
+            importCandidates: 0,
+            lookupAttempts: 0,
+            lookupHits: 0,
+            phase: 'collect',
+            reusedPlans: 1,
+            usages: 2,
+          }),
+        ])
+      );
+      expect(summaries[0].shakes).toMatchObject({
+        errors: 0,
+      });
+      expect(summaries[0].shakes.attempts).toBeGreaterThan(0);
+      expect(summaries[0].shakes.successes).toBe(summaries[0].shakes.attempts);
+      expect(summaries[0].shakes.generatedBytes).toBeGreaterThan(0);
+      expect(summaries[0].cleanup.calls).toBeGreaterThan(0);
+      expect(summaries[0].cleanup.calls).toBe(
+        summaries[0].cleanup.converged +
+          summaries[0].cleanup.rollbacks +
+          summaries[0].cleanup.capHits +
+          summaries[0].cleanup.stalled +
+          summaries[0].cleanup.errors
+      );
+    } finally {
+      unregister();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/transform/src/__tests__/pipelineTelemetryJsonl.test.ts
+++ b/packages/transform/src/__tests__/pipelineTelemetryJsonl.test.ts
@@ -1,0 +1,1086 @@
+/* eslint-disable no-bitwise */
+import path from 'path';
+
+import { serializePipelineTelemetryJSONl } from '../debug/pipelineTelemetry.jsonl';
+import { getPipelineParserAttempts } from '../debug/pipelineTelemetry.parse';
+import { PIPELINE_TELEMETRY_SCHEMA } from '../debug/pipelineTelemetry.schema';
+import { buildCompactPipelineTelemetrySummary } from '../debug/pipelineTelemetry.summary';
+import type {
+  ParseRevisionCounter,
+  PipelineAccumulator,
+} from '../debug/pipelineTelemetry.types';
+
+const WORKING_DIR = path.join(
+  path.parse(process.cwd()).root,
+  'pipeline-telemetry-project'
+);
+const ROOT_FILENAME = path.join(WORKING_DIR, 'src', 'root.ts');
+
+const serializeLegacyPipelineTelemetryJSONl = (
+  accumulator: PipelineAccumulator,
+  workingDir: string
+): string => {
+  const summary = buildCompactPipelineTelemetrySummary(accumulator);
+  const { root } = summary;
+  const { filename: rootFilename } = root;
+  const serialized = JSON.stringify(
+    summary,
+    function legacyPipelineReplacer(
+      this: unknown,
+      key,
+      value: unknown
+    ): unknown {
+      if (typeof value === 'number') {
+        if (value === 0 || (key === 'passes' && value === 1)) return undefined;
+        return value;
+      }
+      if (value === false) return undefined;
+      if (typeof value !== 'string') return value;
+      if (key === 'kind' && value === 'cached') return undefined;
+      if (key === 'filename') {
+        if (this !== root && value === rootFilename) return undefined;
+        return path.isAbsolute(value)
+          ? path.relative(workingDir, value)
+          : value;
+      }
+      return value;
+    }
+  );
+  return `${serialized}\n`;
+};
+
+type JSONRecord = Record<string, unknown>;
+
+const CACHE_NAMES = ['barrelManifests', 'entrypoints', 'exports'] as const;
+const CACHE_OPERATION_NAMES = ['get', 'has'] as const;
+const PARSER_KEYS = [
+  'oxc:module:js:js:r1:j0',
+  'oxc:module:js:js:r1:j1',
+  'oxc:module:js:ts:r1:j0',
+  'oxc:module:js:ts:r1:j1',
+  'oxc:module:jsx:js:r1:j0',
+  'oxc:module:jsx:js:r1:j1',
+  'oxc:module:jsx:ts:r1:j0',
+  'oxc:module:jsx:ts:r1:j1',
+  'oxc:module:ts:js:r1:j0',
+  'oxc:module:ts:js:r1:j1',
+  'oxc:module:ts:ts:r1:j0',
+  'oxc:module:ts:ts:r1:j1',
+  'oxc:module:tsx:js:r1:j0',
+  'oxc:module:tsx:js:r1:j1',
+  'oxc:module:tsx:ts:r1:j0',
+  'oxc:module:tsx:ts:r1:j1',
+  'oxc:module:dts:js:r1:j0',
+  'oxc:module:dts:js:r1:j1',
+  'oxc:module:dts:ts:r1:j0',
+  'oxc:module:dts:ts:r1:j1',
+  'oxc:unambiguous:js:js:r1:j0',
+  'oxc:unambiguous:js:js:r1:j1',
+  'oxc:unambiguous:js:ts:r1:j0',
+  'oxc:unambiguous:js:ts:r1:j1',
+  'oxc:unambiguous:jsx:js:r1:j0',
+  'oxc:unambiguous:jsx:js:r1:j1',
+  'oxc:unambiguous:jsx:ts:r1:j0',
+  'oxc:unambiguous:jsx:ts:r1:j1',
+  'oxc:unambiguous:ts:js:r1:j0',
+  'oxc:unambiguous:ts:js:r1:j1',
+  'oxc:unambiguous:ts:ts:r1:j0',
+  'oxc:unambiguous:ts:ts:r1:j1',
+  'oxc:unambiguous:tsx:js:r1:j0',
+  'oxc:unambiguous:tsx:js:r1:j1',
+  'oxc:unambiguous:tsx:ts:r1:j0',
+  'oxc:unambiguous:tsx:ts:r1:j1',
+  'oxc:unambiguous:dts:js:r1:j0',
+  'oxc:unambiguous:dts:js:r1:j1',
+  'oxc:unambiguous:dts:ts:r1:j0',
+  'oxc:unambiguous:dts:ts:r1:j1',
+] as const;
+
+const stripLegacyDefaults = (value: JSONRecord): JSONRecord =>
+  JSON.parse(
+    JSON.stringify(value, (key, nestedValue: unknown): unknown => {
+      if (typeof nestedValue === 'number') {
+        if (nestedValue === 0 || (key === 'passes' && nestedValue === 1)) {
+          return undefined;
+        }
+      }
+      if (nestedValue === false) return undefined;
+      if (key === 'kind' && nestedValue === 'cached') return undefined;
+      return nestedValue;
+    })
+  );
+
+const decodePipelineTelemetryJSONl = (line: string): JSONRecord => {
+  const wire = JSON.parse(line) as JSONRecord;
+  const result: JSONRecord = {
+    root: wire.root,
+    schemaVersion: wire.schemaVersion,
+    type: wire.type,
+  };
+
+  if (wire.cache) {
+    const [
+      requests,
+      hits,
+      misses,
+      clearRequests,
+      clearEntries,
+      rawSalt,
+      rawByOperation,
+      rawClearReasons,
+    ] = wire.cache as unknown[];
+    const [calls, clears, disables, migrations, unchanged, changes] =
+      rawSalt as unknown[];
+    result.cache = {
+      byOperation: (rawByOperation as unknown[][]).map(
+        ([
+          cacheId,
+          operationId,
+          operationHits,
+          operationMisses,
+          operationRequests,
+        ]) => ({
+          cache: CACHE_NAMES[cacheId as number],
+          operation: CACHE_OPERATION_NAMES[operationId as number],
+          hits: operationHits,
+          misses: operationMisses,
+          requests: operationRequests,
+        })
+      ),
+      clearEntries,
+      clearReasons: (rawClearReasons as unknown[][]).map(
+        ([cacheId, reason, entries, reasonRequests]) => ({
+          cache: CACHE_NAMES[cacheId as number],
+          entries,
+          reason,
+          requests: reasonRequests,
+        })
+      ),
+      clearRequests,
+      hits,
+      misses,
+      requests,
+      salt: { calls, changes, clears, disables, migrations, unchanged },
+    };
+  }
+
+  if (wire.cleanup) {
+    const [
+      calls,
+      attemptedIterations,
+      attemptedRanges,
+      attemptedBytes,
+      committedIterations,
+      committedRanges,
+      committedBytes,
+      rollbackBytes,
+      rawRemovals,
+      converged,
+      rollbacks,
+      capHits,
+      stalled,
+      errors,
+    ] = wire.cleanup as unknown[];
+    const [
+      emptyBlocks,
+      expressions,
+      generatedHelpers,
+      imports,
+      scopedDeclarations,
+      topLevelDeclarations,
+    ] = rawRemovals as unknown[];
+    result.cleanup = {
+      calls,
+      candidateRemovals: {
+        emptyBlocks,
+        expressions,
+        generatedHelpers,
+        imports,
+        scopedDeclarations,
+        topLevelDeclarations,
+      },
+      capHits,
+      committedBytes,
+      committedIterations,
+      committedRanges,
+      converged,
+      errors,
+      rollbackBytes,
+      rollbacks,
+      stalled,
+      attemptedBytes,
+      attemptedIterations,
+      attemptedRanges,
+    };
+  }
+
+  if (wire.entrypoints) {
+    const [
+      requests,
+      roots,
+      children,
+      created,
+      cached,
+      loops,
+      initialRoots,
+      onDemandRoots,
+      disposableRoots,
+      rawByOnly,
+      rawDisposableRootsByPhase,
+    ] = wire.entrypoints as unknown[];
+    result.entrypoints = {
+      byOnly: (rawByOnly as unknown[][]).map(([only, count]) => ({
+        count,
+        only,
+      })),
+      cached,
+      children,
+      created,
+      disposableRoots,
+      disposableRootsByPhase: (rawDisposableRootsByPhase as unknown[][]).map(
+        ([phase, count]) => ({ count, phase })
+      ),
+      initialRoots,
+      loops,
+      onDemandRoots,
+      requests,
+      roots,
+    };
+  }
+
+  if (wire.lateNoMetadata) {
+    const [count, dangerousCodeCalls, dangerousCodeMs, rawEvents] =
+      wire.lateNoMetadata as unknown[];
+    result.lateNoMetadata = {
+      count,
+      dangerousCodeCalls,
+      dangerousCodeMs,
+      events: (rawEvents as unknown[][]).map(([phase, only, filename]) => {
+        const event: JSONRecord = { only, phase };
+        if (filename !== undefined) event.filename = filename;
+        return event;
+      }),
+    };
+  }
+
+  if (wire.parse) {
+    const [rawTotals, rawRevisions] = wire.parse as unknown[][];
+    const [
+      allRequests,
+      cachedRequests,
+      uncachedRequests,
+      cacheHits,
+      cacheMisses,
+      parserAttempts,
+      requestedBytes,
+      parsedBytes,
+      errors,
+      jsxFallbackRequests,
+      jsxFallbackAttempts,
+    ] = rawTotals;
+    result.parse = {
+      allRequests,
+      cacheHits,
+      cacheMisses,
+      cachedRequests,
+      errors,
+      jsxFallbackAttempts,
+      jsxFallbackRequests,
+      parsedBytes,
+      parserAttempts,
+      requestedBytes,
+      uncachedRequests,
+      revisions: rawRevisions.map(
+        ([revision, rawParserKey, bytes, requests, rawMask, ...values]) => {
+          const mask = rawMask as number;
+          let cursor = 0;
+          const counter: JSONRecord = {
+            bytes,
+            cacheHits: 0,
+            cacheMisses: 0,
+            errors: 0,
+            jsxFallbackAttempts: 0,
+            jsxFallbackRequests: 0,
+            kind: 'cached',
+            parserKey:
+              typeof rawParserKey === 'number'
+                ? PARSER_KEYS[rawParserKey]
+                : rawParserKey,
+            requests,
+            revision,
+          };
+          if (mask & 1) {
+            counter.kind = values[cursor];
+            cursor += 1;
+          }
+          const maskedCounters = [
+            [2, 'cacheHits'],
+            [4, 'cacheMisses'],
+            [8, 'errors'],
+            [16, 'jsxFallbackRequests'],
+            [32, 'jsxFallbackAttempts'],
+          ] as const;
+          maskedCounters.forEach(([bit, key]) => {
+            if (mask & bit) {
+              counter[key] = values[cursor];
+              cursor += 1;
+            }
+          });
+          counter.parserAttempts =
+            Number(counter.kind === 'cached' ? counter.cacheMisses : requests) +
+            Number(counter.jsxFallbackAttempts);
+          return counter;
+        }
+      ),
+    };
+  }
+
+  if (wire.processors) {
+    result.processors = {
+      byPhase: (wire.processors as unknown[][]).map(
+        ([phase, rawMask, ...values]) => {
+          const mask = rawMask as number;
+          let cursor = 0;
+          const counter: JSONRecord = {
+            definedProcessors: 0,
+            importCandidates: 0,
+            lookupAttempts: 0,
+            lookupHits: 0,
+            passes: 1,
+            reusedPlans: 0,
+            usages: 0,
+          };
+          const maskedCounters = [
+            [1, 'definedProcessors'],
+            [2, 'importCandidates'],
+            [4, 'lookupAttempts'],
+            [8, 'lookupHits'],
+            [16, 'passes'],
+            [32, 'reusedPlans'],
+            [64, 'usages'],
+          ] as const;
+          maskedCounters.forEach(([bit, key]) => {
+            if (mask & bit) {
+              counter[key] = values[cursor];
+              cursor += 1;
+            }
+          });
+          counter.phase = phase;
+          return counter;
+        }
+      ),
+    };
+  }
+
+  if (wire.shakes) {
+    const [attempts, successes, errors, generatedBytes, rawCalls] =
+      wire.shakes as unknown[];
+    result.shakes = {
+      attempts,
+      calls: (rawCalls as unknown[][]).map(
+        ([
+          inputRevision,
+          mode,
+          only,
+          outputRevision,
+          inputBytes,
+          rawMask,
+          ...values
+        ]) => {
+          const mask = rawMask as number;
+          const call: JSONRecord = {
+            error: (mask & 1) !== 0,
+            generatedBytes: 0,
+            inputBytes,
+            inputRevision,
+            mode,
+            only,
+            outputRevision,
+          };
+          if (mask & 2) {
+            [call.generatedBytes] = values;
+          }
+          return call;
+        }
+      ),
+      errors,
+      generatedBytes,
+      successes,
+    };
+  }
+
+  return stripLegacyDefaults(result);
+};
+
+const createAccumulator = (
+  filename: string = ROOT_FILENAME
+): PipelineAccumulator => ({
+  cache: {
+    byOperation: new Array(6),
+    clearReasons: new Map(),
+    salt: {
+      changes: [],
+      unchanged: 0,
+    },
+  },
+  cleanup: {
+    calls: 0,
+    candidateRemovals: {
+      emptyBlocks: 0,
+      expressions: 0,
+      generatedHelpers: 0,
+      imports: 0,
+      scopedDeclarations: 0,
+      topLevelDeclarations: 0,
+    },
+    capHits: 0,
+    committedBytes: 0,
+    committedIterations: 0,
+    committedRanges: 0,
+    converged: 0,
+    errors: 0,
+    rollbackBytes: 0,
+    rollbacks: 0,
+    stalled: 0,
+    attemptedBytes: 0,
+    attemptedIterations: 0,
+    attemptedRanges: 0,
+  },
+  codeMeasurements: {
+    codeUnits: 0,
+    count: 0,
+    entries: new Map(),
+    evictionKeys: [][Symbol.iterator](),
+  },
+  closed: false,
+  dangerousByFile: new Map(),
+  entrypoints: {
+    byOnly: new Map(),
+    cached: 0,
+    children: 0,
+    created: 0,
+    disposableRootsByPhase: new Map(),
+    initialRoots: 0,
+    loops: 0,
+    roots: 0,
+  },
+  lateNoMetadata: [],
+  lastCode: undefined,
+  lastMeasurement: undefined,
+  lastSharedMissCode: undefined,
+  localCodeMeasurements: new Map(),
+  onlyNormalizations: new Map(),
+  parse: {
+    cachedRevisions: new WeakMap<object, ParseRevisionCounter>(),
+    revisionBuckets: new Map(),
+    revisions: [],
+  },
+  processors: {
+    byPhase: new Map(),
+  },
+  root: {
+    filename,
+    status: 'success',
+  },
+  shakes: {
+    attempts: 0,
+    calls: [],
+    errors: 0,
+    generatedBytes: 0,
+    successes: 0,
+  },
+});
+
+const createFullAccumulator = (): PipelineAccumulator => {
+  const rootFilename = path.join(WORKING_DIR, 'src', 'root "🔥\ud800".tsx');
+  const otherFilename = path.join(WORKING_DIR, 'src', 'other\nfile.ts');
+  const accumulator = createAccumulator(rootFilename);
+
+  accumulator.root.status = 'soft-error';
+  accumulator.cache.byOperation[5] = { hits: 0, misses: 2, requests: 2 };
+  accumulator.cache.byOperation[0] = { hits: 1, misses: 0, requests: 1 };
+  accumulator.cache.clearReasons.set('z', {
+    cache: 'exports',
+    entries: 3,
+    reason: 'z-reason\n🔥',
+    requests: 1,
+  });
+  accumulator.cache.clearReasons.set('a', {
+    cache: 'entrypoints',
+    entries: 0,
+    reason: 'a-reason\ud800',
+    requests: 2,
+  });
+  accumulator.cache.salt.changes.push(
+    { current: 'one', outcome: 'migrate', previous: null },
+    { current: null, outcome: 'disable', previous: 'one' }
+  );
+  accumulator.cache.salt.unchanged = 1;
+
+  Object.assign(accumulator.cleanup, {
+    attemptedBytes: 21,
+    attemptedIterations: 4,
+    attemptedRanges: 6,
+    calls: 2,
+    capHits: 1,
+    committedBytes: 13,
+    committedIterations: 2,
+    committedRanges: 3,
+    converged: 1,
+    errors: 0,
+    rollbackBytes: 8,
+    rollbacks: 1,
+    stalled: 0,
+  });
+  Object.assign(accumulator.cleanup.candidateRemovals, {
+    emptyBlocks: 6,
+    expressions: 5,
+    generatedHelpers: 3,
+    imports: 4,
+    scopedDeclarations: 1,
+    topLevelDeclarations: 2,
+  });
+
+  accumulator.dangerousByFile.set(rootFilename, {
+    calls: 1,
+    durationMs: 0.1,
+  });
+  accumulator.dangerousByFile.set(otherFilename, {
+    calls: 2,
+    durationMs: 0.2,
+  });
+
+  accumulator.entrypoints.byOnly.set('z', {
+    count: 2,
+    only: ['z', 'quote"', '🔥', '\ud800'],
+  });
+  accumulator.entrypoints.byOnly.set('a', { count: 1, only: [] });
+  accumulator.entrypoints.cached = 1;
+  accumulator.entrypoints.children = 1;
+  accumulator.entrypoints.created = 2;
+  accumulator.entrypoints.disposableRootsByPhase.set('preeval', 1);
+  accumulator.entrypoints.disposableRootsByPhase.set('collect', 0);
+  accumulator.entrypoints.initialRoots = 1;
+  accumulator.entrypoints.roots = 2;
+
+  accumulator.lateNoMetadata.push(
+    { filename: rootFilename, only: ['z', '\ud800'], phase: 'preeval' },
+    { filename: otherFilename, only: ['a', '🔥'], phase: 'collect' },
+    { filename: rootFilename, only: [], phase: 'collect' }
+  );
+
+  accumulator.parse.revisions.push(
+    {
+      bytes: 31,
+      cacheHits: 1,
+      cacheMisses: 1,
+      errors: 0,
+      jsxFallbackAttempts: 0,
+      jsxFallbackRequests: 1,
+      kind: 'cached',
+      parserKey: 'z-parser\n🔥',
+      requests: 2,
+      revision: 'z-revision\ud800',
+    },
+    {
+      bytes: 47,
+      cacheHits: 0,
+      cacheMisses: 0,
+      errors: 1,
+      jsxFallbackAttempts: 1,
+      jsxFallbackRequests: 1,
+      kind: 'uncached',
+      parserKey: 'a-parser',
+      requests: 2,
+      revision: 'a-revision',
+    }
+  );
+
+  accumulator.processors.byPhase.set('z-phase\ud800', {
+    definedProcessors: 0,
+    importCandidates: 3,
+    lookupAttempts: 2,
+    lookupHits: 1,
+    passes: 1,
+    reusedPlans: 0,
+    usages: 4,
+  });
+  accumulator.processors.byPhase.set('a-phase🔥', {
+    definedProcessors: 2,
+    importCandidates: 1,
+    lookupAttempts: 1,
+    lookupHits: 0,
+    passes: 2,
+    reusedPlans: 1,
+    usages: 2,
+  });
+
+  accumulator.shakes.attempts = 2;
+  accumulator.shakes.calls.push(
+    {
+      error: false,
+      generatedBytes: 0,
+      inputBytes: 31,
+      inputRevision: 'input-z',
+      mode: 'preval',
+      only: ['z', '\ud800'],
+      outputRevision: null,
+    },
+    {
+      error: true,
+      generatedBytes: 17,
+      inputBytes: 47,
+      inputRevision: 'input-a',
+      mode: 'collect🔥',
+      only: [],
+      outputRevision: 'output-a',
+    }
+  );
+  accumulator.shakes.errors = 1;
+  accumulator.shakes.generatedBytes = 17;
+  accumulator.shakes.successes = 1;
+  return accumulator;
+};
+
+const expectDifferentialMatch = (accumulator: PipelineAccumulator): string => {
+  const actual = serializePipelineTelemetryJSONl(accumulator, WORKING_DIR);
+  expect(decodePipelineTelemetryJSONl(actual)).toEqual(
+    JSON.parse(serializeLegacyPipelineTelemetryJSONl(accumulator, WORKING_DIR))
+  );
+  return actual;
+};
+
+describe('serializePipelineTelemetryJSONl', () => {
+  it.each([
+    ['cached hit', 'cached', 1, 0, 0, 0],
+    ['cached miss', 'cached', 1, 1, 0, 1],
+    ['cached fallback miss', 'cached', 1, 1, 1, 2],
+    ['uncached request', 'uncached', 1, 0, 0, 1],
+    ['uncached aggregate with fallback', 'uncached', 2, 0, 1, 3],
+  ] as const)(
+    'derives physical parser attempts for %s',
+    (_name, kind, requests, cacheMisses, jsxFallbackAttempts, expected) => {
+      const counter: ParseRevisionCounter = {
+        bytes: 17,
+        cacheHits: kind === 'cached' ? requests - cacheMisses : 0,
+        cacheMisses,
+        errors: 0,
+        jsxFallbackAttempts,
+        jsxFallbackRequests: jsxFallbackAttempts,
+        kind,
+        parserKey: 'test',
+        requests,
+        revision: 'test',
+      };
+      const parserAttempts = getPipelineParserAttempts(counter);
+      expect(parserAttempts).toBe(expected);
+      expect(counter.bytes * parserAttempts).toBe(17 * expected);
+    }
+  );
+
+  it('matches the legacy compact serializer for an empty accumulator', () => {
+    const line = expectDifferentialMatch(createAccumulator());
+    expect(line.endsWith('\n')).toBe(true);
+    expect(JSON.parse(line)).toEqual({
+      root: { filename: path.join('src', 'root.ts'), status: 'success' },
+      schemaVersion: 1,
+      type: 'pipeline-telemetry',
+    });
+  });
+
+  it.each([
+    ['/work/project/src/root.ts', '/work/project', 'src/root.ts'],
+    ['C:\\work\\project\\src\\root.ts', 'C:\\work\\project', 'src\\root.ts'],
+    ['D:\\private\\root.ts', 'C:\\work\\project', 'root.ts'],
+    [
+      '\\\\server-a\\project\\src\\root.ts',
+      '\\\\server-a\\project',
+      'src\\root.ts',
+    ],
+    ['\\\\server-b\\private\\root.ts', '\\\\server-a\\project', 'root.ts'],
+    ['//server-b/private/root.ts', '//server-a/project', 'root.ts'],
+  ])(
+    'serializes %s relative to %s without leaking cross-volume paths',
+    (filename, workingDir, expected) => {
+      const line = serializePipelineTelemetryJSONl(
+        createAccumulator(filename),
+        workingDir
+      );
+      const wire = JSON.parse(line) as JSONRecord;
+      expect(wire.root).toEqual({ filename: expected, status: 'success' });
+    }
+  );
+
+  it('matches every populated section, default omission, and path rule', () => {
+    const line = expectDifferentialMatch(createFullAccumulator());
+    const parsed = decodePipelineTelemetryJSONl(line);
+
+    const parse = parsed.parse as JSONRecord;
+    const revisions = parse.revisions as JSONRecord[];
+    expect(revisions[0]).not.toHaveProperty('filename');
+    expect(revisions[0]).not.toHaveProperty('kind');
+    const processors = parsed.processors as JSONRecord;
+    const byPhase = processors.byPhase as JSONRecord[];
+    expect(byPhase[0]).not.toHaveProperty('filename');
+    expect(byPhase[0]).not.toHaveProperty('passes');
+    const shakes = parsed.shakes as JSONRecord;
+    const calls = shakes.calls as JSONRecord[];
+    expect(calls[0]).not.toHaveProperty('error');
+    expect(calls[0]).not.toHaveProperty('filename');
+    expect(calls[0].outputRevision).toBeNull();
+    expect(line).toContain('🔥');
+    expect(line).toContain('\\ud800');
+  });
+
+  it.each([
+    [
+      'cache salt without requests',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.cache.salt.changes.push({
+          current: 'one',
+          outcome: 'migrate',
+          previous: null,
+        });
+        return accumulator;
+      },
+    ],
+    [
+      'cache clear without requests',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.cache.clearReasons.set('entrypoints\0test', {
+          cache: 'entrypoints',
+          entries: 0,
+          reason: 'test',
+          requests: 1,
+        });
+        return accumulator;
+      },
+    ],
+    [
+      'disposable root without entrypoint requests',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.entrypoints.disposableRootsByPhase.set('collect', 1);
+        return accumulator;
+      },
+    ],
+    [
+      'zero, negative zero, and non-finite counters',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.cleanup.calls = 1;
+        accumulator.cleanup.capHits = -0;
+        accumulator.cleanup.errors = Number.NaN;
+        return accumulator;
+      },
+    ],
+    [
+      'dangerous code map with default counters',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.dangerousByFile.set(ROOT_FILENAME, {
+          calls: 0,
+          durationMs: 0,
+        });
+        return accumulator;
+      },
+    ],
+    [
+      'late no-metadata event without dangerous code',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.lateNoMetadata.push({
+          filename: ROOT_FILENAME,
+          only: [],
+          phase: 'collect',
+        });
+        return accumulator;
+      },
+    ],
+    [
+      'parse denominator without revisions',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.parse.revisions.push({
+          bytes: 1,
+          cacheHits: 0,
+          cacheMisses: 0,
+          errors: 0,
+          jsxFallbackAttempts: 0,
+          jsxFallbackRequests: 0,
+          kind: 'uncached',
+          parserKey: 'custom',
+          requests: 1,
+          revision: 'revision',
+        });
+        return accumulator;
+      },
+    ],
+    [
+      'processor phase with default counters',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.processors.byPhase.set('preeval', {
+          definedProcessors: 0,
+          importCandidates: 0,
+          lookupAttempts: 0,
+          lookupHits: 0,
+          passes: 1,
+          reusedPlans: 0,
+          usages: 0,
+        });
+        return accumulator;
+      },
+    ],
+    [
+      'shake denominator without completed calls',
+      () => {
+        const accumulator = createAccumulator();
+        accumulator.shakes.attempts = 1;
+        return accumulator;
+      },
+    ],
+  ])('matches the legacy section boundary for %s', (_name, createFixture) => {
+    expectDifferentialMatch(createFixture());
+  });
+
+  it('uses the exact tuple schema and preserves collection order', () => {
+    const line = expectDifferentialMatch(createFullAccumulator());
+    const wire = JSON.parse(line) as JSONRecord;
+
+    expect(Object.keys(wire)).toEqual([
+      'root',
+      'schemaVersion',
+      'type',
+      'cache',
+      'cleanup',
+      'entrypoints',
+      'lateNoMetadata',
+      'parse',
+      'processors',
+      'shakes',
+    ]);
+    expect(wire.cache).toEqual([
+      3,
+      1,
+      2,
+      3,
+      3,
+      [
+        3,
+        0,
+        1,
+        1,
+        1,
+        [
+          { current: 'one', outcome: 'migrate', previous: null },
+          { current: null, outcome: 'disable', previous: 'one' },
+        ],
+      ],
+      [
+        [0, 0, 1, 0, 1],
+        [2, 1, 0, 2, 2],
+      ],
+      [
+        [2, 'z-reason\n🔥', 3, 1],
+        [1, 'a-reason\ud800', 0, 2],
+      ],
+    ]);
+    expect(wire.cleanup).toEqual([
+      2,
+      4,
+      6,
+      21,
+      2,
+      3,
+      13,
+      8,
+      [6, 5, 3, 4, 1, 2],
+      1,
+      1,
+      1,
+      0,
+      0,
+    ]);
+    expect(wire.entrypoints).toEqual([
+      3,
+      2,
+      1,
+      2,
+      1,
+      0,
+      1,
+      1,
+      1,
+      [
+        [['z', 'quote"', '🔥', '\ud800'], 2],
+        [[], 1],
+      ],
+      [
+        ['preeval', 1],
+        ['collect', 0],
+      ],
+    ]);
+    expect(wire.lateNoMetadata).toEqual([
+      3,
+      3,
+      0.1 + 0.2,
+      [
+        ['preeval', ['z', '\ud800']],
+        ['collect', ['a', '🔥'], path.join('src', 'other\nfile.ts')],
+        ['collect', []],
+      ],
+    ]);
+    expect(wire.parse).toEqual([
+      [4, 2, 2, 1, 1, 4, 156, 172, 1, 2, 1],
+      [
+        ['z-revision\ud800', 'z-parser\n🔥', 31, 2, 22, 1, 1, 1],
+        ['a-revision', 'a-parser', 47, 2, 57, 'uncached', 1, 1, 1],
+      ],
+    ]);
+    expect(wire.processors).toEqual([
+      ['z-phase\ud800', 78, 3, 2, 1, 4],
+      ['a-phase🔥', 119, 2, 1, 1, 2, 1, 2],
+    ]);
+    expect(wire.shakes).toEqual([
+      2,
+      1,
+      1,
+      17,
+      [
+        ['input-z', 'preval', ['z', '\ud800'], null, 31, 0],
+        ['input-a', 'collect🔥', [], 'output-a', 47, 3, 17],
+      ],
+    ]);
+  });
+
+  it('publishes the minimal wire layouts and masks', () => {
+    const { enumIds, layouts, masks } = PIPELINE_TELEMETRY_SCHEMA.tupleEncoding;
+
+    expect(enumIds).toEqual({
+      cache: CACHE_NAMES,
+      cacheOperation: CACHE_OPERATION_NAMES,
+      parserKey: PARSER_KEYS,
+    });
+    expect(enumIds.parserKey).toEqual(PARSER_KEYS);
+    expect(enumIds.parserKey).toHaveLength(40);
+    expect(enumIds.parserKey[10]).toBe('oxc:module:ts:ts:r1:j0');
+    expect(layouts).not.toHaveProperty('dangerousCode');
+    expect(layouts).not.toHaveProperty('entrypointFile');
+    expect(layouts.entrypoints).toEqual([
+      'requests',
+      'roots',
+      'children',
+      'created',
+      'cached',
+      'loops',
+      'initialRoots',
+      'onDemandRoots',
+      'disposableRoots',
+      'byOnly',
+      'disposableRootsByPhase',
+    ]);
+    expect(layouts.parseRevision).toEqual([
+      'revision',
+      'parserKeyIdOrString',
+      'bytes',
+      'requests',
+      'mask',
+      '...values',
+    ]);
+    expect(layouts.processor).toEqual(['phase', 'mask', '...values']);
+    expect(layouts.shakeCall).toEqual([
+      'inputRevision',
+      'mode',
+      'only',
+      'outputRevision',
+      'inputBytes',
+      'mask',
+      '...values',
+    ]);
+    expect(masks).toEqual({
+      parseRevision: {
+        cacheHits: 2,
+        cacheMisses: 4,
+        errors: 8,
+        jsxFallbackAttempts: 32,
+        jsxFallbackRequests: 16,
+        kind: 1,
+      },
+      processor: {
+        definedProcessors: 1,
+        importCandidates: 2,
+        lookupAttempts: 4,
+        lookupHits: 8,
+        passes: 16,
+        reusedPlans: 32,
+        usages: 64,
+      },
+      shakeCall: { error: 1, generatedBytes: 2 },
+    });
+    expect(PIPELINE_TELEMETRY_SCHEMA.denominators).not.toHaveProperty(
+      'dangerousCode'
+    );
+    expect(PIPELINE_TELEMETRY_SCHEMA.encodings).toEqual({
+      bytes: 'UTF-8 byte length',
+      filenames:
+        'relative to the reporter working directory; cross-volume paths fall back to basename',
+      only: 'deduplicated and sorted; any list containing the wildcard normalizes to ["*"]',
+      revision: 'SHA-256 digest encoded as unpadded base64url',
+    });
+    expect(Object.keys(layouts)).toEqual([
+      'cache',
+      'cacheByOperation',
+      'cacheClearReason',
+      'cacheSalt',
+      'cleanup',
+      'cleanupCandidateRemovals',
+      'entrypoints',
+      'entrypointByOnly',
+      'entrypointDisposableRoot',
+      'lateNoMetadata',
+      'lateNoMetadataEvent',
+      'parse',
+      'parseRevision',
+      'parseTotals',
+      'processor',
+      'shakes',
+      'shakeCall',
+    ]);
+    expect(Object.isFrozen(PIPELINE_TELEMETRY_SCHEMA)).toBe(true);
+    expect(Object.isFrozen(PIPELINE_TELEMETRY_SCHEMA.tupleEncoding)).toBe(true);
+    expect(Object.isFrozen(enumIds.parserKey)).toBe(true);
+    expect(Object.isFrozen(layouts.parseRevision)).toBe(true);
+    expect(Object.isFrozen(masks.parseRevision)).toBe(true);
+  });
+
+  it('encodes common parser keys with stable numeric ids', () => {
+    const accumulator = createAccumulator();
+    const parserKeys = [...PARSER_KEYS, 'custom:source:ts:r9:j0'] as const;
+    parserKeys.forEach((parserKey, index) => {
+      accumulator.parse.revisions.push({
+        bytes: index + 1,
+        cacheHits: 0,
+        cacheMisses: 1,
+        errors: 0,
+        jsxFallbackAttempts: 0,
+        jsxFallbackRequests: 0,
+        kind: 'cached',
+        parserKey,
+        requests: 1,
+        revision: `revision-${index}`,
+      });
+    });
+
+    const wire = JSON.parse(
+      serializePipelineTelemetryJSONl(accumulator, WORKING_DIR)
+    ) as JSONRecord;
+    const [, revisions] = wire.parse as unknown[][];
+    expect(revisions.map((revision) => revision[1])).toEqual([
+      ...PARSER_KEYS.map((_parserKey, index) => index),
+      'custom:source:ts:r9:j0',
+    ]);
+  });
+});

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -2,6 +2,13 @@ import { createHash } from 'crypto';
 import fs from 'node:fs';
 import { logger } from '@wyw-in-js/shared';
 
+import {
+  getPipelineCodeSha256Hex,
+  primePipelineCodeSha256Hex,
+  recordPipelineCacheClear,
+  recordPipelineCacheRequest,
+  recordPipelineCacheSalt,
+} from './debug/pipelineTelemetry';
 import type { BarrelManifestCacheEntry } from './transform/barrelManifest.types';
 import type { Entrypoint } from './transform/Entrypoint';
 import type { IEvaluatedEntrypoint } from './transform/EvaluatedEntrypoint';
@@ -9,7 +16,12 @@ import { getFileIdx } from './utils/getFileIdx';
 import { stripQueryAndHash } from './utils/parseRequest';
 
 function hashContent(content: string) {
-  return createHash('sha256').update(content).digest('hex');
+  const cached = getPipelineCodeSha256Hex(content);
+  if (cached) return cached;
+
+  const sha256Hex = createHash('sha256').update(content).digest('hex');
+  primePipelineCodeSha256Hex(content, sha256Hex);
+  return sha256Hex;
 }
 
 function isMissingFileError(error: unknown): boolean {
@@ -90,12 +102,16 @@ export class TransformCacheCollection<
   }
 
   public setKeySalt(keySalt: string | null) {
-    if (this.keySalt === keySalt) return;
-
     const prevKeySalt = this.keySalt;
+    if (prevKeySalt === keySalt) {
+      recordPipelineCacheSalt(prevKeySalt, keySalt, 'unchanged');
+      return;
+    }
+
     this.keySalt = keySalt;
 
     if (prevKeySalt === null && keySalt) {
+      recordPipelineCacheSalt(prevKeySalt, keySalt, 'migrate');
       const migrate = <TValue>(cache: Map<string, TValue>) => {
         const entries = Array.from(cache.entries());
         cache.clear();
@@ -113,8 +129,21 @@ export class TransformCacheCollection<
       return;
     }
 
+    const clearReason = keySalt === null ? 'salt-disable' : 'salt-change';
+    recordPipelineCacheSalt(
+      prevKeySalt,
+      keySalt,
+      keySalt === null ? 'disable' : 'clear'
+    );
+    recordPipelineCacheClear(
+      'barrelManifests',
+      clearReason,
+      this.barrelManifests.size
+    );
     this.barrelManifests.clear();
+    recordPipelineCacheClear('entrypoints', clearReason, this.entrypoints.size);
     this.entrypoints.clear();
+    recordPipelineCacheClear('exports', clearReason, this.exports.size);
     this.exports.clear();
     this.entrypointDependencySnapshots.clear();
     this.clearCacheDependencies('all');
@@ -217,6 +246,7 @@ export class TransformCacheCollection<
     loggers[cacheName]('clear');
     const cache = this[cacheName] as Map<string, unknown>;
 
+    recordPipelineCacheClear(cacheName, 'explicit', cache.size);
     cache.clear();
     if (cacheName === 'entrypoints') {
       this.entrypointDependencySnapshots.clear();
@@ -236,6 +266,7 @@ export class TransformCacheCollection<
     const res = cache.get(this.getKey(key));
 
     loggers[cacheName]('get', key, res === undefined ? 'miss' : 'hit');
+    recordPipelineCacheRequest(cacheName, 'get', res !== undefined);
     return res;
   }
 
@@ -244,6 +275,7 @@ export class TransformCacheCollection<
     const res = cache.has(this.getKey(key));
 
     loggers[cacheName]('has', key, res);
+    recordPipelineCacheRequest(cacheName, 'has', res);
     return res;
   }
 
@@ -265,6 +297,7 @@ export class TransformCacheCollection<
     }
 
     cache.delete(cacheKey);
+    recordPipelineCacheClear(cacheName, 'invalidate', 1);
     this.clearCacheDependencies(cacheName, key);
   }
 

--- a/packages/transform/src/debug/fileReporter.ts
+++ b/packages/transform/src/debug/fileReporter.ts
@@ -11,6 +11,10 @@ import type {
   PerfFinishEvent,
 } from '../utils/EventEmitter';
 import { EventEmitter, isOnActionStartArgs } from '../utils/EventEmitter';
+import {
+  PIPELINE_TELEMETRY_SCHEMA,
+  registerPipelineTelemetryJSONlReporter,
+} from './pipelineTelemetry';
 
 type Timings = Map<string, Map<string, number>>;
 
@@ -95,6 +99,43 @@ const writeJSONl = (stream: NodeJS.WritableStream, data: unknown) => {
   }
 
   stream.write(`${JSON.stringify(data, replacer)}\n`);
+};
+
+const PIPELINE_TELEMETRY_WRITE_CHUNK_CHARS = 256 * 1024;
+
+const createPipelineTelemetryJSONlWriter = (stream: NodeJS.WritableStream) => {
+  let bufferedChars = 0;
+  let bufferedLines: string[] = [];
+  let closed = false;
+  const flush = (): void => {
+    if (closed) return;
+    if (!stream.writable) {
+      bufferedChars = 0;
+      bufferedLines = [];
+      return;
+    }
+    if (bufferedLines.length === 0) return;
+    stream.write(
+      bufferedLines.length === 1 ? bufferedLines[0] : bufferedLines.join('')
+    );
+    bufferedChars = 0;
+    bufferedLines = [];
+  };
+
+  return {
+    end: (): void => {
+      if (closed) return;
+      flush();
+      closed = true;
+    },
+    flush,
+    write: (line: string): void => {
+      if (closed || !stream.writable) return;
+      bufferedLines.push(line);
+      bufferedChars += line.length;
+      if (bufferedChars >= PIPELINE_TELEMETRY_WRITE_CHUNK_CHARS) flush();
+    },
+  };
 };
 
 const createReportStream = (dir: string, filename: string) => {
@@ -188,6 +229,15 @@ export const createFileReporter = (
   const perfSpanStream = createReportStream(options.dir, 'perf-spans.jsonl');
 
   const evalFilesStream = createReportStream(options.dir, 'eval-files.jsonl');
+
+  const pipelineTelemetryStream = createReportStream(
+    options.dir,
+    'pipeline-telemetry.jsonl'
+  );
+  const pipelineTelemetryWriter = createPipelineTelemetryJSONlWriter(
+    pipelineTelemetryStream
+  );
+  writeJSONl(pipelineTelemetryStream, PIPELINE_TELEMETRY_SCHEMA);
 
   const startedAt = performance.now();
   const timings: Timings = new Map();
@@ -312,10 +362,25 @@ export const createFileReporter = (
   };
 
   const emitter = new EventEmitter(onEvent, onAction, onEntrypointEvent);
+  let unregisterPipelineTelemetry = registerPipelineTelemetryJSONlReporter(
+    emitter,
+    workingDir,
+    (line, status) => {
+      pipelineTelemetryWriter.write(line);
+      if (status === 'error') pipelineTelemetryWriter.flush();
+    }
+  );
+  let done = false;
 
   return {
     emitter,
     onDone: (sourceRoot: string) => {
+      if (done) return;
+      done = true;
+      unregisterPipelineTelemetry();
+      unregisterPipelineTelemetry = () => {};
+      pipelineTelemetryWriter.end();
+
       if (options.print) {
         printTimings(timings, startedAt, sourceRoot);
 
@@ -330,6 +395,7 @@ export const createFileReporter = (
         staticPlanStream,
         perfSpanStream,
         evalFilesStream,
+        pipelineTelemetryStream,
       ].forEach((stream) => {
         if (stream.writable) {
           stream.end();

--- a/packages/transform/src/debug/pipelineTelemetry.jsonl.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.jsonl.ts
@@ -1,0 +1,411 @@
+/* eslint-disable no-bitwise */
+import path from 'path';
+
+import { getPipelineParserAttempts } from './pipelineTelemetry.parse';
+import { PIPELINE_TELEMETRY_SCHEMA } from './pipelineTelemetry.schema';
+import type {
+  CacheName,
+  CacheOperation,
+  PipelineAccumulator,
+} from './pipelineTelemetry.types';
+
+type JSONRecord = Record<string, unknown>;
+
+const enumIds = <T extends string>(values: readonly T[]): Record<T, number> =>
+  Object.fromEntries(values.map((value, id) => [value, id])) as Record<
+    T,
+    number
+  >;
+
+const CACHE_IDS = enumIds<CacheName>(
+  PIPELINE_TELEMETRY_SCHEMA.tupleEncoding.enumIds.cache
+);
+
+const CACHE_OPERATION_IDS = enumIds<CacheOperation>(
+  PIPELINE_TELEMETRY_SCHEMA.tupleEncoding.enumIds.cacheOperation
+);
+
+const CACHE_OPERATIONS = [
+  ['barrelManifests', 'get'],
+  ['barrelManifests', 'has'],
+  ['entrypoints', 'get'],
+  ['entrypoints', 'has'],
+  ['exports', 'get'],
+  ['exports', 'has'],
+] as const satisfies ReadonlyArray<readonly [CacheName, CacheOperation]>;
+
+const PARSER_KEY_IDS: Readonly<Record<string, number>> = enumIds(
+  PIPELINE_TELEMETRY_SCHEMA.tupleEncoding.enumIds.parserKey
+);
+
+const relativeFilename = (filename: string, workingDir: string): string => {
+  const isWindowsPath = (value: string): boolean =>
+    /^(?:[A-Za-z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/u.test(value);
+  const pathApi = isWindowsPath(filename) ? path.win32 : path.posix;
+  if (!pathApi.isAbsolute(filename)) return filename;
+  if (!pathApi.isAbsolute(workingDir)) return pathApi.basename(filename);
+
+  const relative = pathApi.relative(workingDir, filename);
+  return pathApi.isAbsolute(relative) ? pathApi.basename(filename) : relative;
+};
+
+const nestedFilename = (
+  filename: string,
+  rootFilename: string,
+  workingDir: string
+): string | undefined =>
+  filename === rootFilename
+    ? undefined
+    : relativeFilename(filename, workingDir);
+
+const buildCache = (accumulator: PipelineAccumulator): unknown[] => {
+  const { cache } = accumulator;
+  let hits = 0;
+  let misses = 0;
+  let requests = 0;
+  const byOperation: unknown[][] = [];
+  CACHE_OPERATIONS.forEach(([cacheName, operation], index) => {
+    const counter = cache.byOperation[index];
+    if (!counter) return;
+    hits += counter.hits;
+    misses += counter.misses;
+    requests += counter.requests;
+    byOperation.push([
+      CACHE_IDS[cacheName],
+      CACHE_OPERATION_IDS[operation],
+      counter.hits,
+      counter.misses,
+      counter.requests,
+    ]);
+  });
+
+  let clearEntries = 0;
+  let clearRequests = 0;
+  const clearReasons = Array.from(cache.clearReasons.values(), (counter) => {
+    clearEntries += counter.entries;
+    clearRequests += counter.requests;
+    return [
+      CACHE_IDS[counter.cache],
+      counter.reason,
+      counter.entries,
+      counter.requests,
+    ];
+  });
+
+  const { changes, unchanged } = cache.salt;
+  let clears = 0;
+  let disables = 0;
+  let migrations = 0;
+  changes.forEach(({ outcome }) => {
+    if (outcome === 'clear') clears += 1;
+    if (outcome === 'disable') disables += 1;
+    if (outcome === 'migrate') migrations += 1;
+  });
+
+  return [
+    requests,
+    hits,
+    misses,
+    clearRequests,
+    clearEntries,
+    [
+      unchanged + changes.length,
+      clears,
+      disables,
+      migrations,
+      unchanged,
+      changes,
+    ],
+    byOperation,
+    clearReasons,
+  ];
+};
+
+const hasCacheActivity = (accumulator: PipelineAccumulator): boolean =>
+  accumulator.cache.byOperation.some(Boolean) ||
+  accumulator.cache.clearReasons.size > 0 ||
+  accumulator.cache.salt.unchanged > 0 ||
+  accumulator.cache.salt.changes.length > 0;
+
+const buildCleanup = (accumulator: PipelineAccumulator): unknown[] => {
+  const { cleanup } = accumulator;
+  const { candidateRemovals } = cleanup;
+  return [
+    cleanup.calls,
+    cleanup.attemptedIterations,
+    cleanup.attemptedRanges,
+    cleanup.attemptedBytes,
+    cleanup.committedIterations,
+    cleanup.committedRanges,
+    cleanup.committedBytes,
+    cleanup.rollbackBytes,
+    [
+      candidateRemovals.emptyBlocks,
+      candidateRemovals.expressions,
+      candidateRemovals.generatedHelpers,
+      candidateRemovals.imports,
+      candidateRemovals.scopedDeclarations,
+      candidateRemovals.topLevelDeclarations,
+    ],
+    cleanup.converged,
+    cleanup.rollbacks,
+    cleanup.capHits,
+    cleanup.stalled,
+    cleanup.errors,
+  ];
+};
+
+const buildEntrypoints = (accumulator: PipelineAccumulator): unknown[] => {
+  const { entrypoints } = accumulator;
+  let disposableRoots = 0;
+  const disposableRootsByPhase = Array.from(
+    entrypoints.disposableRootsByPhase,
+    ([phase, count]) => {
+      disposableRoots += count;
+      return [phase, count];
+    }
+  );
+
+  return [
+    entrypoints.roots + entrypoints.children,
+    entrypoints.roots,
+    entrypoints.children,
+    entrypoints.created,
+    entrypoints.cached,
+    entrypoints.loops,
+    entrypoints.initialRoots,
+    entrypoints.roots - entrypoints.initialRoots,
+    disposableRoots,
+    Array.from(entrypoints.byOnly.values(), (counter) => [
+      counter.only,
+      counter.count,
+    ]),
+    disposableRootsByPhase,
+  ];
+};
+
+const buildLateNoMetadata = (
+  accumulator: PipelineAccumulator,
+  rootFilename: string,
+  workingDir: string
+): unknown[] => {
+  let dangerousCodeCalls = 0;
+  let dangerousCodeMs = 0;
+  if (accumulator.lateNoMetadata.length === 1) {
+    const dangerous = accumulator.dangerousByFile.get(
+      accumulator.lateNoMetadata[0].filename
+    );
+    dangerousCodeCalls = dangerous?.calls ?? 0;
+    dangerousCodeMs = dangerous?.durationMs ?? 0;
+  } else {
+    const uniqueFiles = new Set(
+      accumulator.lateNoMetadata.map(({ filename }) => filename)
+    );
+    uniqueFiles.forEach((filename) => {
+      const dangerous = accumulator.dangerousByFile.get(filename);
+      dangerousCodeCalls += dangerous?.calls ?? 0;
+      dangerousCodeMs += dangerous?.durationMs ?? 0;
+    });
+  }
+
+  return [
+    accumulator.lateNoMetadata.length,
+    dangerousCodeCalls,
+    dangerousCodeMs,
+    accumulator.lateNoMetadata.map((event) => {
+      const record: unknown[] = [event.phase, event.only];
+      const filename = nestedFilename(event.filename, rootFilename, workingDir);
+      if (filename !== undefined) record.push(filename);
+      return record;
+    }),
+  ];
+};
+
+const buildParse = (accumulator: PipelineAccumulator): unknown[] => {
+  const { parse } = accumulator;
+  let allRequests = 0;
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  let errors = 0;
+  let jsxFallbackAttempts = 0;
+  let jsxFallbackRequests = 0;
+  let parsedBytes = 0;
+  let parserAttempts = 0;
+  let requestedBytes = 0;
+  let uncachedRequests = 0;
+  const revisions = parse.revisions.map((counter) => {
+    const revisionParserAttempts = getPipelineParserAttempts(counter);
+    allRequests += counter.requests;
+    cacheHits += counter.cacheHits;
+    cacheMisses += counter.cacheMisses;
+    errors += counter.errors;
+    jsxFallbackAttempts += counter.jsxFallbackAttempts;
+    jsxFallbackRequests += counter.jsxFallbackRequests;
+    parsedBytes += counter.bytes * revisionParserAttempts;
+    parserAttempts += revisionParserAttempts;
+    requestedBytes += counter.bytes * counter.requests;
+    if (counter.kind === 'uncached') uncachedRequests += counter.requests;
+
+    let mask = 0;
+    const values: unknown[] = [];
+    if (counter.kind !== 'cached') {
+      mask |= 1;
+      values.push(counter.kind);
+    }
+    if (counter.cacheHits !== 0) {
+      mask |= 2;
+      values.push(counter.cacheHits);
+    }
+    if (counter.cacheMisses !== 0) {
+      mask |= 4;
+      values.push(counter.cacheMisses);
+    }
+    if (counter.errors !== 0) {
+      mask |= 8;
+      values.push(counter.errors);
+    }
+    if (counter.jsxFallbackRequests !== 0) {
+      mask |= 16;
+      values.push(counter.jsxFallbackRequests);
+    }
+    if (counter.jsxFallbackAttempts !== 0) {
+      mask |= 32;
+      values.push(counter.jsxFallbackAttempts);
+    }
+    return [
+      counter.revision,
+      typeof counter.parserKey === 'number'
+        ? counter.parserKey
+        : PARSER_KEY_IDS[counter.parserKey] ?? counter.parserKey,
+      counter.bytes,
+      counter.requests,
+      mask,
+      ...values,
+    ];
+  });
+  const totals = [
+    allRequests,
+    cacheHits + cacheMisses,
+    uncachedRequests,
+    cacheHits,
+    cacheMisses,
+    parserAttempts,
+    requestedBytes,
+    parsedBytes,
+    errors,
+    jsxFallbackRequests,
+    jsxFallbackAttempts,
+  ];
+  return [totals, revisions];
+};
+
+const buildProcessors = (accumulator: PipelineAccumulator): unknown[] =>
+  Array.from(accumulator.processors.byPhase, ([phase, counter]) => {
+    let mask = 0;
+    const values: unknown[] = [];
+    if (counter.definedProcessors !== 0) {
+      mask |= 1;
+      values.push(counter.definedProcessors);
+    }
+    if (counter.importCandidates !== 0) {
+      mask |= 2;
+      values.push(counter.importCandidates);
+    }
+    if (counter.lookupAttempts !== 0) {
+      mask |= 4;
+      values.push(counter.lookupAttempts);
+    }
+    if (counter.lookupHits !== 0) {
+      mask |= 8;
+      values.push(counter.lookupHits);
+    }
+    if (counter.passes !== 1) {
+      mask |= 16;
+      values.push(counter.passes);
+    }
+    if (counter.reusedPlans !== 0) {
+      mask |= 32;
+      values.push(counter.reusedPlans);
+    }
+    if (counter.usages !== 0) {
+      mask |= 64;
+      values.push(counter.usages);
+    }
+    return [phase, mask, ...values];
+  });
+
+const buildShakes = (accumulator: PipelineAccumulator): unknown[] => {
+  const { shakes } = accumulator;
+  return [
+    shakes.attempts,
+    shakes.successes,
+    shakes.errors,
+    shakes.generatedBytes,
+    shakes.calls.map((call) => {
+      let mask = 0;
+      const values: unknown[] = [];
+      if (call.error) mask |= 1;
+      if (call.generatedBytes !== 0) {
+        mask |= 2;
+        values.push(call.generatedBytes);
+      }
+      return [
+        call.inputRevision,
+        call.mode,
+        call.only,
+        call.outputRevision,
+        call.inputBytes,
+        mask,
+        ...values,
+      ];
+    }),
+  ];
+};
+
+/**
+ * Serializes a root-scoped telemetry record as named sections containing
+ * compact tuples. The file reporter writes the returned newline as-is.
+ */
+export const serializePipelineTelemetryJSONl = (
+  accumulator: PipelineAccumulator,
+  workingDir: string
+): string => {
+  const { root } = accumulator;
+  const result: JSONRecord = {
+    root: {
+      filename: relativeFilename(root.filename, workingDir),
+      status: root.status,
+    },
+    schemaVersion: 1,
+    type: 'pipeline-telemetry',
+  };
+  const { cleanup, entrypoints, parse, processors, shakes } = accumulator;
+  if (hasCacheActivity(accumulator)) {
+    result.cache = buildCache(accumulator);
+  }
+  if (cleanup.calls > 0) result.cleanup = buildCleanup(accumulator);
+  if (
+    entrypoints.roots > 0 ||
+    entrypoints.children > 0 ||
+    entrypoints.disposableRootsByPhase.size > 0
+  ) {
+    result.entrypoints = buildEntrypoints(accumulator);
+  }
+  if (accumulator.lateNoMetadata.length > 0) {
+    result.lateNoMetadata = buildLateNoMetadata(
+      accumulator,
+      root.filename,
+      workingDir
+    );
+  }
+  if (parse.revisions.length > 0) {
+    result.parse = buildParse(accumulator);
+  }
+  if (processors.byPhase.size > 0) {
+    result.processors = buildProcessors(accumulator);
+  }
+  if (shakes.attempts > 0) {
+    result.shakes = buildShakes(accumulator);
+  }
+  return `${JSON.stringify(result)}\n`;
+};

--- a/packages/transform/src/debug/pipelineTelemetry.measurements.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.measurements.ts
@@ -1,0 +1,343 @@
+import { hash } from 'node:crypto';
+
+import type {
+  CodeMeasurement,
+  CodeMeasurementBucket,
+  CodeMeasurementEntry,
+  PipelineAccumulator,
+} from './pipelineTelemetry.types';
+
+// A reporter spans an entire build, where the same dependency revisions are
+// observed from many transform roots. Keep enough measurements to cover a
+// medium-sized build without repeatedly hashing the same source, while still
+// bounding debug-only retention. The code-unit limit is an explicit retention
+// bound; it is not an estimate of the strings' allocated memory.
+const MAX_CODE_MEASUREMENTS = 4_096;
+const MAX_CACHED_CODE_UNITS = 64 * 1024;
+const MAX_SHARED_CODE_UNITS = 16 * 1024 * 1024;
+
+export type CompletedCodeMeasurement = CodeMeasurement & {
+  revision: string;
+};
+
+const codeMeasurementKey = (code: string): number => {
+  const { length } = code;
+  if (length === 0) return 0;
+
+  let key = length;
+  key = (key * 33 + code.charCodeAt(0)) % 2_147_483_647;
+  key = (key * 33 + code.charCodeAt(Math.floor(length / 2))) % 2_147_483_647;
+  return (key * 33 + code.charCodeAt(length - 1)) % 2_147_483_647;
+};
+
+const findCodeMeasurement = (
+  entries: Map<number, CodeMeasurementBucket>,
+  key: number,
+  code: string
+): CodeMeasurementEntry | undefined => {
+  const bucket = entries.get(key);
+  if (!bucket) return undefined;
+  if (!Array.isArray(bucket)) {
+    return bucket.code === code ? bucket : undefined;
+  }
+
+  for (const entry of bucket) {
+    if (entry.code === code) return entry;
+  }
+  return undefined;
+};
+
+const addCodeMeasurement = (
+  entries: Map<number, CodeMeasurementBucket>,
+  key: number,
+  code: string,
+  measurement: CodeMeasurement,
+  reusableEntry?: CodeMeasurementEntry
+): CodeMeasurementEntry => {
+  const bucket = entries.get(key);
+  if (!bucket) {
+    const entry = reusableEntry ?? { code, measurement };
+    entries.set(key, entry);
+    return entry;
+  }
+  if (Array.isArray(bucket)) {
+    const existing = bucket.find((candidate) => candidate.code === code);
+    if (existing) {
+      existing.measurement = measurement;
+      return existing;
+    }
+    const entry = reusableEntry ?? { code, measurement };
+    bucket.push(entry);
+    return entry;
+  }
+  if (bucket.code === code) {
+    bucket.measurement = measurement;
+    return bucket;
+  }
+
+  const entry = reusableEntry ?? { code, measurement };
+  entries.set(key, [bucket, entry]);
+  return entry;
+};
+
+const setCodeMeasurementWithKey = (
+  accumulator: PipelineAccumulator,
+  key: number,
+  code: string,
+  measurement: CodeMeasurement,
+  cacheShared = true,
+  sharedKnownMissing = false
+) => {
+  accumulator.lastSharedMissCode = undefined;
+  const localEntry = addCodeMeasurement(
+    accumulator.localCodeMeasurements,
+    key,
+    code,
+    measurement
+  );
+  accumulator.lastCode = code;
+  accumulator.lastMeasurement = measurement;
+  if (!cacheShared) return measurement;
+  if (
+    code.length > MAX_CACHED_CODE_UNITS ||
+    code.length > MAX_SHARED_CODE_UNITS
+  ) {
+    return measurement;
+  }
+
+  const { codeMeasurements } = accumulator;
+  if (!sharedKnownMissing) {
+    const existingShared = findCodeMeasurement(
+      codeMeasurements.entries,
+      key,
+      code
+    );
+    if (existingShared) {
+      existingShared.measurement = measurement;
+      return measurement;
+    }
+  }
+  while (
+    codeMeasurements.count >= MAX_CODE_MEASUREMENTS ||
+    codeMeasurements.codeUnits + code.length > MAX_SHARED_CODE_UNITS
+  ) {
+    let oldestResult = codeMeasurements.evictionKeys.next();
+    if (oldestResult.done) {
+      codeMeasurements.evictionKeys = codeMeasurements.entries.keys();
+      oldestResult = codeMeasurements.evictionKeys.next();
+    }
+    if (oldestResult.done) break;
+    const oldestKey = oldestResult.value;
+    const oldestBucket = codeMeasurements.entries.get(oldestKey);
+    codeMeasurements.entries.delete(oldestKey);
+    if (oldestBucket) {
+      if (!Array.isArray(oldestBucket)) {
+        codeMeasurements.codeUnits -= oldestBucket.code.length;
+        codeMeasurements.count -= 1;
+      } else {
+        codeMeasurements.count -= oldestBucket.length;
+        for (const entry of oldestBucket) {
+          codeMeasurements.codeUnits -= entry.code.length;
+        }
+      }
+    }
+  }
+  codeMeasurements.codeUnits += code.length;
+  codeMeasurements.count += 1;
+  addCodeMeasurement(
+    codeMeasurements.entries,
+    key,
+    code,
+    measurement,
+    localEntry
+  );
+  return measurement;
+};
+
+export function setCodeMeasurement(
+  accumulator: PipelineAccumulator,
+  code: string,
+  measurement: CompletedCodeMeasurement,
+  cacheShared?: boolean
+): CompletedCodeMeasurement;
+export function setCodeMeasurement(
+  accumulator: PipelineAccumulator,
+  code: string,
+  measurement: CodeMeasurement,
+  cacheShared?: boolean
+): CodeMeasurement;
+export function setCodeMeasurement(
+  accumulator: PipelineAccumulator,
+  code: string,
+  measurement: CodeMeasurement,
+  cacheShared = true
+): CodeMeasurement {
+  return setCodeMeasurementWithKey(
+    accumulator,
+    codeMeasurementKey(code),
+    code,
+    measurement,
+    cacheShared
+  );
+}
+
+export const setMissingCodeMeasurement = (
+  accumulator: PipelineAccumulator,
+  code: string,
+  measurement: CompletedCodeMeasurement
+): CompletedCodeMeasurement => {
+  const sharedKnownMissing = accumulator.lastSharedMissCode === code;
+  return setCodeMeasurementWithKey(
+    accumulator,
+    codeMeasurementKey(code),
+    code,
+    measurement,
+    true,
+    sharedKnownMissing
+  ) as CompletedCodeMeasurement;
+};
+
+export const getCodeMeasurement = (
+  accumulator: PipelineAccumulator,
+  code: string
+): CompletedCodeMeasurement | undefined => {
+  accumulator.lastSharedMissCode = undefined;
+  if (accumulator.lastCode === code && accumulator.lastMeasurement?.revision) {
+    return accumulator.lastMeasurement as CompletedCodeMeasurement;
+  }
+  const key = codeMeasurementKey(code);
+  const local = findCodeMeasurement(
+    accumulator.localCodeMeasurements,
+    key,
+    code
+  );
+  if (local?.measurement.revision) {
+    accumulator.lastCode = code;
+    accumulator.lastMeasurement = local.measurement;
+    return local.measurement as CompletedCodeMeasurement;
+  }
+
+  const shared = findCodeMeasurement(
+    accumulator.codeMeasurements.entries,
+    key,
+    code
+  );
+  if (!shared?.measurement.revision) {
+    if (shared) {
+      accumulator.lastCode = code;
+      accumulator.lastMeasurement = shared.measurement;
+    } else {
+      accumulator.lastSharedMissCode = code;
+    }
+    return undefined;
+  }
+  addCodeMeasurement(
+    accumulator.localCodeMeasurements,
+    key,
+    code,
+    shared.measurement,
+    shared
+  );
+  accumulator.lastCode = code;
+  accumulator.lastMeasurement = shared.measurement;
+  return shared.measurement as CompletedCodeMeasurement;
+};
+
+export const measureCode = (
+  accumulator: PipelineAccumulator,
+  code: string,
+  cacheShared = true
+): CompletedCodeMeasurement => {
+  if (accumulator.lastCode === code && accumulator.lastMeasurement?.revision) {
+    return accumulator.lastMeasurement as CompletedCodeMeasurement;
+  }
+  const key = codeMeasurementKey(code);
+  const local = findCodeMeasurement(
+    accumulator.localCodeMeasurements,
+    key,
+    code
+  );
+  if (local?.measurement.revision) {
+    accumulator.lastCode = code;
+    accumulator.lastMeasurement = local.measurement;
+    return local.measurement as CompletedCodeMeasurement;
+  }
+
+  const shared = findCodeMeasurement(
+    accumulator.codeMeasurements.entries,
+    key,
+    code
+  );
+  if (shared?.measurement.revision) {
+    addCodeMeasurement(
+      accumulator.localCodeMeasurements,
+      key,
+      code,
+      shared.measurement,
+      shared
+    );
+    accumulator.lastCode = code;
+    accumulator.lastMeasurement = shared.measurement;
+    return shared.measurement as CompletedCodeMeasurement;
+  }
+
+  const measurement = {
+    bytes: local?.measurement.bytes ?? Buffer.byteLength(code),
+    revision: hash('sha256', code, 'base64url'),
+  };
+  setCodeMeasurementWithKey(
+    accumulator,
+    key,
+    code,
+    measurement,
+    cacheShared,
+    shared === undefined
+  );
+  return measurement;
+};
+
+export const measureBytes = (
+  accumulator: PipelineAccumulator,
+  code: string
+): number => {
+  if (accumulator.lastCode === code && accumulator.lastMeasurement) {
+    return accumulator.lastMeasurement.bytes;
+  }
+  const key = codeMeasurementKey(code);
+  const local = findCodeMeasurement(
+    accumulator.localCodeMeasurements,
+    key,
+    code
+  );
+  if (local) {
+    accumulator.lastCode = code;
+    accumulator.lastMeasurement = local.measurement;
+    return local.measurement.bytes;
+  }
+
+  const shared = findCodeMeasurement(
+    accumulator.codeMeasurements.entries,
+    key,
+    code
+  );
+  if (shared) {
+    addCodeMeasurement(
+      accumulator.localCodeMeasurements,
+      key,
+      code,
+      shared.measurement,
+      shared
+    );
+    accumulator.lastCode = code;
+    accumulator.lastMeasurement = shared.measurement;
+    return shared.measurement.bytes;
+  }
+
+  return setCodeMeasurementWithKey(
+    accumulator,
+    key,
+    code,
+    { bytes: Buffer.byteLength(code) },
+    false
+  ).bytes;
+};

--- a/packages/transform/src/debug/pipelineTelemetry.parse.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.parse.ts
@@ -1,0 +1,7 @@
+import type { ParseRevisionCounter } from './pipelineTelemetry.types';
+
+export const getPipelineParserAttempts = (
+  counter: ParseRevisionCounter
+): number =>
+  (counter.kind === 'cached' ? counter.cacheMisses : counter.requests) +
+  counter.jsxFallbackAttempts;

--- a/packages/transform/src/debug/pipelineTelemetry.schema.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.schema.ts
@@ -1,0 +1,213 @@
+const DENOMINATORS = Object.freeze({
+  cache:
+    'requests = get requests + has requests; each byOperation bucket has requests = hits + misses; salt.calls counts setKeySalt decisions, while salt.changes retains only transitions; clearRequests counts primary-cache clear/invalidate operations and clearEntries counts entries present before them',
+  cleanup:
+    'calls are cleanup invocations; attemptedIterations are loop bodies and committedIterations are candidate revisions accepted after parse; candidateRemovals are raw pre-merge ranges by collector and can overlap, while attempted/committed ranges and bytes use merged ranges; outcomes partition calls',
+  entrypoints:
+    'requests are completed Entrypoint.innerCreate decisions; requests = roots + children = created + cached + loops; byOnly counts the effective merged entrypoint.only list; initialRoots means a root request with loadedCode, while onDemandRoots has no loadedCode; disposable roots are events rather than unique filenames; calls that throw before a decision are not counted',
+  lateNoMetadata:
+    'count is late no-metadata short-circuit events; events retain each phase/only occurrence, while dangerousCodeCalls and dangerousCodeMs include each distinct affected filename once',
+  parse:
+    'allRequests = cachedRequests + uncachedRequests; cachedRequests = cacheHits + cacheMisses; every miss or uncached request has one primary parse and at most one JSX fallback, so parserAttempts are derived as cacheMisses + jsxFallbackAttempts for cached revisions and requests + jsxFallbackAttempts for uncached revisions; requestedBytes count each logical request input, parsedBytes count input bytes per physical parseSync attempt, errors count failed logical requests, and JSX fallback requests/attempts separate logical need from physical fallback parses; compact revision records store source bytes once',
+  processors:
+    'passes are applyOxcProcessors invocations that reach a recorded import/usage analysis result; lookupAttempts exclude side-effect imports and candidates without a local binding; reused plans skip import lookup but still count usages',
+  shakes:
+    'attempts are core prepareOxcCodeImpl shake calls; attempts = successes + errors',
+});
+
+const TUPLE_LAYOUTS = Object.freeze({
+  cache: [
+    'requests',
+    'hits',
+    'misses',
+    'clearRequests',
+    'clearEntries',
+    'salt',
+    'byOperation',
+    'clearReasons',
+  ],
+  cacheByOperation: ['cacheId', 'operationId', 'hits', 'misses', 'requests'],
+  cacheClearReason: ['cacheId', 'reason', 'entries', 'requests'],
+  cacheSalt: [
+    'calls',
+    'clears',
+    'disables',
+    'migrations',
+    'unchanged',
+    'changes',
+  ],
+  cleanup: [
+    'calls',
+    'attemptedIterations',
+    'attemptedRanges',
+    'attemptedBytes',
+    'committedIterations',
+    'committedRanges',
+    'committedBytes',
+    'rollbackBytes',
+    'candidateRemovals',
+    'converged',
+    'rollbacks',
+    'capHits',
+    'stalled',
+    'errors',
+  ],
+  cleanupCandidateRemovals: [
+    'emptyBlocks',
+    'expressions',
+    'generatedHelpers',
+    'imports',
+    'scopedDeclarations',
+    'topLevelDeclarations',
+  ],
+  entrypoints: [
+    'requests',
+    'roots',
+    'children',
+    'created',
+    'cached',
+    'loops',
+    'initialRoots',
+    'onDemandRoots',
+    'disposableRoots',
+    'byOnly',
+    'disposableRootsByPhase',
+  ],
+  entrypointByOnly: ['only', 'count'],
+  entrypointDisposableRoot: ['phase', 'count'],
+  lateNoMetadata: ['count', 'dangerousCodeCalls', 'dangerousCodeMs', 'events'],
+  lateNoMetadataEvent: ['phase', 'only', 'filename?'],
+  parse: ['totals', 'revisions'],
+  parseRevision: [
+    'revision',
+    'parserKeyIdOrString',
+    'bytes',
+    'requests',
+    'mask',
+    '...values',
+  ],
+  parseTotals: [
+    'allRequests',
+    'cachedRequests',
+    'uncachedRequests',
+    'cacheHits',
+    'cacheMisses',
+    'parserAttempts',
+    'requestedBytes',
+    'parsedBytes',
+    'errors',
+    'jsxFallbackRequests',
+    'jsxFallbackAttempts',
+  ],
+  processor: ['phase', 'mask', '...values'],
+  shakes: ['attempts', 'successes', 'errors', 'generatedBytes', 'calls'],
+  shakeCall: [
+    'inputRevision',
+    'mode',
+    'only',
+    'outputRevision',
+    'inputBytes',
+    'mask',
+    '...values',
+  ],
+});
+
+const ENUM_IDS = Object.freeze({
+  cache: ['barrelManifests', 'entrypoints', 'exports'],
+  cacheOperation: ['get', 'has'],
+  parserKey: [
+    'oxc:module:js:js:r1:j0',
+    'oxc:module:js:js:r1:j1',
+    'oxc:module:js:ts:r1:j0',
+    'oxc:module:js:ts:r1:j1',
+    'oxc:module:jsx:js:r1:j0',
+    'oxc:module:jsx:js:r1:j1',
+    'oxc:module:jsx:ts:r1:j0',
+    'oxc:module:jsx:ts:r1:j1',
+    'oxc:module:ts:js:r1:j0',
+    'oxc:module:ts:js:r1:j1',
+    'oxc:module:ts:ts:r1:j0',
+    'oxc:module:ts:ts:r1:j1',
+    'oxc:module:tsx:js:r1:j0',
+    'oxc:module:tsx:js:r1:j1',
+    'oxc:module:tsx:ts:r1:j0',
+    'oxc:module:tsx:ts:r1:j1',
+    'oxc:module:dts:js:r1:j0',
+    'oxc:module:dts:js:r1:j1',
+    'oxc:module:dts:ts:r1:j0',
+    'oxc:module:dts:ts:r1:j1',
+    'oxc:unambiguous:js:js:r1:j0',
+    'oxc:unambiguous:js:js:r1:j1',
+    'oxc:unambiguous:js:ts:r1:j0',
+    'oxc:unambiguous:js:ts:r1:j1',
+    'oxc:unambiguous:jsx:js:r1:j0',
+    'oxc:unambiguous:jsx:js:r1:j1',
+    'oxc:unambiguous:jsx:ts:r1:j0',
+    'oxc:unambiguous:jsx:ts:r1:j1',
+    'oxc:unambiguous:ts:js:r1:j0',
+    'oxc:unambiguous:ts:js:r1:j1',
+    'oxc:unambiguous:ts:ts:r1:j0',
+    'oxc:unambiguous:ts:ts:r1:j1',
+    'oxc:unambiguous:tsx:js:r1:j0',
+    'oxc:unambiguous:tsx:js:r1:j1',
+    'oxc:unambiguous:tsx:ts:r1:j0',
+    'oxc:unambiguous:tsx:ts:r1:j1',
+    'oxc:unambiguous:dts:js:r1:j0',
+    'oxc:unambiguous:dts:js:r1:j1',
+    'oxc:unambiguous:dts:ts:r1:j0',
+    'oxc:unambiguous:dts:ts:r1:j1',
+  ],
+} as const);
+
+const MASKS = Object.freeze({
+  parseRevision: {
+    cacheHits: 2,
+    cacheMisses: 4,
+    errors: 8,
+    jsxFallbackAttempts: 32,
+    jsxFallbackRequests: 16,
+    kind: 1,
+  },
+  processor: {
+    definedProcessors: 1,
+    importCandidates: 2,
+    lookupAttempts: 4,
+    lookupHits: 8,
+    passes: 16,
+    reusedPlans: 32,
+    usages: 64,
+  },
+  shakeCall: { error: 1, generatedBytes: 2 },
+});
+
+const deepFreeze = <T>(value: T): T => {
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+};
+
+export const PIPELINE_TELEMETRY_SCHEMA = deepFreeze({
+  denominators: DENOMINATORS,
+  encodings: {
+    bytes: 'UTF-8 byte length',
+    filenames:
+      'relative to the reporter working directory; cross-volume paths fall back to basename',
+    only: 'deduplicated and sorted; any list containing the wildcard normalizes to ["*"]',
+    revision: 'SHA-256 digest encoded as unpadded base64url',
+  },
+  omittedSections:
+    'root summaries omit counter sections whose denominator and totals are zero',
+  schemaVersion: 1 as const,
+  tupleEncoding: {
+    defaults:
+      'nested filename omission means the root filename; absent parse kind means cached; absent processor passes means 1',
+    enumIds: ENUM_IDS,
+    layouts: TUPLE_LAYOUTS,
+    masks: MASKS,
+    optionalValues:
+      'values for set bits are appended in ascending bit order; the marker-only error bit appends no value',
+  },
+  type: 'pipeline-telemetry-schema' as const,
+});

--- a/packages/transform/src/debug/pipelineTelemetry.state.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.state.ts
@@ -1,0 +1,122 @@
+import type {
+  CleanupRemovalKinds,
+  PipelineAccumulator,
+} from './pipelineTelemetry.types';
+
+const EMPTY_REMOVAL_KINDS = (): CleanupRemovalKinds => ({
+  emptyBlocks: 0,
+  expressions: 0,
+  generatedHelpers: 0,
+  imports: 0,
+  scopedDeclarations: 0,
+  topLevelDeclarations: 0,
+});
+
+export const normalizeOnly = (
+  accumulator: PipelineAccumulator,
+  only: readonly string[]
+): { key: string; only: string[] } => {
+  const cached = accumulator.onlyNormalizations.get(only);
+  if (cached) return cached;
+
+  let normalized: string[];
+  if (only.length <= 1) {
+    normalized = only.length === 0 ? [] : [only[0]];
+  } else if (only.includes('*')) {
+    normalized = ['*'];
+  } else {
+    normalized = [...new Set(only)].sort();
+  }
+
+  const result = { key: JSON.stringify(normalized), only: normalized };
+  accumulator.onlyNormalizations.set(only, result);
+  return result;
+};
+
+export const createAccumulator = (
+  filename: string,
+  codeMeasurements: PipelineAccumulator['codeMeasurements']
+): PipelineAccumulator => ({
+  cache: {
+    byOperation: new Array(6),
+    clearReasons: new Map(),
+    salt: {
+      changes: [],
+      unchanged: 0,
+    },
+  },
+  cleanup: {
+    calls: 0,
+    candidateRemovals: EMPTY_REMOVAL_KINDS(),
+    capHits: 0,
+    committedBytes: 0,
+    committedIterations: 0,
+    committedRanges: 0,
+    converged: 0,
+    errors: 0,
+    rollbackBytes: 0,
+    rollbacks: 0,
+    stalled: 0,
+    attemptedBytes: 0,
+    attemptedIterations: 0,
+    attemptedRanges: 0,
+  },
+  codeMeasurements,
+  closed: false,
+  dangerousByFile: new Map(),
+  entrypoints: {
+    byOnly: new Map(),
+    cached: 0,
+    children: 0,
+    created: 0,
+    disposableRootsByPhase: new Map(),
+    initialRoots: 0,
+    loops: 0,
+    roots: 0,
+  },
+  lateNoMetadata: [],
+  lastCode: undefined,
+  lastMeasurement: undefined,
+  lastSharedMissCode: undefined,
+  localCodeMeasurements: new Map(),
+  onlyNormalizations: new Map(),
+  parse: {
+    cachedRevisions: new WeakMap(),
+    revisionBuckets: new Map(),
+    revisions: [],
+  },
+  processors: {
+    byPhase: new Map(),
+  },
+  root: {
+    filename,
+    status: 'success',
+  },
+  shakes: {
+    attempts: 0,
+    calls: [],
+    errors: 0,
+    generatedBytes: 0,
+    successes: 0,
+  },
+});
+
+export const releaseAccumulator = (accumulator: PipelineAccumulator): void => {
+  accumulator.closed = true;
+  accumulator.cache.byOperation.fill(undefined);
+  accumulator.cache.clearReasons.clear();
+  accumulator.cache.salt.changes.length = 0;
+  accumulator.dangerousByFile.clear();
+  accumulator.entrypoints.byOnly.clear();
+  accumulator.entrypoints.disposableRootsByPhase.clear();
+  accumulator.lateNoMetadata.length = 0;
+  accumulator.lastCode = undefined;
+  accumulator.lastMeasurement = undefined;
+  accumulator.lastSharedMissCode = undefined;
+  accumulator.localCodeMeasurements.clear();
+  accumulator.onlyNormalizations.clear();
+  accumulator.parse.revisionBuckets.clear();
+  accumulator.parse.revisions.length = 0;
+  accumulator.processors.byPhase.clear();
+  accumulator.shakes.calls.length = 0;
+};

--- a/packages/transform/src/debug/pipelineTelemetry.summary.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.summary.ts
@@ -1,0 +1,402 @@
+import { getPipelineParserAttempts } from './pipelineTelemetry.parse';
+import { PIPELINE_TELEMETRY_SCHEMA } from './pipelineTelemetry.schema';
+import type {
+  CacheName,
+  CacheOperation,
+  ParseRevisionCounter,
+  PipelineAccumulator,
+  ProcessorCounter,
+} from './pipelineTelemetry.types';
+
+const CACHE_OPERATIONS = [
+  ['barrelManifests', 'get'],
+  ['barrelManifests', 'has'],
+  ['entrypoints', 'get'],
+  ['entrypoints', 'has'],
+  ['exports', 'get'],
+  ['exports', 'has'],
+] as const satisfies ReadonlyArray<readonly [CacheName, CacheOperation]>;
+
+const sortedEntries = <T>(map: Map<string, T>): Array<[string, T]> => {
+  const entries = [...map.entries()];
+  return entries.length > 1
+    ? entries.sort(([left], [right]) => left.localeCompare(right))
+    : entries;
+};
+
+const getParserKey = (counter: ParseRevisionCounter): string =>
+  typeof counter.parserKey === 'number'
+    ? PIPELINE_TELEMETRY_SCHEMA.tupleEncoding.enumIds.parserKey[
+        counter.parserKey
+      ]
+    : counter.parserKey;
+
+const buildCache = (
+  accumulator: PipelineAccumulator,
+  preserveInsertionOrder = false
+) => {
+  let hits = 0;
+  let misses = 0;
+  let requests = 0;
+  const byOperation: Array<{
+    cache: CacheName;
+    hits: number;
+    misses: number;
+    operation: CacheOperation;
+    requests: number;
+  }> = [];
+  CACHE_OPERATIONS.forEach(([cache, operation], index) => {
+    const counter = accumulator.cache.byOperation[index];
+    if (!counter) return;
+    hits += counter.hits;
+    misses += counter.misses;
+    requests += counter.requests;
+    byOperation.push({ cache, operation, ...counter });
+  });
+
+  const rawClearReasons = Array.from(accumulator.cache.clearReasons.values());
+  let clearEntries = 0;
+  let clearRequests = 0;
+  rawClearReasons.forEach((counter) => {
+    clearEntries += counter.entries;
+    clearRequests += counter.requests;
+  });
+  const clearReasons = preserveInsertionOrder
+    ? rawClearReasons
+    : sortedEntries(accumulator.cache.clearReasons).map(
+        ([, counter]) => counter
+      );
+
+  const { changes, unchanged } = accumulator.cache.salt;
+  let clears = 0;
+  let disables = 0;
+  let migrations = 0;
+  changes.forEach(({ outcome }) => {
+    if (outcome === 'clear') clears += 1;
+    if (outcome === 'disable') disables += 1;
+    if (outcome === 'migrate') migrations += 1;
+  });
+
+  return {
+    byOperation,
+    clearEntries,
+    clearReasons,
+    clearRequests,
+    hits,
+    misses,
+    requests,
+    salt: {
+      calls: unchanged + changes.length,
+      changes: [...changes],
+      clears,
+      disables,
+      migrations,
+      unchanged,
+    },
+  };
+};
+
+const hasCacheActivity = (accumulator: PipelineAccumulator): boolean =>
+  accumulator.cache.byOperation.some(Boolean) ||
+  accumulator.cache.clearReasons.size > 0 ||
+  accumulator.cache.salt.unchanged > 0 ||
+  accumulator.cache.salt.changes.length > 0;
+
+const buildCleanup = (accumulator: PipelineAccumulator) => ({
+  ...accumulator.cleanup,
+  candidateRemovals: { ...accumulator.cleanup.candidateRemovals },
+});
+
+const buildEntrypoints = (
+  accumulator: PipelineAccumulator,
+  preserveInsertionOrder = false
+) => {
+  const { entrypoints } = accumulator;
+  let disposableRoots = 0;
+  entrypoints.disposableRootsByPhase.forEach((count) => {
+    disposableRoots += count;
+  });
+
+  return {
+    byOnly: preserveInsertionOrder
+      ? Array.from(entrypoints.byOnly.values())
+      : sortedEntries(entrypoints.byOnly).map(([, counter]) => counter),
+    cached: entrypoints.cached,
+    children: entrypoints.children,
+    created: entrypoints.created,
+    disposableRoots,
+    disposableRootsByPhase: preserveInsertionOrder
+      ? Array.from(entrypoints.disposableRootsByPhase, ([phase, count]) => ({
+          count,
+          phase,
+        }))
+      : sortedEntries(entrypoints.disposableRootsByPhase).map(
+          ([phase, count]) => ({ count, phase })
+        ),
+    initialRoots: entrypoints.initialRoots,
+    loops: entrypoints.loops,
+    onDemandRoots: entrypoints.roots - entrypoints.initialRoots,
+    requests: entrypoints.roots + entrypoints.children,
+    roots: entrypoints.roots,
+  };
+};
+
+const buildLateNoMetadata = (accumulator: PipelineAccumulator) => {
+  const events = accumulator.lateNoMetadata
+    .map((event) => ({ ...event }))
+    .sort((left, right) =>
+      `${left.filename}\0${left.phase}\0${left.only.join('\0')}`.localeCompare(
+        `${right.filename}\0${right.phase}\0${right.only.join('\0')}`
+      )
+    );
+  const uniqueFiles = new Set(events.map(({ filename }) => filename));
+  let dangerousCodeCalls = 0;
+  let dangerousCodeMs = 0;
+  uniqueFiles.forEach((filename) => {
+    const dangerous = accumulator.dangerousByFile.get(filename);
+    dangerousCodeCalls += dangerous?.calls ?? 0;
+    dangerousCodeMs += dangerous?.durationMs ?? 0;
+  });
+  return {
+    count: events.length,
+    dangerousCodeCalls,
+    dangerousCodeMs,
+    events,
+  };
+};
+
+const buildCompactLateNoMetadata = (accumulator: PipelineAccumulator) => {
+  const events = [...accumulator.lateNoMetadata];
+  if (events.length === 1) {
+    const dangerous = accumulator.dangerousByFile.get(events[0].filename);
+    return {
+      count: 1,
+      dangerousCodeCalls: dangerous?.calls ?? 0,
+      dangerousCodeMs: dangerous?.durationMs ?? 0,
+      events,
+    };
+  }
+
+  const uniqueFiles = new Set(events.map(({ filename }) => filename));
+  let dangerousCodeCalls = 0;
+  let dangerousCodeMs = 0;
+  uniqueFiles.forEach((filename) => {
+    const dangerous = accumulator.dangerousByFile.get(filename);
+    dangerousCodeCalls += dangerous?.calls ?? 0;
+    dangerousCodeMs += dangerous?.durationMs ?? 0;
+  });
+  return {
+    count: events.length,
+    dangerousCodeCalls,
+    dangerousCodeMs,
+    events,
+  };
+};
+
+const buildParseTotals = (accumulator: PipelineAccumulator) => {
+  let allRequests = 0;
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  let errors = 0;
+  let jsxFallbackAttempts = 0;
+  let jsxFallbackRequests = 0;
+  let parsedBytes = 0;
+  let parserAttempts = 0;
+  let requestedBytes = 0;
+  let uncachedRequests = 0;
+  accumulator.parse.revisions.forEach((counter) => {
+    const revisionParserAttempts = getPipelineParserAttempts(counter);
+    allRequests += counter.requests;
+    cacheHits += counter.cacheHits;
+    cacheMisses += counter.cacheMisses;
+    errors += counter.errors;
+    jsxFallbackAttempts += counter.jsxFallbackAttempts;
+    jsxFallbackRequests += counter.jsxFallbackRequests;
+    parsedBytes += counter.bytes * revisionParserAttempts;
+    parserAttempts += revisionParserAttempts;
+    requestedBytes += counter.bytes * counter.requests;
+    if (counter.kind === 'uncached') uncachedRequests += counter.requests;
+  });
+  return {
+    allRequests,
+    cacheHits,
+    cacheMisses,
+    cachedRequests: cacheHits + cacheMisses,
+    errors,
+    jsxFallbackAttempts,
+    jsxFallbackRequests,
+    parsedBytes,
+    parserAttempts,
+    requestedBytes,
+    uncachedRequests,
+  };
+};
+
+const buildParse = (accumulator: PipelineAccumulator) => ({
+  ...buildParseTotals(accumulator),
+  revisions: [...accumulator.parse.revisions]
+    .sort((left, right) =>
+      `${left.revision}\0${getParserKey(left)}\0${left.kind}`.localeCompare(
+        `${right.revision}\0${getParserKey(right)}\0${right.kind}`
+      )
+    )
+    .map((counter) => {
+      const parserAttempts = getPipelineParserAttempts(counter);
+      return {
+        cacheHits: counter.cacheHits,
+        cacheMisses: counter.cacheMisses,
+        errors: counter.errors,
+        jsxFallbackAttempts: counter.jsxFallbackAttempts,
+        jsxFallbackRequests: counter.jsxFallbackRequests,
+        kind: counter.kind,
+        parsedBytes: counter.bytes * parserAttempts,
+        parserAttempts,
+        parserKey: getParserKey(counter),
+        requestedBytes: counter.bytes * counter.requests,
+        requests: counter.requests,
+        revision: counter.revision,
+      };
+    }),
+});
+
+const createProcessorCounter = (): ProcessorCounter => ({
+  definedProcessors: 0,
+  importCandidates: 0,
+  lookupAttempts: 0,
+  lookupHits: 0,
+  passes: 0,
+  reusedPlans: 0,
+  usages: 0,
+});
+
+const addProcessorCounters = (
+  target: ProcessorCounter,
+  source: ProcessorCounter
+): void => {
+  const counter = target;
+  counter.definedProcessors += source.definedProcessors;
+  counter.importCandidates += source.importCandidates;
+  counter.lookupAttempts += source.lookupAttempts;
+  counter.lookupHits += source.lookupHits;
+  counter.passes += source.passes;
+  counter.reusedPlans += source.reusedPlans;
+  counter.usages += source.usages;
+};
+
+const buildProcessors = (accumulator: PipelineAccumulator) => {
+  const byPhase = sortedEntries(accumulator.processors.byPhase);
+  const totals = createProcessorCounter();
+  byPhase.forEach(([, counter]) => {
+    addProcessorCounters(totals, counter);
+  });
+  return {
+    byPhase: byPhase.map(([phase, counter]) => ({
+      phase,
+      ...counter,
+    })),
+    totals,
+  };
+};
+
+const buildShakes = (accumulator: PipelineAccumulator) => ({
+  ...accumulator.shakes,
+  calls: [...accumulator.shakes.calls],
+});
+
+export const buildPipelineTelemetrySummary = (
+  accumulator: PipelineAccumulator
+) => ({
+  cache: buildCache(accumulator),
+  cleanup: buildCleanup(accumulator),
+  entrypoints: buildEntrypoints(accumulator),
+  lateNoMetadata: buildLateNoMetadata(accumulator),
+  parse: buildParse(accumulator),
+  processors: buildProcessors(accumulator),
+  root: { ...accumulator.root },
+  schemaVersion: 1 as const,
+  shakes: buildShakes(accumulator),
+  type: 'pipeline-telemetry' as const,
+});
+
+export type PipelineTelemetrySummary = ReturnType<
+  typeof buildPipelineTelemetrySummary
+>;
+
+export type PipelineTelemetryCompactSummary = Pick<
+  PipelineTelemetrySummary,
+  'root' | 'schemaVersion' | 'type'
+> &
+  Partial<
+    Omit<
+      PipelineTelemetrySummary,
+      'parse' | 'processors' | 'root' | 'schemaVersion' | 'type'
+    >
+  > & {
+    parse?: Omit<PipelineTelemetrySummary['parse'], 'revisions'> & {
+      revisions: Array<
+        Omit<ParseRevisionCounter, 'parserKey'> & {
+          parserAttempts: number;
+          parserKey: string;
+        }
+      >;
+    };
+    processors?: {
+      byPhase: PipelineTelemetrySummary['processors']['byPhase'];
+    };
+  };
+
+const buildCompactParse = (
+  accumulator: PipelineAccumulator
+): NonNullable<PipelineTelemetryCompactSummary['parse']> => ({
+  ...buildParseTotals(accumulator),
+  revisions: accumulator.parse.revisions.map((counter) => {
+    const parserAttempts = getPipelineParserAttempts(counter);
+    return {
+      ...counter,
+      parserAttempts,
+      parserKey: getParserKey(counter),
+    };
+  }),
+});
+
+const buildCompactProcessors = (
+  accumulator: PipelineAccumulator
+): NonNullable<PipelineTelemetryCompactSummary['processors']> => ({
+  byPhase: Array.from(accumulator.processors.byPhase, ([phase, counter]) => ({
+    phase,
+    ...counter,
+  })),
+});
+
+export const buildCompactPipelineTelemetrySummary = (
+  accumulator: PipelineAccumulator
+): PipelineTelemetryCompactSummary => {
+  const summary: PipelineTelemetryCompactSummary = {
+    root: { ...accumulator.root },
+    schemaVersion: 1,
+    type: 'pipeline-telemetry',
+  };
+  const { cleanup, entrypoints, parse, processors, shakes } = accumulator;
+  if (hasCacheActivity(accumulator)) {
+    summary.cache = buildCache(accumulator, true);
+  }
+  if (cleanup.calls > 0) summary.cleanup = buildCleanup(accumulator);
+  if (
+    entrypoints.roots > 0 ||
+    entrypoints.children > 0 ||
+    entrypoints.disposableRootsByPhase.size > 0
+  ) {
+    summary.entrypoints = buildEntrypoints(accumulator, true);
+  }
+  if (accumulator.lateNoMetadata.length > 0) {
+    summary.lateNoMetadata = buildCompactLateNoMetadata(accumulator);
+  }
+  if (parse.revisions.length > 0) {
+    summary.parse = buildCompactParse(accumulator);
+  }
+  if (processors.byPhase.size > 0) {
+    summary.processors = buildCompactProcessors(accumulator);
+  }
+  if (shakes.attempts > 0) summary.shakes = buildShakes(accumulator);
+  return summary;
+};

--- a/packages/transform/src/debug/pipelineTelemetry.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.ts
@@ -1,0 +1,874 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { EventEmitter } from '../utils/EventEmitter';
+import { serializePipelineTelemetryJSONl } from './pipelineTelemetry.jsonl';
+import {
+  getCodeMeasurement,
+  measureBytes,
+  measureCode,
+  setMissingCodeMeasurement,
+  type CompletedCodeMeasurement,
+} from './pipelineTelemetry.measurements';
+import { PIPELINE_TELEMETRY_SCHEMA } from './pipelineTelemetry.schema';
+import {
+  createAccumulator,
+  normalizeOnly,
+  releaseAccumulator,
+} from './pipelineTelemetry.state';
+import {
+  buildCompactPipelineTelemetrySummary,
+  buildPipelineTelemetrySummary,
+  type PipelineTelemetryCompactSummary,
+  type PipelineTelemetrySummary,
+} from './pipelineTelemetry.summary';
+import type {
+  CacheName,
+  CacheOperation,
+  EntrypointStatus,
+  ParseKind,
+  PipelineAccumulator,
+  PipelineCacheSaltOutcome,
+  PipelineCleanupOutcome,
+  PipelineCleanupToken,
+  PipelineDangerousCodeToken,
+  PipelineNoMetadataPhase,
+  PipelineShakeToken,
+  ParseRevisionCounter,
+  ProcessorCounter,
+  RootStatus,
+} from './pipelineTelemetry.types';
+
+const EMPTY_PROCESSOR_COUNTER = (): ProcessorCounter => ({
+  definedProcessors: 0,
+  importCandidates: 0,
+  lookupAttempts: 0,
+  lookupHits: 0,
+  passes: 0,
+  reusedPlans: 0,
+  usages: 0,
+});
+
+const addProcessorCounter = (
+  counter: ProcessorCounter,
+  reusedPlan: boolean,
+  importCandidates: number,
+  lookupAttempts: number,
+  lookupHits: number,
+  definedProcessors: number,
+  usages: number
+): void => {
+  const target = counter;
+  target.definedProcessors += definedProcessors;
+  target.importCandidates += importCandidates;
+  target.lookupAttempts += lookupAttempts;
+  target.lookupHits += lookupHits;
+  target.passes += 1;
+  target.reusedPlans += reusedPlan ? 1 : 0;
+  target.usages += usages;
+};
+
+const CACHE_OPERATION_INDEX = {
+  barrelManifests: { get: 0, has: 1 },
+  entrypoints: { get: 2, has: 3 },
+  exports: { get: 4, has: 5 },
+} satisfies Record<CacheName, Record<CacheOperation, number>>;
+export {
+  PIPELINE_TELEMETRY_SCHEMA,
+  type PipelineTelemetryCompactSummary,
+  type PipelineTelemetrySummary,
+};
+
+const telemetryStorage = new AsyncLocalStorage<
+  PipelineAccumulator | undefined
+>();
+const reporterByEmitter = new WeakMap<
+  EventEmitter,
+  PipelineTelemetryReporter
+>();
+let activeTelemetryRoots = 0;
+
+const getAccumulator = (): PipelineAccumulator | undefined => {
+  if (activeTelemetryRoots === 0) {
+    return undefined;
+  }
+
+  const accumulator = telemetryStorage.getStore();
+  return accumulator && !accumulator.closed ? accumulator : undefined;
+};
+
+type PipelineTelemetryReporterSink =
+  | ((summary: PipelineTelemetrySummary) => void)
+  | ((summary: PipelineTelemetryCompactSummary) => void);
+type PipelineTelemetrySink = (
+  summary: PipelineTelemetrySummary | PipelineTelemetryCompactSummary
+) => void;
+type PipelineTelemetryReporter = {
+  codeMeasurements: PipelineAccumulator['codeMeasurements'];
+  emit: (accumulator: PipelineAccumulator) => void;
+};
+
+export const hasPipelineTelemetryReporter = (emitter: EventEmitter): boolean =>
+  reporterByEmitter.has(emitter);
+
+export const isPipelineTelemetryActive = (): boolean =>
+  getAccumulator() !== undefined;
+
+const registerPipelineTelemetryEmitter = (
+  emitter: EventEmitter,
+  emit: PipelineTelemetryReporter['emit']
+): (() => void) => {
+  const codeMeasurementEntries: PipelineAccumulator['codeMeasurements']['entries'] =
+    new Map();
+  const reporter: PipelineTelemetryReporter = {
+    codeMeasurements: {
+      codeUnits: 0,
+      count: 0,
+      entries: codeMeasurementEntries,
+      evictionKeys: codeMeasurementEntries.keys(),
+    },
+    emit,
+  };
+  reporterByEmitter.set(emitter, reporter);
+  let registered = true;
+
+  return () => {
+    if (!registered) {
+      return;
+    }
+
+    registered = false;
+    reporter.codeMeasurements.entries.clear();
+    reporter.codeMeasurements.evictionKeys =
+      reporter.codeMeasurements.entries.keys();
+    reporter.codeMeasurements.codeUnits = 0;
+    reporter.codeMeasurements.count = 0;
+    if (reporterByEmitter.get(emitter) === reporter) {
+      reporterByEmitter.delete(emitter);
+    }
+  };
+};
+
+export const getPipelineCodeSha256Hex = (code: string): string | undefined => {
+  const accumulator = getAccumulator();
+  if (!accumulator) return undefined;
+
+  try {
+    const measurement = getCodeMeasurement(accumulator, code);
+    if (!measurement) return undefined;
+    if (measurement.sha256Hex === undefined) {
+      measurement.sha256Hex = Buffer.from(
+        measurement.revision,
+        'base64url'
+      ).toString('hex');
+    }
+    return measurement.sha256Hex;
+  } catch {
+    return undefined;
+  }
+};
+
+export const primePipelineCodeSha256Hex = (
+  code: string,
+  sha256Hex: string
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) return;
+
+  try {
+    if (!/^[\da-f]{64}$/u.test(sha256Hex)) return;
+    setMissingCodeMeasurement(accumulator, code, {
+      bytes: Buffer.byteLength(code),
+      revision: Buffer.from(sha256Hex, 'hex').toString('base64url'),
+      sha256Hex,
+    });
+  } catch {
+    // Debug measurement failures must not affect transform cache behavior.
+  }
+};
+
+export const runWithoutPipelineTelemetry = <T>(callback: () => T): T =>
+  telemetryStorage.run(undefined, callback);
+
+export function registerPipelineTelemetryReporter(
+  emitter: EventEmitter,
+  sink: (summary: PipelineTelemetrySummary) => void
+): () => void;
+export function registerPipelineTelemetryReporter(
+  emitter: EventEmitter,
+  sink: (summary: PipelineTelemetryCompactSummary) => void,
+  compact: true
+): () => void;
+export function registerPipelineTelemetryReporter(
+  emitter: EventEmitter,
+  sink: PipelineTelemetryReporterSink,
+  compact = false
+): () => void {
+  const pipelineSink = sink as PipelineTelemetrySink;
+  return registerPipelineTelemetryEmitter(emitter, (accumulator) => {
+    pipelineSink(
+      compact
+        ? buildCompactPipelineTelemetrySummary(accumulator)
+        : buildPipelineTelemetrySummary(accumulator)
+    );
+  });
+}
+
+export const registerPipelineTelemetryJSONlReporter = (
+  emitter: EventEmitter,
+  workingDirectory: string,
+  sink: (line: string, status: RootStatus) => void
+): (() => void) =>
+  registerPipelineTelemetryEmitter(emitter, (accumulator) =>
+    sink(
+      serializePipelineTelemetryJSONl(accumulator, workingDirectory),
+      accumulator.root.status
+    )
+  );
+
+export const runWithPipelineTelemetry = <T>(
+  emitter: EventEmitter,
+  createRoot: () => { filename: string },
+  callback: () => T
+): T => {
+  const reporter = reporterByEmitter.get(emitter);
+  if (!reporter) {
+    return callback();
+  }
+
+  let accumulator: PipelineAccumulator;
+  try {
+    accumulator = createAccumulator(
+      createRoot().filename,
+      reporter.codeMeasurements
+    );
+  } catch {
+    return callback();
+  }
+
+  activeTelemetryRoots += 1;
+  const finish = () => {
+    activeTelemetryRoots -= 1;
+    try {
+      reporter.emit(accumulator);
+    } catch {
+      // Debug reporting must never change transform behavior.
+    } finally {
+      releaseAccumulator(accumulator);
+    }
+  };
+
+  try {
+    const result = telemetryStorage.run(accumulator, callback);
+    if (result instanceof Promise) {
+      result.then(finish, () => {
+        accumulator.root.status = 'error';
+        finish();
+      });
+      return result;
+    }
+
+    finish();
+    return result;
+  } catch (error) {
+    accumulator.root.status = 'error';
+    finish();
+    throw error;
+  }
+};
+
+export const markPipelineRootStatus = (status: RootStatus): void => {
+  const accumulator = getAccumulator();
+  if (accumulator) {
+    accumulator.root.status = status;
+  }
+};
+
+export const recordPipelineCacheRequest = (
+  cache: CacheName,
+  operation: CacheOperation,
+  hit: boolean
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return;
+  }
+
+  const index = CACHE_OPERATION_INDEX[cache][operation];
+  let counter = accumulator.cache.byOperation[index];
+  if (!counter) {
+    counter = { hits: 0, misses: 0, requests: 0 };
+    accumulator.cache.byOperation[index] = counter;
+  }
+  counter.requests += 1;
+  if (hit) {
+    counter.hits += 1;
+  } else {
+    counter.misses += 1;
+  }
+};
+
+export const recordPipelineCacheSalt = (
+  previous: string | null,
+  current: string | null,
+  outcome: PipelineCacheSaltOutcome
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return;
+  }
+
+  if (outcome !== 'unchanged') {
+    accumulator.cache.salt.changes.push({ current, outcome, previous });
+  }
+  if (outcome === 'unchanged') accumulator.cache.salt.unchanged += 1;
+};
+
+export const recordPipelineCacheClear = (
+  cache: CacheName,
+  reason: string,
+  removedEntries: number
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return;
+  }
+
+  const key = `${cache}\0${reason}`;
+  let counter = accumulator.cache.clearReasons.get(key);
+  if (!counter) {
+    counter = { cache, entries: 0, reason, requests: 0 };
+    accumulator.cache.clearReasons.set(key, counter);
+  }
+  counter.entries += removedEntries;
+  counter.requests += 1;
+};
+
+export const recordPipelineEntrypoint = (
+  isRoot: boolean,
+  isInitial: boolean,
+  status: EntrypointStatus,
+  only: readonly string[]
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return;
+  }
+
+  const { key: onlyKey, only: normalizedOnly } = normalizeOnly(
+    accumulator,
+    only
+  );
+  let onlyCounter = accumulator.entrypoints.byOnly.get(onlyKey);
+  if (!onlyCounter) {
+    onlyCounter = { count: 0, only: normalizedOnly };
+    accumulator.entrypoints.byOnly.set(onlyKey, onlyCounter);
+  }
+  onlyCounter.count += 1;
+  if (isRoot) {
+    accumulator.entrypoints.roots += 1;
+    if (isInitial) accumulator.entrypoints.initialRoots += 1;
+  } else {
+    accumulator.entrypoints.children += 1;
+  }
+  if (status === 'created') accumulator.entrypoints.created += 1;
+  if (status === 'cached') accumulator.entrypoints.cached += 1;
+  if (status === 'loop') accumulator.entrypoints.loops += 1;
+};
+
+export const recordPipelineDisposableRoot = (
+  filename: string,
+  phase: PipelineNoMetadataPhase
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator || accumulator.root.filename !== filename) {
+    return;
+  }
+
+  accumulator.entrypoints.disposableRootsByPhase.set(
+    phase,
+    (accumulator.entrypoints.disposableRootsByPhase.get(phase) ?? 0) + 1
+  );
+};
+
+type PipelineParserLanguage = 'dts' | 'js' | 'jsx' | 'ts' | 'tsx';
+
+const PIPELINE_PARSER_LANGUAGE_INDEX = {
+  js: 0,
+  jsx: 1,
+  ts: 2,
+  tsx: 3,
+  dts: 4,
+} as const satisfies Record<PipelineParserLanguage, number>;
+
+const getPipelineParserLanguage = (
+  filename: string
+): PipelineParserLanguage => {
+  if (filename.endsWith('.jsx')) return 'jsx';
+  if (filename.endsWith('.tsx')) return 'tsx';
+  const basenameStart =
+    Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\')) + 1;
+  if (filename.endsWith('.ts')) {
+    return filename.lastIndexOf('.d.') > basenameStart ? 'dts' : 'ts';
+  }
+  if (filename.endsWith('.mts') || filename.endsWith('.cts')) {
+    const basenameLength = filename.length - basenameStart;
+    return basenameLength > 6 &&
+      (filename.endsWith('.d.mts') || filename.endsWith('.d.cts'))
+      ? 'dts'
+      : 'ts';
+  }
+  return 'js';
+};
+
+const createPipelineParserKey = (
+  sourceType: string,
+  filename: string,
+  astType: string,
+  jsxFallbackAllowed: boolean
+): number | string => {
+  const language = getPipelineParserLanguage(filename);
+  if (
+    (sourceType === 'module' || sourceType === 'unambiguous') &&
+    (astType === 'js' || astType === 'ts')
+  ) {
+    const sourceTypeIndex = sourceType === 'module' ? 0 : 1;
+    const astTypeIndex = astType === 'js' ? 0 : 1;
+    const parserKeyIndex =
+      sourceTypeIndex * 20 +
+      PIPELINE_PARSER_LANGUAGE_INDEX[language] * 4 +
+      astTypeIndex * 2 +
+      (jsxFallbackAllowed ? 1 : 0);
+    return parserKeyIndex;
+  }
+
+  return `oxc:${sourceType}:${language}:${astType}:r1:j${
+    jsxFallbackAllowed ? 1 : 0
+  }`;
+};
+
+const updatePipelineParseMissCounters = (
+  revision: ParseRevisionCounter,
+  kind: ParseKind,
+  jsxFallback: boolean,
+  error: boolean
+): void => {
+  const counter = revision;
+  counter.requests += 1;
+  if (kind === 'cached') counter.cacheMisses += 1;
+  if (jsxFallback) {
+    counter.jsxFallbackRequests += 1;
+    counter.jsxFallbackAttempts += 1;
+  }
+  if (error) {
+    counter.errors += 1;
+  }
+};
+
+const updatePipelineCachedHitCounters = (
+  revision: ParseRevisionCounter,
+  jsxFallback: boolean
+): void => {
+  const counter = revision;
+  counter.requests += 1;
+  counter.cacheHits += 1;
+  if (jsxFallback) {
+    counter.jsxFallbackRequests += 1;
+  }
+};
+
+const getPipelineParseRevision = (
+  accumulator: PipelineAccumulator,
+  parserKey: ParseRevisionCounter['parserKey'],
+  kind: ParseKind,
+  measurement: CompletedCodeMeasurement
+) => {
+  const { revision: revisionKey } = measurement;
+  const bucket = accumulator.parse.revisionBuckets.get(measurement);
+  if (bucket) {
+    if (Array.isArray(bucket)) {
+      for (const existing of bucket) {
+        if (existing.parserKey === parserKey && existing.kind === kind) {
+          return existing;
+        }
+      }
+    } else if (bucket.parserKey === parserKey && bucket.kind === kind) {
+      return bucket;
+    }
+  }
+
+  const revision: ParseRevisionCounter = {
+    bytes: measurement.bytes,
+    cacheHits: 0,
+    cacheMisses: 0,
+    errors: 0,
+    jsxFallbackAttempts: 0,
+    jsxFallbackRequests: 0,
+    kind,
+    parserKey,
+    requests: 0,
+    revision: revisionKey,
+  };
+  if (!bucket) {
+    accumulator.parse.revisionBuckets.set(measurement, revision);
+  } else if (Array.isArray(bucket)) {
+    bucket.push(revision);
+  } else {
+    accumulator.parse.revisionBuckets.set(measurement, [bucket, revision]);
+  }
+  accumulator.parse.revisions.push(revision);
+  return revision;
+};
+
+export const recordPipelineCachedParseHit = (
+  cacheEntry: object,
+  filename: string,
+  code: string,
+  sourceType: string,
+  jsxFallback: boolean,
+  knownMeasurement?: CompletedCodeMeasurement
+): CompletedCodeMeasurement | undefined => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return undefined;
+  }
+
+  if (knownMeasurement) {
+    const knownRevision = accumulator.parse.cachedRevisions.get(cacheEntry);
+    if (knownRevision) {
+      updatePipelineCachedHitCounters(knownRevision, jsxFallback);
+      return knownMeasurement;
+    }
+  }
+
+  let measurement: CompletedCodeMeasurement;
+  try {
+    measurement = knownMeasurement
+      ? getCodeMeasurement(accumulator, code) ??
+        setMissingCodeMeasurement(accumulator, code, knownMeasurement)
+      : measureCode(accumulator, code, false);
+  } catch {
+    return undefined;
+  }
+  let revision = accumulator.parse.cachedRevisions.get(cacheEntry);
+  if (!revision) {
+    const astType =
+      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
+    revision = getPipelineParseRevision(
+      accumulator,
+      createPipelineParserKey(
+        sourceType,
+        filename,
+        astType,
+        filename.endsWith('.js')
+      ),
+      'cached',
+      measurement
+    );
+    accumulator.parse.cachedRevisions.set(cacheEntry, revision);
+  }
+  updatePipelineCachedHitCounters(revision, jsxFallback);
+  return measurement;
+};
+
+const recordPipelineParseMiss = (
+  filename: string,
+  code: string,
+  sourceType: string,
+  astType: string,
+  kind: ParseKind,
+  jsxFallback: boolean,
+  error: boolean,
+  jsxFallbackAllowed: boolean,
+  cacheEntry?: object
+): CompletedCodeMeasurement | undefined => {
+  const accumulator = getAccumulator();
+  if (!accumulator) return undefined;
+
+  try {
+    const measurement = measureCode(accumulator, code);
+    const revision = getPipelineParseRevision(
+      accumulator,
+      createPipelineParserKey(
+        sourceType,
+        filename,
+        astType,
+        jsxFallbackAllowed
+      ),
+      kind,
+      measurement
+    );
+    if (cacheEntry) {
+      accumulator.parse.cachedRevisions.set(cacheEntry, revision);
+    }
+    updatePipelineParseMissCounters(revision, kind, jsxFallback, error);
+    return measurement;
+  } catch {
+    // Debug reporting must never change parser behavior or its errors.
+    return undefined;
+  }
+};
+
+export const recordPipelineCachedParseMiss = (
+  filename: string,
+  code: string,
+  sourceType: string,
+  astType: string,
+  jsxFallback: boolean,
+  error: boolean,
+  cacheEntry?: object
+): CompletedCodeMeasurement | undefined =>
+  recordPipelineParseMiss(
+    filename,
+    code,
+    sourceType,
+    astType,
+    'cached',
+    jsxFallback,
+    error,
+    filename.endsWith('.js'),
+    cacheEntry
+  );
+
+export const recordPipelineUncachedParse = (
+  filename: string,
+  code: string,
+  sourceType: string,
+  astType: string,
+  error: boolean
+): void => {
+  recordPipelineParseMiss(
+    filename,
+    code,
+    sourceType,
+    astType,
+    'uncached',
+    false,
+    error,
+    false
+  );
+};
+
+export const recordPipelineProcessors = (
+  phase: string,
+  reusedPlan: boolean,
+  importCandidates: number,
+  lookupAttempts: number,
+  lookupHits: number,
+  definedProcessors: number,
+  usages: number
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return;
+  }
+
+  let phaseCounter = accumulator.processors.byPhase.get(phase);
+  if (!phaseCounter) {
+    phaseCounter = EMPTY_PROCESSOR_COUNTER();
+    accumulator.processors.byPhase.set(phase, phaseCounter);
+  }
+  addProcessorCounter(
+    phaseCounter,
+    reusedPlan,
+    importCandidates,
+    lookupAttempts,
+    lookupHits,
+    definedProcessors,
+    usages
+  );
+};
+
+export const beginPipelineDangerousCode = (
+  filename: string
+): PipelineDangerousCodeToken => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return undefined;
+  }
+
+  return {
+    accumulator,
+    filename,
+    finished: false,
+    startedAt: performance.now(),
+  };
+};
+
+export const finishPipelineDangerousCode = (
+  token: PipelineDangerousCodeToken
+): void => {
+  if (!token || token.finished || token.accumulator.closed) {
+    return;
+  }
+  const dangerousToken = token;
+  dangerousToken.finished = true;
+  let current = dangerousToken.accumulator.dangerousByFile.get(
+    dangerousToken.filename
+  );
+  if (!current) {
+    current = { calls: 0, durationMs: 0 };
+    dangerousToken.accumulator.dangerousByFile.set(
+      dangerousToken.filename,
+      current
+    );
+  }
+  current.calls += 1;
+  current.durationMs += performance.now() - dangerousToken.startedAt;
+};
+
+export const recordPipelineLateNoMetadata = (
+  filename: string,
+  only: readonly string[],
+  phase: PipelineNoMetadataPhase
+): void => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return;
+  }
+
+  accumulator.lateNoMetadata.push({
+    filename,
+    only: normalizeOnly(accumulator, only).only,
+    phase,
+  });
+};
+
+export const beginPipelineShake = (
+  inputCode: string,
+  only: readonly string[],
+  mode: string
+): PipelineShakeToken => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return undefined;
+  }
+
+  let inputBytes: number;
+  let inputRevision: string;
+  let normalizedOnly: string[];
+  try {
+    const measurement = measureCode(accumulator, inputCode);
+    inputBytes = measurement.bytes;
+    inputRevision = measurement.revision;
+    normalizedOnly = normalizeOnly(accumulator, only).only;
+  } catch {
+    return undefined;
+  }
+  accumulator.shakes.attempts += 1;
+  return {
+    accumulator,
+    finished: false,
+    inputBytes,
+    inputRevision,
+    mode,
+    only: normalizedOnly,
+  };
+};
+
+export const finishPipelineShake = (
+  token: PipelineShakeToken,
+  outputCode: string | null,
+  error: boolean
+): void => {
+  if (!token || token.finished || token.accumulator.closed) {
+    return;
+  }
+  const shakeToken = token;
+  shakeToken.finished = true;
+  let generatedBytes = 0;
+  let outputRevision: string | null = null;
+  try {
+    if (outputCode !== null) {
+      const measurement = measureCode(shakeToken.accumulator, outputCode);
+      generatedBytes = measurement.bytes;
+      outputRevision = measurement.revision;
+    }
+  } catch {
+    // Debug measurement failures must not affect transform output.
+  }
+  if (error) shakeToken.accumulator.shakes.errors += 1;
+  else shakeToken.accumulator.shakes.successes += 1;
+  shakeToken.accumulator.shakes.generatedBytes += generatedBytes;
+  shakeToken.accumulator.shakes.calls.push({
+    error,
+    generatedBytes,
+    inputBytes: shakeToken.inputBytes,
+    inputRevision: shakeToken.inputRevision,
+    mode: shakeToken.mode,
+    only: shakeToken.only,
+    outputRevision,
+  });
+};
+
+export const beginPipelineCleanup = (
+  filename: string
+): PipelineCleanupToken => {
+  const accumulator = getAccumulator();
+  if (!accumulator) {
+    return undefined;
+  }
+
+  accumulator.cleanup.calls += 1;
+  return { accumulator, filename, finished: false };
+};
+
+export const recordPipelineCleanupIteration = (
+  token: PipelineCleanupToken,
+  code: string,
+  mergedRanges: readonly { end: number; start: number }[],
+  committed: boolean,
+  scopedDeclarations: number,
+  topLevelDeclarations: number,
+  generatedHelpers: number,
+  imports: number,
+  expressions: number,
+  emptyBlocks: number
+): void => {
+  if (!token || token.finished || token.accumulator.closed) {
+    return;
+  }
+
+  const { cleanup } = token.accumulator;
+  let bytes = 0;
+  try {
+    const ascii = measureBytes(token.accumulator, code) === code.length;
+    mergedRanges.forEach(({ end, start }) => {
+      bytes += ascii ? end - start : Buffer.byteLength(code.slice(start, end));
+    });
+  } catch {
+    return;
+  }
+  cleanup.attemptedIterations += 1;
+  cleanup.attemptedRanges += mergedRanges.length;
+  cleanup.attemptedBytes += bytes;
+  cleanup.candidateRemovals.scopedDeclarations += scopedDeclarations;
+  cleanup.candidateRemovals.topLevelDeclarations += topLevelDeclarations;
+  cleanup.candidateRemovals.generatedHelpers += generatedHelpers;
+  cleanup.candidateRemovals.imports += imports;
+  cleanup.candidateRemovals.expressions += expressions;
+  cleanup.candidateRemovals.emptyBlocks += emptyBlocks;
+  if (committed) {
+    cleanup.committedIterations += 1;
+    cleanup.committedRanges += mergedRanges.length;
+    cleanup.committedBytes += bytes;
+  } else if (mergedRanges.length > 0) {
+    cleanup.rollbackBytes += bytes;
+  }
+};
+
+export const finishPipelineCleanup = (
+  token: PipelineCleanupToken,
+  outcome: PipelineCleanupOutcome
+): void => {
+  if (!token || token.finished || token.accumulator.closed) {
+    return;
+  }
+  const cleanupToken = token;
+  cleanupToken.finished = true;
+  const { cleanup } = cleanupToken.accumulator;
+  if (outcome === 'converged') cleanup.converged += 1;
+  if (outcome === 'rollback') cleanup.rollbacks += 1;
+  if (outcome === 'cap') cleanup.capHits += 1;
+  if (outcome === 'stalled') cleanup.stalled += 1;
+  if (outcome === 'error') cleanup.errors += 1;
+};

--- a/packages/transform/src/debug/pipelineTelemetry.types.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.types.ts
@@ -1,0 +1,197 @@
+export type CacheName = 'barrelManifests' | 'entrypoints' | 'exports';
+export type CacheOperation = 'get' | 'has';
+export type EntrypointStatus = 'cached' | 'created' | 'loop';
+export type ParseKind = 'cached' | 'uncached';
+export type RootStatus = 'error' | 'ignored' | 'soft-error' | 'success';
+
+export type Counter = {
+  hits: number;
+  misses: number;
+  requests: number;
+};
+
+export type ParseRevisionCounter = {
+  bytes: number;
+  cacheHits: number;
+  cacheMisses: number;
+  errors: number;
+  jsxFallbackAttempts: number;
+  jsxFallbackRequests: number;
+  kind: ParseKind;
+  parserKey: number | string;
+  requests: number;
+  revision: string;
+};
+
+export type ProcessorCounter = {
+  definedProcessors: number;
+  importCandidates: number;
+  lookupAttempts: number;
+  lookupHits: number;
+  passes: number;
+  reusedPlans: number;
+  usages: number;
+};
+
+export type CodeMeasurement = {
+  bytes: number;
+  revision?: string;
+  sha256Hex?: string;
+};
+
+export type CodeMeasurementEntry = {
+  code: string;
+  measurement: CodeMeasurement;
+};
+
+export type CodeMeasurementBucket =
+  | CodeMeasurementEntry
+  | CodeMeasurementEntry[];
+
+export type CodeMeasurementCache = {
+  codeUnits: number;
+  count: number;
+  entries: Map<number, CodeMeasurementBucket>;
+  evictionKeys: IterableIterator<number>;
+};
+
+export type CleanupRemovalKinds = {
+  emptyBlocks: number;
+  expressions: number;
+  generatedHelpers: number;
+  imports: number;
+  scopedDeclarations: number;
+  topLevelDeclarations: number;
+};
+
+export type PipelineCacheSaltOutcome =
+  | 'clear'
+  | 'disable'
+  | 'migrate'
+  | 'unchanged';
+
+export type PipelineNoMetadataPhase = 'collect' | 'preeval';
+
+export type PipelineCleanupOutcome =
+  | 'cap'
+  | 'converged'
+  | 'error'
+  | 'rollback'
+  | 'stalled';
+
+export type PipelineShakeRecord = {
+  error: boolean;
+  generatedBytes: number;
+  inputBytes: number;
+  inputRevision: string;
+  mode: string;
+  only: string[];
+  outputRevision: string | null;
+};
+
+export type PipelineAccumulator = {
+  cache: {
+    byOperation: Array<Counter | undefined>;
+    clearReasons: Map<
+      string,
+      { cache: CacheName; entries: number; reason: string; requests: number }
+    >;
+    salt: {
+      changes: Array<{
+        current: string | null;
+        outcome: PipelineCacheSaltOutcome;
+        previous: string | null;
+      }>;
+      unchanged: number;
+    };
+  };
+  cleanup: {
+    calls: number;
+    candidateRemovals: CleanupRemovalKinds;
+    capHits: number;
+    committedBytes: number;
+    committedIterations: number;
+    committedRanges: number;
+    converged: number;
+    errors: number;
+    rollbackBytes: number;
+    rollbacks: number;
+    stalled: number;
+    attemptedBytes: number;
+    attemptedIterations: number;
+    attemptedRanges: number;
+  };
+  codeMeasurements: CodeMeasurementCache;
+  closed: boolean;
+  dangerousByFile: Map<string, { calls: number; durationMs: number }>;
+  entrypoints: {
+    byOnly: Map<string, { count: number; only: string[] }>;
+    cached: number;
+    children: number;
+    created: number;
+    disposableRootsByPhase: Map<string, number>;
+    initialRoots: number;
+    loops: number;
+    roots: number;
+  };
+  lateNoMetadata: Array<{
+    filename: string;
+    only: string[];
+    phase: PipelineNoMetadataPhase;
+  }>;
+  lastCode: string | undefined;
+  lastMeasurement: CodeMeasurement | undefined;
+  lastSharedMissCode: string | undefined;
+  localCodeMeasurements: Map<number, CodeMeasurementBucket>;
+  onlyNormalizations: Map<readonly string[], { key: string; only: string[] }>;
+  parse: {
+    cachedRevisions: WeakMap<object, ParseRevisionCounter>;
+    revisionBuckets: Map<
+      CodeMeasurement,
+      ParseRevisionCounter | ParseRevisionCounter[]
+    >;
+    revisions: ParseRevisionCounter[];
+  };
+  processors: {
+    byPhase: Map<string, ProcessorCounter>;
+  };
+  root: {
+    filename: string;
+    status: RootStatus;
+  };
+  shakes: {
+    attempts: number;
+    calls: PipelineShakeRecord[];
+    errors: number;
+    generatedBytes: number;
+    successes: number;
+  };
+};
+
+export type PipelineDangerousCodeToken =
+  | {
+      accumulator: PipelineAccumulator;
+      filename: string;
+      finished: boolean;
+      startedAt: number;
+    }
+  | undefined;
+
+export type PipelineShakeToken =
+  | {
+      accumulator: PipelineAccumulator;
+      finished: boolean;
+      inputBytes: number;
+      inputRevision: string;
+      mode: string;
+      only: string[];
+    }
+  | undefined;
+
+export type PipelineCleanupToken =
+  | {
+      accumulator: PipelineAccumulator;
+      filename: string;
+      finished: boolean;
+    }
+  | undefined;

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -24,6 +24,13 @@ import { withDefaultServices } from './transform/helpers/withDefaultServices';
 import type { Handlers, Services } from './transform/types';
 import { configureEvalSession } from './transform/evalSession';
 import type { Result } from './types';
+import {
+  hasPipelineTelemetryReporter,
+  isPipelineTelemetryActive,
+  markPipelineRootStatus,
+  runWithoutPipelineTelemetry,
+  runWithPipelineTelemetry,
+} from './debug/pipelineTelemetry';
 
 type PartialServices = Partial<Omit<Services, 'options'>> & {
   options: Omit<Services['options'], 'pluginOptions'> & {
@@ -33,22 +40,7 @@ type PartialServices = Partial<Omit<Services, 'options'>> & {
 
 type AllHandlers<TMode extends 'async' | 'sync'> = Handlers<TMode>;
 
-export function transformSync(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _partialServices: PartialServices,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _originalCode: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _syncResolve: (what: string, importer: string, stack: string[]) => string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _customHandlers: Partial<AllHandlers<'sync'>> = {}
-): Result {
-  throw new Error(
-    '[wyw-in-js] transformSync is not supported in v2. Use transform() (async) instead.'
-  );
-}
-
-export async function transform(
+const executeTransform = async (
   partialServices: PartialServices,
   originalCode: string,
   asyncResolve: (
@@ -56,17 +48,18 @@ export async function transform(
     importer: string,
     stack: string[]
   ) => Promise<string | null>,
-  customHandlers: Partial<AllHandlers<'sync'>> = {}
-): Promise<Result> {
-  const { options } = partialServices;
-  const pluginOptions = loadWywOptions(options.pluginOptions);
+  customHandlers: Partial<AllHandlers<'sync'>>
+): Promise<Result> => {
+  const { options: partialOptions } = partialServices;
+  const pluginOptions = loadWywOptions(partialOptions.pluginOptions);
   const services = withDefaultServices({
     ...partialServices,
     options: {
-      ...options,
+      ...partialOptions,
       pluginOptions,
     },
   });
+  const { options } = services;
 
   if (
     !isFeatureEnabled(pluginOptions.features, 'globalCache', options.filename)
@@ -97,6 +90,7 @@ export async function transform(
   );
 
   if (entrypoint.ignored) {
+    markPipelineRootStatus('ignored');
     return {
       code: originalCode,
       sourceMap: options.inputSourceMap,
@@ -130,6 +124,7 @@ export async function transform(
     if (
       isFeatureEnabled(pluginOptions.features, 'softErrors', options.filename)
     ) {
+      markPipelineRootStatus('soft-error');
       // eslint-disable-next-line no-console
       console.error(`Error during transform of ${entrypoint.name}:`, err);
 
@@ -143,4 +138,63 @@ export async function transform(
   } finally {
     disposeActionContext(actionContext);
   }
+};
+
+export function transformSync(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _partialServices: PartialServices,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _originalCode: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _syncResolve: (what: string, importer: string, stack: string[]) => string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _customHandlers: Partial<AllHandlers<'sync'>> = {}
+): Result {
+  throw new Error(
+    '[wyw-in-js] transformSync is not supported in v2. Use transform() (async) instead.'
+  );
+}
+
+export function transform(
+  partialServices: PartialServices,
+  originalCode: string,
+  asyncResolve: (
+    what: string,
+    importer: string,
+    stack: string[]
+  ) => Promise<string | null>,
+  customHandlers: Partial<AllHandlers<'sync'>> = {}
+): Promise<Result> {
+  const { eventEmitter } = partialServices;
+  if (!eventEmitter || !hasPipelineTelemetryReporter(eventEmitter)) {
+    if (isPipelineTelemetryActive()) {
+      return runWithoutPipelineTelemetry(() =>
+        executeTransform(
+          partialServices,
+          originalCode,
+          asyncResolve,
+          customHandlers
+        )
+      );
+    }
+
+    return executeTransform(
+      partialServices,
+      originalCode,
+      asyncResolve,
+      customHandlers
+    );
+  }
+
+  return runWithPipelineTelemetry(
+    eventEmitter,
+    () => ({ filename: partialServices.options.filename }),
+    () =>
+      executeTransform(
+        partialServices,
+        originalCode,
+        asyncResolve,
+        customHandlers
+      )
+  );
 }

--- a/packages/transform/src/transform/Entrypoint.helpers.ts
+++ b/packages/transform/src/transform/Entrypoint.helpers.ts
@@ -7,6 +7,7 @@ import { parseSync } from 'oxc-parser';
 import type { Debugger, EvalRule, Evaluator } from '@wyw-in-js/shared';
 import { logger } from '@wyw-in-js/shared';
 
+import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
 import { oxcShaker } from '../shaker';
 import type { ParentEntrypoint } from '../types';
 import { getFileIdx } from '../utils/getFileIdx';
@@ -51,18 +52,39 @@ export function parseFile(
 ): ParsedAst {
   const log = logger.extend('transform:parse').extend(getFileIdx(filename));
 
-  const parseResult = parseSync(filename, originalCode, {
-    astType:
-      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js',
-    range: true,
-    sourceType: 'module',
-  });
+  const astType =
+    filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
+  let parseResult: ReturnType<typeof parseSync>;
+  try {
+    parseResult = parseSync(filename, originalCode, {
+      astType,
+      range: true,
+      sourceType: 'module',
+    });
+  } catch (error) {
+    recordPipelineUncachedParse(
+      filename,
+      originalCode,
+      'module',
+      astType,
+      true
+    );
+    throw error;
+  }
   const fatalError = parseResult.errors.find(
     (error) => error.severity === 'Error'
   );
   if (fatalError) {
+    recordPipelineUncachedParse(
+      filename,
+      originalCode,
+      'module',
+      astType,
+      true
+    );
     throw new Error(fatalError.message);
   }
+  recordPipelineUncachedParse(filename, originalCode, 'module', astType, false);
 
   log('stage-1', `${filename} has been parsed`);
 

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -19,6 +19,7 @@ import { BaseAction } from './actions/BaseAction';
 import { UnprocessedEntrypointError } from './actions/UnprocessedEntrypointError';
 import type { Services, ActionTypes, ActionQueueItem } from './types';
 import { stripQueryAndHash } from '../utils/parseRequest';
+import { recordPipelineEntrypoint } from '../debug/pipelineTelemetry';
 
 const EMPTY_FILE = '=== empty file ===';
 const DEFAULT_ACTION_CONTEXT = Symbol('defaultActionContext');
@@ -222,6 +223,13 @@ export class Entrypoint extends BaseEntrypoint {
         only,
         loadedCode,
         options
+      );
+
+      recordPipelineEntrypoint(
+        parent === null,
+        loadedCode !== undefined,
+        status,
+        entrypoint.only
       );
 
       if (status !== 'cached') {

--- a/packages/transform/src/transform/generators/parse-rewritten-barrel.ts
+++ b/packages/transform/src/transform/generators/parse-rewritten-barrel.ts
@@ -1,0 +1,31 @@
+import { parseSync } from 'oxc-parser';
+import type { Program } from 'oxc-parser';
+
+import { recordPipelineUncachedParse } from '../../debug/pipelineTelemetry';
+
+export const parseRewrittenBarrel = (
+  code: string,
+  filename: string
+): Program => {
+  const astType =
+    filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
+  let parsed: ReturnType<typeof parseSync>;
+  try {
+    parsed = parseSync(filename, code, {
+      astType,
+      range: true,
+      sourceType: 'module',
+    });
+  } catch (error) {
+    recordPipelineUncachedParse(filename, code, 'module', astType, true);
+    throw error;
+  }
+  const fatalError = parsed.errors.find((error) => error.severity === 'Error');
+  if (fatalError) {
+    recordPipelineUncachedParse(filename, code, 'module', astType, true);
+    throw new Error(fatalError.message);
+  }
+  recordPipelineUncachedParse(filename, code, 'module', astType, false);
+
+  return parsed.program as Program;
+};

--- a/packages/transform/src/transform/generators/rewriteOxcBarrelImports.ts
+++ b/packages/transform/src/transform/generators/rewriteOxcBarrelImports.ts
@@ -1,14 +1,12 @@
 /* eslint-disable no-continue, @typescript-eslint/no-use-before-define, @typescript-eslint/no-explicit-any, no-param-reassign */
 import path from 'path';
 
-import { parseSync } from 'oxc-parser';
 import type {
   ExportAllDeclaration,
   ExportNamedDeclaration,
   ImportDeclaration,
   ImportSpecifier,
   ModuleExportName,
-  Program,
   Statement,
 } from 'oxc-parser';
 
@@ -28,6 +26,7 @@ import type {
   BarrelResolvedBinding,
   RawBarrelManifest,
 } from '../barrelManifest.types';
+import { parseRewrittenBarrel } from './parse-rewritten-barrel';
 
 const NODE_MODULES_SEGMENT = `${path.sep}node_modules${path.sep}`;
 
@@ -231,21 +230,6 @@ const exportSpecifierCode = (specifier: RewrittenExportSpecifier): string => {
   return imported === exported ? imported : `${imported} as ${exported}`;
 };
 
-function parseProgram(code: string, filename: string): Program {
-  const parsed = parseSync(filename, code, {
-    astType:
-      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js',
-    range: true,
-    sourceType: 'module',
-  });
-  const fatalError = parsed.errors.find((error) => error.severity === 'Error');
-  if (fatalError) {
-    throw new Error(fatalError.message);
-  }
-
-  return parsed.program as Program;
-}
-
 function createAnalysisEntrypoint(
   services: Services,
   filename: string,
@@ -321,7 +305,7 @@ function collectOptimizedImports(
   filename: string
 ): Map<string, string[]> {
   const imports = new Map<string, string[]>();
-  const program = parseProgram(code, filename);
+  const program = parseRewrittenBarrel(code, filename);
 
   for (const statement of program.body as Statement[]) {
     if (statement.type === 'ImportDeclaration') {
@@ -1312,7 +1296,7 @@ export function* rewriteOptimizedOxcBarrelImports(
 ): Generator<any, RewriteResult, any> {
   const dependencies = buildResolvedDependencyMap(resolvedImports);
   const analysisServices = createAnalysisServices(this.services);
-  const program = parseProgram(code, filename);
+  const program = parseRewrittenBarrel(code, filename);
   const replacements: Replacement[] = [];
   const generatedSources = new Set<string>();
   let optimizedCount = 0;

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -23,6 +23,11 @@ import {
 } from '../static-plan/buildStaticPlan';
 import { rewriteOptimizedOxcBarrelImports } from './rewriteOxcBarrelImports';
 import { resolveStaticOxcPreevalValues } from './resolveStaticOxcValues';
+import {
+  beginPipelineShake,
+  finishPipelineShake,
+  recordPipelineLateNoMetadata,
+} from '../../debug/pipelineTelemetry';
 
 const EMPTY_FILE = '=== empty file ===';
 
@@ -211,6 +216,7 @@ const prepareOxcCodeImpl = (
     options.shortCircuitOnMissingMetadata !== false
   ) {
     log('[evaluator:end] no metadata');
+    recordPipelineLateNoMetadata(filename, only, 'preeval');
     const strippedCode = stripTypesAndJsxWithOxc(preevalCode, filename).code;
 
     return [
@@ -224,13 +230,35 @@ const prepareOxcCodeImpl = (
   log('[evaluator:start] using %s', loadedAndParsed.evaluator.name);
   log.extend('source')('%s', preevalCode);
 
-  const shaken = eventEmitter.perf('transform:evaluator', () =>
-    shakeOxcToESM(preevalCode, filename, {
-      importOverrides: pluginOptions.importOverrides,
-      onlyExports: only,
-      root,
-    })
+  const shakeToken = beginPipelineShake(
+    preevalCode,
+    only,
+    options.stripForEvalRuntime ? 'eval-runtime' : 'transform'
   );
+  let shaken: ReturnType<typeof shakeOxcToESM>;
+  if (!shakeToken) {
+    shaken = eventEmitter.perf('transform:evaluator', () =>
+      shakeOxcToESM(preevalCode, filename, {
+        importOverrides: pluginOptions.importOverrides,
+        onlyExports: only,
+        root,
+      })
+    );
+  } else {
+    try {
+      shaken = eventEmitter.perf('transform:evaluator', () =>
+        shakeOxcToESM(preevalCode, filename, {
+          importOverrides: pluginOptions.importOverrides,
+          onlyExports: only,
+          root,
+        })
+      );
+      finishPipelineShake(shakeToken, shaken.code, false);
+    } catch (error) {
+      finishPipelineShake(shakeToken, null, true);
+      throw error;
+    }
+  }
 
   log('[evaluator:end]');
 

--- a/packages/transform/src/transform/generators/workflow.ts
+++ b/packages/transform/src/transform/generators/workflow.ts
@@ -2,6 +2,10 @@ import { isAborted } from '../actions/AbortError';
 import type { IWorkflowAction, SyncScenarioForAction } from '../types';
 import { collectTransformDiagnostics } from '../../utils/TransformDiagnostics';
 import { toTransformResultMetadata } from '../../utils/TransformMetadata';
+import {
+  recordPipelineDisposableRoot,
+  recordPipelineLateNoMetadata,
+} from '../../debug/pipelineTelemetry';
 
 const isLoadedEntrypointWithoutArtifacts = (
   entrypoint: IWorkflowAction['entrypoint']
@@ -77,6 +81,7 @@ export function* workflow(
     if (isLoadedEntrypointWithoutArtifacts(entrypoint)) {
       // A root bundler pass for a plain dependency must not pin eval/cache state.
       // If another WyW file needs this module, it will be prepared on demand.
+      recordPipelineDisposableRoot(entrypoint.name, 'preeval');
       cache.delete('entrypoints', entrypoint.name);
     }
 
@@ -124,7 +129,9 @@ export function* workflow(
     entrypoint.assertNotSuperseded();
 
     if (!collectStageResult.metadata) {
+      recordPipelineLateNoMetadata(entrypoint.name, entrypoint.only, 'collect');
       if (isLoadedEntrypointWithoutArtifacts(entrypoint)) {
+        recordPipelineDisposableRoot(entrypoint.name, 'collect');
         cache.delete('entrypoints', entrypoint.name);
       }
 

--- a/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
+++ b/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
@@ -8,6 +8,8 @@ import type {
   VariableDeclarator,
 } from 'oxc-parser';
 
+import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
+
 const isNode = (value: unknown): value is Node =>
   !!value &&
   typeof value === 'object' &&
@@ -17,16 +19,25 @@ const isNode = (value: unknown): value is Node =>
 const getNodeType = (node: Pick<Node, 'type'>): string => node.type as string;
 
 const parseOxc = (code: string, filename: string): Program => {
-  const parsed = parseSync(filename, code, {
-    astType:
-      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js',
-    range: true,
-    sourceType: 'unambiguous',
-  });
+  const astType =
+    filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
+  let parsed: ReturnType<typeof parseSync>;
+  try {
+    parsed = parseSync(filename, code, {
+      astType,
+      range: true,
+      sourceType: 'unambiguous',
+    });
+  } catch (error) {
+    recordPipelineUncachedParse(filename, code, 'unambiguous', astType, true);
+    throw error;
+  }
   const fatalError = parsed.errors.find((error) => error.severity === 'Error');
   if (fatalError) {
+    recordPipelineUncachedParse(filename, code, 'unambiguous', astType, true);
     throw new Error(fatalError.message);
   }
+  recordPipelineUncachedParse(filename, code, 'unambiguous', astType, false);
 
   return parsed.program as Program;
 };

--- a/packages/transform/src/transform/oxcBarrelManifest.ts
+++ b/packages/transform/src/transform/oxcBarrelManifest.ts
@@ -13,6 +13,8 @@ import type {
   VariableDeclaration,
 } from 'oxc-parser';
 
+import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
+
 import type {
   BarrelManifestCacheEntry,
   RawBarrelManifest,
@@ -423,16 +425,25 @@ const collectPassthroughReexports = (
 };
 
 const parseProgram = (code: string, filename: string): Program => {
-  const parsed = parseSync(filename, code, {
-    astType:
-      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js',
-    range: true,
-    sourceType: 'module',
-  });
+  const astType =
+    filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
+  let parsed: ReturnType<typeof parseSync>;
+  try {
+    parsed = parseSync(filename, code, {
+      astType,
+      range: true,
+      sourceType: 'module',
+    });
+  } catch (error) {
+    recordPipelineUncachedParse(filename, code, 'module', astType, true);
+    throw error;
+  }
   const fatalError = parsed.errors.find((error) => error.severity === 'Error');
   if (fatalError) {
+    recordPipelineUncachedParse(filename, code, 'module', astType, true);
     throw new Error(fatalError.message);
   }
+  recordPipelineUncachedParse(filename, code, 'module', astType, false);
 
   return parsed.program as Program;
 };

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -45,7 +45,7 @@ import {
   collectProcessorUsages,
   collectUsageExpressionSpans,
 } from './processorUsages';
-import { removeUnusedAfterReplacement } from './cleanupRemovals';
+import { removeUnusedAfterReplacement } from './cleanup-after-replacement';
 import { insertAddedImports, parseOxc } from './shared';
 import type {
   ApplyOxcProcessorsResult,
@@ -57,6 +57,10 @@ import type {
   SameFileProcessorObject,
   StaticPlanFacts,
 } from './types';
+import {
+  isPipelineTelemetryActive,
+  recordPipelineProcessors,
+} from '../../debug/pipelineTelemetry';
 
 const EMPTY_STATIC_PLAN_FACTS: StaticPlanFacts = {
   importedNeeds: [],
@@ -131,6 +135,14 @@ export const applyOxcProcessors = (
   const eventEmitter = options.eventEmitter ?? EventEmitter.dummy;
   const perfPrefix = options.perfPrefix ?? 'transform:preeval:processTemplate';
   const perfLabel = (suffix: string): string => `${perfPrefix}:${suffix}`;
+  const pipelineTelemetryEnabled = isPipelineTelemetryActive();
+  const pipelineTelemetryPhase =
+    pipelineTelemetryEnabled && perfPrefix.includes(':collect')
+      ? 'collect'
+      : 'preeval';
+  let pipelineImportCandidates = 0;
+  let pipelineLookupAttempts = 0;
+  let pipelineLookupHits = 0;
   const collectStaticExpressionValues =
     shouldCollectStaticExpressionValues(options);
   const workingCode = code;
@@ -167,12 +179,18 @@ export const applyOxcProcessors = (
       const imports = eventEmitter.perf(perfLabel('imports:analysis'), () =>
         collectOxcProcessorImportsFromProgram(program, workingCode)
       );
+      if (pipelineTelemetryEnabled) {
+        pipelineImportCandidates = imports.length;
+      }
 
       eventEmitter.perf(perfLabel('imports:lookup'), () => {
         imports.forEach((item) => {
           const localName = item.local.name ?? item.local.code;
           if (item.imported === 'side-effect' || !localName) {
             return;
+          }
+          if (pipelineTelemetryEnabled) {
+            pipelineLookupAttempts += 1;
           }
 
           const [processor, tagSource, manifest] = getProcessorForImport(
@@ -185,6 +203,9 @@ export const applyOxcProcessors = (
           );
 
           if (processor) {
+            if (pipelineTelemetryEnabled) {
+              pipelineLookupHits += 1;
+            }
             definedProcessors.set(localName, [
               processor,
               tagSource,
@@ -207,6 +228,17 @@ export const applyOxcProcessors = (
   }
 
   if (!reusablePlan && definedProcessors.size === 0) {
+    if (pipelineTelemetryEnabled) {
+      recordPipelineProcessors(
+        pipelineTelemetryPhase,
+        false,
+        pipelineImportCandidates,
+        pipelineLookupAttempts,
+        pipelineLookupHits,
+        0,
+        0
+      );
+    }
     return {
       code: buildUnprocessedCode(),
       processorManagedExpressionSpans: [],
@@ -223,6 +255,17 @@ export const applyOxcProcessors = (
     eventEmitter.perf(perfLabel('usages'), () =>
       collectProcessorUsages(program, definedProcessors)
     );
+  if (pipelineTelemetryEnabled) {
+    recordPipelineProcessors(
+      pipelineTelemetryPhase,
+      Boolean(reusablePlan),
+      pipelineImportCandidates,
+      pipelineLookupAttempts,
+      pipelineLookupHits,
+      definedProcessors.size,
+      processorUsages.length
+    );
+  }
   if (processorUsages.length === 0) {
     return {
       code: buildUnprocessedCode(),

--- a/packages/transform/src/utils/applyOxcProcessors/cleanup-after-replacement.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/cleanup-after-replacement.ts
@@ -1,0 +1,164 @@
+import type { Program } from 'oxc-parser';
+
+import { applyOxcReplacements } from '../oxc/replacements';
+import {
+  collectReferencedNames,
+  collectRemovableNamesFromStatements,
+  collectTopLevelBindingsFromStatements,
+  collectTopLevelStatementInfos,
+} from './cleanupBindings';
+import {
+  collectEmptyTopLevelBlockRemovals,
+  collectScopedBindingInfos,
+  collectTopLevelExpressionStatementRemovals,
+  collectUnusedGeneratedHelperDeclarationRemovals,
+  collectUnusedImportRemovals,
+  collectUnusedScopedDeclarationRemovals,
+  collectUnusedTopLevelDeclarationRemovals,
+  mergeEmptyRemovalRanges,
+} from './cleanupRemovals';
+import { parseOxc } from './shared';
+import {
+  beginPipelineCleanup,
+  finishPipelineCleanup,
+  recordPipelineCleanupIteration,
+} from '../../debug/pipelineTelemetry';
+
+export const removeUnusedAfterReplacement = (
+  code: string,
+  filename: string,
+  initialRemovableNames: Set<string>,
+  removableExpressionRefs: Set<string>,
+  preserveSideEffectImportLocals: Set<string>,
+  preserveSideEffectImportOrderLocals: Set<string> = preserveSideEffectImportLocals
+): string => {
+  let current = code;
+  let program: Program | null = null;
+  const cumulativeRemovableNames = new Set(initialRemovableNames);
+  const pipelineCleanup = beginPipelineCleanup(filename);
+
+  try {
+    // Validate the next revision once and reuse that AST on the next iteration.
+    for (let idx = 0; idx < 5; idx += 1) {
+      const previous = current;
+      if (program === null) {
+        program = parseOxc(current, filename);
+      }
+      const statements = collectTopLevelStatementInfos(program);
+      const removableNames = collectRemovableNamesFromStatements(
+        statements,
+        cumulativeRemovableNames
+      );
+      removableNames.forEach((name) => cumulativeRemovableNames.add(name));
+      const referencedNames = collectReferencedNames(program);
+      const topLevelBindings =
+        collectTopLevelBindingsFromStatements(statements);
+      const scopedBindings = collectScopedBindingInfos(program);
+      const scopedDeclarationRemovals = collectUnusedScopedDeclarationRemovals(
+        current,
+        scopedBindings,
+        cumulativeRemovableNames
+      );
+      const topLevelDeclarationRemovals =
+        collectUnusedTopLevelDeclarationRemovals(
+          current,
+          program,
+          referencedNames,
+          cumulativeRemovableNames
+        );
+      const generatedHelperRemovals =
+        collectUnusedGeneratedHelperDeclarationRemovals(
+          current,
+          program,
+          referencedNames
+        );
+      const importRemovals = collectUnusedImportRemovals(
+        current,
+        program,
+        referencedNames,
+        cumulativeRemovableNames,
+        preserveSideEffectImportLocals,
+        preserveSideEffectImportOrderLocals
+      );
+      const expressionRemovals = collectTopLevelExpressionStatementRemovals(
+        current,
+        statements,
+        topLevelBindings,
+        removableExpressionRefs
+      );
+      const emptyBlockRemovals = collectEmptyTopLevelBlockRemovals(
+        current,
+        program
+      );
+      const removals = mergeEmptyRemovalRanges([
+        ...scopedDeclarationRemovals,
+        ...topLevelDeclarationRemovals,
+        ...generatedHelperRemovals,
+        ...importRemovals,
+        ...expressionRemovals,
+        ...emptyBlockRemovals,
+      ]);
+
+      if (removals.length === 0) {
+        recordPipelineCleanupIteration(
+          pipelineCleanup,
+          current,
+          removals,
+          false,
+          scopedDeclarationRemovals.length,
+          topLevelDeclarationRemovals.length,
+          generatedHelperRemovals.length,
+          importRemovals.length,
+          expressionRemovals.length,
+          emptyBlockRemovals.length
+        );
+        finishPipelineCleanup(pipelineCleanup, 'converged');
+        return current;
+      }
+
+      const next = applyOxcReplacements(current, removals);
+      try {
+        program = parseOxc(next, filename);
+        recordPipelineCleanupIteration(
+          pipelineCleanup,
+          current,
+          removals,
+          true,
+          scopedDeclarationRemovals.length,
+          topLevelDeclarationRemovals.length,
+          generatedHelperRemovals.length,
+          importRemovals.length,
+          expressionRemovals.length,
+          emptyBlockRemovals.length
+        );
+        current = next;
+      } catch {
+        recordPipelineCleanupIteration(
+          pipelineCleanup,
+          current,
+          removals,
+          false,
+          scopedDeclarationRemovals.length,
+          topLevelDeclarationRemovals.length,
+          generatedHelperRemovals.length,
+          importRemovals.length,
+          expressionRemovals.length,
+          emptyBlockRemovals.length
+        );
+        finishPipelineCleanup(pipelineCleanup, 'rollback');
+        return current;
+      }
+
+      if (current === previous) {
+        finishPipelineCleanup(pipelineCleanup, 'stalled');
+        return current;
+      }
+    }
+
+    finishPipelineCleanup(pipelineCleanup, 'cap');
+    return current;
+  } catch (error) {
+    finishPipelineCleanup(pipelineCleanup, 'error');
+    throw error;
+  }
+};

--- a/packages/transform/src/utils/applyOxcProcessors/cleanupRemovals.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/cleanupRemovals.ts
@@ -3,19 +3,14 @@
 import type { Node, Program } from 'oxc-parser';
 
 import { getOxcNodeChildren, isOxcNode } from '../oxc/ast';
-import { applyOxcReplacements } from '../oxc/replacements';
 import {
   collectDeclaredNames,
   collectImportLocalNames,
-  collectReferencedNames,
-  collectRemovableNamesFromStatements,
   collectTopLevelBindings,
-  collectTopLevelBindingsFromStatements,
-  collectTopLevelStatementInfos,
   getImportSpecifierLocalName,
   isNodeReference,
 } from './cleanupBindings';
-import { GENERATED_HELPER_NAME_RE, parseOxc } from './shared';
+import { GENERATED_HELPER_NAME_RE } from './shared';
 import type {
   AnyNode,
   Replacement,
@@ -926,93 +921,4 @@ export const collectEmptyTopLevelBlockRemovals = (
   });
 
   return removals;
-};
-
-export const removeUnusedAfterReplacement = (
-  code: string,
-  filename: string,
-  initialRemovableNames: Set<string>,
-  removableExpressionRefs: Set<string>,
-  preserveSideEffectImportLocals: Set<string>,
-  preserveSideEffectImportOrderLocals: Set<string> = preserveSideEffectImportLocals
-): string => {
-  let current = code;
-  let program: Program | null = null;
-  const cumulativeRemovableNames = new Set(initialRemovableNames);
-
-  // Incremental cleanup loop: validate-by-parsing the next iteration's
-  // candidate code AND reuse that parse as the next iter's `program` input,
-  // instead of re-parsing at the top of the next iter. Saves one parse per
-  // loop revolution (N+1 parses for an N-iter loop instead of 2N).
-  // Also short-circuits a round earlier when no removals were collected.
-  for (let idx = 0; idx < 5; idx += 1) {
-    const previous = current;
-    if (program === null) {
-      program = parseOxc(current, filename);
-    }
-    const statements = collectTopLevelStatementInfos(program);
-    const removableNames = collectRemovableNamesFromStatements(
-      statements,
-      cumulativeRemovableNames
-    );
-    removableNames.forEach((name) => cumulativeRemovableNames.add(name));
-    const referencedNames = collectReferencedNames(program);
-    const topLevelBindings = collectTopLevelBindingsFromStatements(statements);
-    const scopedBindings = collectScopedBindingInfos(program);
-    const removals = mergeEmptyRemovalRanges([
-      ...collectUnusedScopedDeclarationRemovals(
-        current,
-        scopedBindings,
-        cumulativeRemovableNames
-      ),
-      ...collectUnusedTopLevelDeclarationRemovals(
-        current,
-        program,
-        referencedNames,
-        cumulativeRemovableNames
-      ),
-      ...collectUnusedGeneratedHelperDeclarationRemovals(
-        current,
-        program,
-        referencedNames
-      ),
-      ...collectUnusedImportRemovals(
-        current,
-        program,
-        referencedNames,
-        cumulativeRemovableNames,
-        preserveSideEffectImportLocals,
-        preserveSideEffectImportOrderLocals
-      ),
-      ...collectTopLevelExpressionStatementRemovals(
-        current,
-        statements,
-        topLevelBindings,
-        removableExpressionRefs
-      ),
-      ...collectEmptyTopLevelBlockRemovals(current, program),
-    ]);
-
-    if (removals.length === 0) {
-      // Convergence: next iter would parse the same code and see the same
-      // removable set. Skip the round of walks + parse.
-      return current;
-    }
-
-    const next = applyOxcReplacements(current, removals);
-    try {
-      // Validate + capture the AST for the next iteration in one parse.
-      program = parseOxc(next, filename);
-      current = next;
-    } catch {
-      // Pathological removal — drop this iteration and return prior state.
-      return current;
-    }
-
-    if (current === previous) {
-      return current;
-    }
-  }
-
-  return current;
 };

--- a/packages/transform/src/utils/oxcEmit.ts
+++ b/packages/transform/src/utils/oxcEmit.ts
@@ -18,6 +18,8 @@ import type {
   VariableDeclarator,
 } from 'oxc-parser';
 
+import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
+
 type Replacement = {
   end: number;
   start: number;
@@ -244,15 +246,23 @@ const applyReplacements = (
 };
 
 const parseJsModule = (code: string, filename: string): Program => {
-  const parsed = parseSync(filename, code, {
-    astType: 'js',
-    range: true,
-    sourceType: 'module',
-  });
+  let parsed: ReturnType<typeof parseSync>;
+  try {
+    parsed = parseSync(filename, code, {
+      astType: 'js',
+      range: true,
+      sourceType: 'module',
+    });
+  } catch (error) {
+    recordPipelineUncachedParse(filename, code, 'module', 'js', true);
+    throw error;
+  }
   const fatalError = parsed.errors.find((error) => error.severity === 'Error');
   if (fatalError) {
+    recordPipelineUncachedParse(filename, code, 'module', 'js', true);
     throw new Error(fatalError.message);
   }
+  recordPipelineUncachedParse(filename, code, 'module', 'js', false);
 
   return parsed.program as Program;
 };

--- a/packages/transform/src/utils/oxcPreevalStage/prevalExport.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/prevalExport.ts
@@ -1,19 +1,30 @@
 import { parseSync } from 'oxc-parser';
 
+import { recordPipelineUncachedParse } from '../../debug/pipelineTelemetry';
+
 const parseSourceType = (
   code: string,
   filename: string
 ): 'module' | 'script' => {
-  const parsed = parseSync(filename, code, {
-    astType:
-      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js',
-    range: true,
-    sourceType: 'unambiguous',
-  });
+  const astType =
+    filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
+  let parsed: ReturnType<typeof parseSync>;
+  try {
+    parsed = parseSync(filename, code, {
+      astType,
+      range: true,
+      sourceType: 'unambiguous',
+    });
+  } catch (error) {
+    recordPipelineUncachedParse(filename, code, 'unambiguous', astType, true);
+    throw error;
+  }
   const fatalError = parsed.errors.find((error) => error.severity === 'Error');
   if (fatalError) {
+    recordPipelineUncachedParse(filename, code, 'unambiguous', astType, true);
     throw new Error(fatalError.message);
   }
+  recordPipelineUncachedParse(filename, code, 'unambiguous', astType, false);
 
   return parsed.program.sourceType === 'script' ? 'script' : 'module';
 };

--- a/packages/transform/src/utils/oxcPreevalStage/processors.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/processors.ts
@@ -6,6 +6,10 @@ import { applyOxcProcessors } from '../applyOxcProcessors';
 import type { ApplyOxcProcessorsResult } from '../applyOxcProcessors/types';
 import { createDangerousCodePlanWithOxc } from '../dangerousCodeRemoval';
 import type { OxcPreevalOptions } from './types';
+import {
+  beginPipelineDangerousCode,
+  finishPipelineDangerousCode,
+} from '../../debug/pipelineTelemetry';
 
 type PreevalProcessorCollection = {
   dependencyNames: string[];
@@ -24,13 +28,42 @@ export const collectPreevalProcessors = (
     'dangerousCodeRemover',
     filename
   )
-    ? (processorSpans: Array<{ end: number; start: number }>) =>
-        eventEmitter.perf('transform:preeval:removeDangerousCode', () =>
-          createDangerousCodePlanWithOxc(code, filename, options.codeRemover, {
-            ignoredSpans: processorSpans,
-            preserveImportMetaEnv: true,
-          })
-        )
+    ? (processorSpans: Array<{ end: number; start: number }>) => {
+        const telemetryToken = beginPipelineDangerousCode(filename);
+        if (!telemetryToken) {
+          return eventEmitter.perf(
+            'transform:preeval:removeDangerousCode',
+            () =>
+              createDangerousCodePlanWithOxc(
+                code,
+                filename,
+                options.codeRemover,
+                {
+                  ignoredSpans: processorSpans,
+                  preserveImportMetaEnv: true,
+                }
+              )
+          );
+        }
+
+        try {
+          return eventEmitter.perf(
+            'transform:preeval:removeDangerousCode',
+            () =>
+              createDangerousCodePlanWithOxc(
+                code,
+                filename,
+                options.codeRemover,
+                {
+                  ignoredSpans: processorSpans,
+                  preserveImportMetaEnv: true,
+                }
+              )
+          );
+        } finally {
+          finishPipelineDangerousCode(telemetryToken);
+        }
+      }
     : undefined;
   const processed = eventEmitter.perf('transform:preeval:processTemplate', () =>
     applyOxcProcessors(

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -1,12 +1,19 @@
 import { parseSync } from 'oxc-parser';
 import type { Program } from 'oxc-parser';
 
+import {
+  recordPipelineCachedParseMiss,
+  recordPipelineCachedParseHit,
+} from '../debug/pipelineTelemetry';
+
 type OxcSourceType = 'module' | 'unambiguous';
 
 type ParsedOxc = {
+  jsxFallback: boolean;
   module: {
     hasModuleSyntax: boolean;
   };
+  pipelineMeasurement: { bytes: number; revision: string } | undefined;
   program: Program;
 };
 
@@ -53,36 +60,99 @@ export const parseOxcCached = (
   const cacheKey = makeCacheKey(filename, code, sourceType);
   const cached = parseCache.get(cacheKey);
   if (cached) {
+    const knownMeasurement = cached.pipelineMeasurement;
+    const measurement = recordPipelineCachedParseHit(
+      cached,
+      filename,
+      code,
+      sourceType,
+      cached.jsxFallback,
+      knownMeasurement
+    );
+    if (measurement && measurement !== knownMeasurement) {
+      cached.pipelineMeasurement = measurement;
+    }
     return cached;
   }
 
-  let parsed = parseSync(filename, code, {
-    astType: getAstType(filename),
-    range: true,
-    sourceType,
-  });
-  let fatalError = parsed.errors.find((error) => error.severity === 'Error');
-  const jsxFallbackFilename = getJsxFallbackFilename(filename);
-  if (fatalError?.message.includes('JSX') && jsxFallbackFilename) {
-    // Some bundlers pass .js files with JSX to WyW before a later JSX transform.
-    parsed = parseSync(jsxFallbackFilename, code, {
-      astType: getAstType(jsxFallbackFilename),
+  const astType = getAstType(filename);
+  let parsed: ReturnType<typeof parseSync>;
+  try {
+    parsed = parseSync(filename, code, {
+      astType,
       range: true,
       sourceType,
     });
+  } catch (error) {
+    recordPipelineCachedParseMiss(
+      filename,
+      code,
+      sourceType,
+      astType,
+      false,
+      true
+    );
+    throw error;
+  }
+  let fatalError = parsed.errors.find((error) => error.severity === 'Error');
+  const jsxFallbackFilename = getJsxFallbackFilename(filename);
+  let jsxFallback = false;
+  if (fatalError?.message.includes('JSX') && jsxFallbackFilename) {
+    // Some bundlers pass .js files with JSX to WyW before a later JSX transform.
+    jsxFallback = true;
+    try {
+      parsed = parseSync(jsxFallbackFilename, code, {
+        astType: getAstType(jsxFallbackFilename),
+        range: true,
+        sourceType,
+      });
+    } catch (error) {
+      recordPipelineCachedParseMiss(
+        filename,
+        code,
+        sourceType,
+        astType,
+        jsxFallback,
+        true
+      );
+      throw error;
+    }
     fatalError = parsed.errors.find((error) => error.severity === 'Error');
   }
 
   if (fatalError) {
+    recordPipelineCachedParseMiss(
+      filename,
+      code,
+      sourceType,
+      astType,
+      jsxFallback,
+      true
+    );
     throw new Error(fatalError.message);
   }
 
-  return setCachedParse(cacheKey, {
+  const cachedParse = setCachedParse(cacheKey, {
+    jsxFallback,
     module: {
       hasModuleSyntax: parsed.module.hasModuleSyntax,
     },
+    pipelineMeasurement: undefined,
     program: parsed.program as Program,
   });
+  const telemetryMeasurement = recordPipelineCachedParseMiss(
+    filename,
+    code,
+    sourceType,
+    astType,
+    jsxFallback,
+    false,
+    cachedParse
+  );
+  if (telemetryMeasurement) {
+    cachedParse.pipelineMeasurement = telemetryMeasurement;
+  }
+  return cachedParse;
 };
 
 export const parseOxcProgramCached = (


### PR DESCRIPTION
## Motivation

The file reporter exposes detailed event logs, but it lacks a compact root-level view of work across parsing, caches, entrypoints, processors, shaking, and cleanup. This makes pipeline behavior and performance regressions difficult to compare across real builds.

## Summary

- Emit one versioned `pipeline-telemetry.jsonl` summary per transform root, together with schema metadata, through the existing file reporter.
- Record aggregate and revision-level counters for parsing, caches, entrypoints, processors, shaking, cleanup, and late no-metadata paths.
- Bound code-measurement retention, redact paths, and buffer JSONL writes.
- Add a patch changeset for `@wyw-in-js/transform`. Telemetry remains disabled unless the existing file reporter is configured; transform APIs and generated output are unchanged.

## Test plan

- `bun test packages/transform/src/__tests__/fileReporter.test.ts packages/transform/src/__tests__/pipelineTelemetry.test.ts packages/transform/src/__tests__/pipelineTelemetryJsonl.test.ts`
- All transform test files were also run in isolated Bun processes: 107 files and 1,743 tests passed.
- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform build:types`
- production builds preserved their CSS baselines with telemetry disabled and enabled.
- In paired production-build measurements, median telemetry-on overhead stayed below 1% for both consumers.
