### PR TITLE
feat(transform): add eval broker telemetry diagnostics

### DIFF
--- a/.changeset/trace-eval-broker.md
+++ b/.changeset/trace-eval-broker.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Add evaluation broker, cache, preparation, and transport counters to file reporter output.

--- a/packages/transform/src/__tests__/eval-broker.telemetry.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.telemetry.test.ts
@@ -1,0 +1,1487 @@
+import * as babel from '@babel/core';
+import { EventEmitter as NodeEventEmitter } from 'events';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PassThrough } from 'stream';
+
+import { disposeEvalBroker, EvalBroker, getEvalBroker } from '../eval/broker';
+import { LruCache } from '../eval/lru';
+import {
+  beginEvalTelemetry,
+  registerEvalTelemetryReporter,
+  type EvalBrokerMirrorSnapshot,
+  type EvalTelemetryRecord,
+  type EvalTelemetryToken,
+} from '../debug/evalTelemetry';
+import { Entrypoint } from '../transform/Entrypoint';
+import {
+  loadWywOptions,
+  type PartialOptions,
+} from '../transform/helpers/loadWywOptions';
+import { withDefaultServices } from '../transform/helpers/withDefaultServices';
+import { shaker } from '../shaker';
+import { serializeValue } from '../eval/serialize';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const createEmitter = () => {
+  let actionId = 0;
+  return new EventEmitter(
+    () => {},
+    ((phase: string) => {
+      if (phase !== 'start') return undefined;
+      const id = actionId;
+      actionId += 1;
+      return id;
+    }) as never,
+    () => {}
+  );
+};
+
+const createServices = (
+  root: string,
+  filename: string,
+  emitter: EventEmitter,
+  overrides: PartialOptions = {}
+) =>
+  withDefaultServices({
+    babel,
+    eventEmitter: emitter,
+    options: {
+      root,
+      filename,
+      pluginOptions: loadWywOptions({
+        configFile: false,
+        rules: [{ test: () => true, action: shaker }],
+        babelOptions: {
+          babelrc: false,
+          configFile: false,
+        },
+        ...overrides,
+      }),
+    },
+  });
+
+const testCssProcessorFile = join(
+  __dirname,
+  '__fixtures__',
+  'test-css-processor.js'
+);
+
+describe('EvalBroker telemetry', () => {
+  it('attributes batched roots explicitly when the middle root fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entries = ['a', 'b', 'c'].map((name) => join(root, `${name}.js`));
+    entries.forEach((entry) =>
+      writeFileSync(entry, 'export const __wywPreval = {};')
+    );
+
+    const emitter = createEmitter();
+    const services = createServices(root, entries[0], emitter);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const privateBroker = broker as unknown as {
+      ensureRunner: () => Promise<void>;
+      handleLoad: (
+        requestId: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      initRunner: (entrypoint: Entrypoint) => Promise<void>;
+      loadModule: jest.Mock;
+      request: (
+        type: string,
+        payload: unknown,
+        timeoutMs?: number
+      ) => Promise<unknown>;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+    privateBroker.ensureRunner = jest.fn(async () => {});
+    privateBroker.initRunner = jest.fn(async () => {});
+    privateBroker.runnerInputQueue = { write: () => Promise.resolve() };
+    privateBroker.sendMessage = jest.fn(async () => {});
+    privateBroker.loadModule = jest.fn(async (payload) => ({
+      code: `export const value = ${JSON.stringify(payload.id)};`,
+      hash: `hash:${payload.id}`,
+      imports: null,
+      only: ['value'],
+    }));
+
+    const executionOrder: string[] = [];
+    privateBroker.request = jest.fn(async (type, payload) => {
+      if (type !== 'EVAL') throw new Error(`unexpected request: ${type}`);
+      const { id } = payload as { id: string };
+      executionOrder.push(id);
+      await privateBroker.handleLoad(`load:${id}`, {
+        id: `${id}:dependency`,
+        importerId: id,
+        request: './dependency',
+      });
+      if (id === entries[1]) throw new Error('middle-fail');
+      return {
+        values: {
+          value: serializeValue(id, { allowFunctions: true }),
+        },
+      };
+    });
+
+    try {
+      const entrypoints = entries.map((entry) =>
+        Entrypoint.createRoot(
+          services,
+          entry,
+          ['__wywPreval'],
+          readFileSync(entry, 'utf8')
+        )
+      );
+      const settled = await Promise.allSettled(
+        entrypoints.map((entrypoint) => broker.evaluate(entrypoint))
+      );
+
+      expect(executionOrder).toEqual(entries);
+      expect(settled.map(({ status }) => status)).toEqual([
+        'fulfilled',
+        'rejected',
+        'fulfilled',
+      ]);
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(3);
+      expect(roots.map((record) => record.root.entrypoint)).toEqual(entries);
+      expect(roots.map((record) => record.root.status)).toEqual([
+        'success',
+        'error',
+        'success',
+      ]);
+      expect(roots.map((record) => record.root.batchIndex)).toEqual([0, 1, 2]);
+      expect(roots.map((record) => record.root.batchSize)).toEqual([3, 3, 3]);
+      expect(roots.map((record) => record.loads.requests)).toEqual([1, 1, 1]);
+      expect(new Set(roots.map((record) => record.brokerId)).size).toBe(1);
+      roots.forEach((record) => {
+        expect(record.root.queueWaitMs).toBeGreaterThanOrEqual(0);
+        expect(record.root.durationMs).toBeGreaterThanOrEqual(0);
+      });
+    } finally {
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves batch metadata when runner startup fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entries = ['a', 'b', 'c'].map((name) => join(root, `${name}.js`));
+    entries.forEach((entry) =>
+      writeFileSync(entry, 'export const __wywPreval = {};')
+    );
+
+    const emitter = createEmitter();
+    const services = createServices(root, entries[0], emitter);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const privateBroker = broker as unknown as {
+      ensureRunner: () => Promise<void>;
+    };
+    privateBroker.ensureRunner = jest.fn(async () => {
+      throw new Error('runner-unavailable');
+    });
+
+    try {
+      const entrypoints = entries.map((entry) =>
+        Entrypoint.createRoot(
+          services,
+          entry,
+          ['__wywPreval'],
+          readFileSync(entry, 'utf8')
+        )
+      );
+      const settled = await Promise.allSettled(
+        entrypoints.map((entrypoint) => broker.evaluate(entrypoint))
+      );
+
+      expect(settled.every(({ status }) => status === 'rejected')).toBe(true);
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(3);
+      expect(roots.map((record) => record.root.batchIndex)).toEqual([0, 1, 2]);
+      expect(roots.map((record) => record.root.batchSize)).toEqual([3, 3, 3]);
+      expect(roots.map((record) => record.root.status)).toEqual([
+        'error',
+        'error',
+        'error',
+      ]);
+      expect(roots.map((record) => record.loads.requests)).toEqual([0, 0, 0]);
+    } finally {
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('partitions miss, inflight hit, cache hit, and invalidation exactly', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    const dependency = join(root, 'dependency.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    writeFileSync(dependency, 'export const value = 1;');
+
+    let releaseFirstLoad:
+      | ((value: { code: string; loader?: string | null }) => void)
+      | undefined;
+    let loaderCalls = 0;
+    const customLoader = jest.fn(() => {
+      loaderCalls += 1;
+      if (loaderCalls === 1) {
+        return new Promise<{ code: string }>((resolve) => {
+          releaseFirstLoad = resolve;
+        });
+      }
+
+      return Promise.resolve({ code: 'export const value = 2;' });
+    });
+    const emitter = createEmitter();
+    const services = createServices(root, entry, emitter, {
+      eval: { customLoader },
+    });
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dependency)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      loadModule: (payload: {
+        id: string;
+        importerId: string | null;
+        request: string | null;
+      }) => Promise<{ code: string }>;
+      onlyByModule: Map<string, string[]>;
+    };
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+    privateBroker.onlyByModule.set(dependency, ['*']);
+    const payload = {
+      id: dependency,
+      importerId: entry,
+      request: null,
+    };
+
+    try {
+      token!.recordLoadRequest();
+      const first = privateBroker.loadModule(payload);
+      token!.recordLoadRequest();
+      const inflight = privateBroker.loadModule(payload);
+      expect(customLoader).toHaveBeenCalledTimes(1);
+      releaseFirstLoad?.({ code: 'export const value = 1;' });
+      await Promise.all([first, inflight]);
+
+      token!.recordLoadRequest();
+      await privateBroker.loadModule(payload);
+      services.cache.invalidateForFile(dependency);
+      token!.recordLoadRequest();
+      await privateBroker.loadModule(payload);
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      const [record] = roots;
+      expect(record.loads.requests).toBe(4);
+      expect(record.loads.cache).toEqual(
+        expect.objectContaining({
+          hits: 2,
+          inflightHits: 1,
+          inflightWaitMisses: 0,
+          inflightWaits: 1,
+          invalidationMisses: 1,
+          misses: 2,
+          promotions: 0,
+        })
+      );
+      expect(record.loads.cache.outcomes).toEqual(
+        expect.objectContaining({
+          hit: 1,
+          'inflight-hit': 1,
+          'inflight-wait': 1,
+          'invalidation-miss': 1,
+          miss: 1,
+        })
+      );
+      expect(record.evictions.hostPreparedCache).toEqual(
+        expect.objectContaining({
+          invalidation: 1,
+          total: 1,
+          unknownByteEntries: 0,
+        })
+      );
+      expect(customLoader).toHaveBeenCalledTimes(2);
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('records capacity eviction through the broker load cache wiring', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    const dependencyA = join(root, 'dependency-a.js');
+    const dependencyB = join(root, 'dependency-b.js');
+    const codeA = 'export const valueA = 1;';
+    const codeB = 'export const valueB = 2;';
+    const codeById = new Map([
+      [dependencyA, codeA],
+      [dependencyB, codeB],
+    ]);
+    writeFileSync(entry, 'export const __wywPreval = {};');
+
+    const customLoader = jest.fn(async (id: string) => ({
+      code: codeById.get(id)!,
+    }));
+    const emitter = createEmitter();
+    const services = createServices(root, entry, emitter, {
+      eval: { customLoader },
+    });
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      handleLoad: (
+        requestId: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      loadCache: LruCache<string, { code: string }>;
+      onlyByModule: Map<string, string[]>;
+      runnerInputQueue: { write: (payload: string) => Promise<void> };
+    };
+    const wirePayloads: string[] = [];
+    privateBroker.loadCache = new LruCache(1);
+    privateBroker.runnerInputQueue = {
+      write: async (payload: string) => {
+        wirePayloads.push(payload);
+      },
+    };
+    privateBroker.onlyByModule.set(dependencyA, ['*']);
+    privateBroker.onlyByModule.set(dependencyB, ['*']);
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+
+    try {
+      await privateBroker.handleLoad('load-a', {
+        id: dependencyA,
+        importerId: entry,
+        request: null,
+      });
+      await privateBroker.handleLoad('load-b', {
+        id: dependencyB,
+        importerId: entry,
+        request: null,
+      });
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      const [record] = roots;
+      expect(record.loads.requests).toBe(2);
+      expect(record.evictions.hostPreparedCache).toEqual({
+        capacity: 1,
+        invalidation: 0,
+        knownCodeBytes: Buffer.byteLength(codeA),
+        replacement: 0,
+        total: 1,
+        unknownByteEntries: 0,
+      });
+      expect(privateBroker.loadCache.has(dependencyA)).toBe(false);
+      expect(privateBroker.loadCache.has(dependencyB)).toBe(true);
+      expect(customLoader).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(wirePayloads.at(-1)!).payload.code).toBe(codeB);
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps inflight waits orthogonal when widening requires promotion', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    const dependency = join(root, 'dependency.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    writeFileSync(dependency, 'export const first = 1;');
+
+    let releaseNarrowLoad:
+      | ((value: { code: string; loader?: string | null }) => void)
+      | undefined;
+    let loaderCalls = 0;
+    const customLoader = jest.fn(() => {
+      loaderCalls += 1;
+      if (loaderCalls === 1) {
+        return new Promise<{ code: string }>((resolve) => {
+          releaseNarrowLoad = resolve;
+        });
+      }
+
+      return Promise.resolve({
+        code: 'export const first = 1; export const second = 2;',
+      });
+    });
+    const emitter = createEmitter();
+    const services = createServices(root, entry, emitter, {
+      eval: { customLoader },
+    });
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dependency)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      loadModule: (payload: {
+        id: string;
+        importerId: string | null;
+        request: string | null;
+      }) => Promise<{ code: string }>;
+      onlyByModule: Map<string, string[]>;
+    };
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+    const payload = {
+      id: dependency,
+      importerId: entry,
+      request: null,
+    };
+
+    try {
+      privateBroker.onlyByModule.set(dependency, ['first']);
+      token!.recordLoadRequest();
+      const narrow = privateBroker.loadModule(payload);
+      privateBroker.onlyByModule.set(dependency, ['first', 'second']);
+      token!.recordLoadRequest();
+      const wide = privateBroker.loadModule(payload);
+      releaseNarrowLoad?.({ code: 'export const first = 1;' });
+      await Promise.all([narrow, wide]);
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      const [record] = roots;
+      expect(record.loads.cache).toEqual(
+        expect.objectContaining({
+          hits: 0,
+          inflightHits: 0,
+          inflightWaitMisses: 1,
+          inflightWaits: 1,
+          misses: 2,
+          promotions: 1,
+        })
+      );
+      expect(record.loads.cache.outcomes).toEqual(
+        expect.objectContaining({
+          'inflight-wait': 1,
+          'inflight-wait-miss': 1,
+          miss: 1,
+          promotion: 1,
+        })
+      );
+      expect(record.evictions.hostPreparedCache).toEqual(
+        expect.objectContaining({
+          knownCodeBytes: Buffer.byteLength('export const first = 1;'),
+          replacement: 1,
+          total: 1,
+          unknownByteEntries: 0,
+        })
+      );
+      expect(customLoader).toHaveBeenCalledTimes(2);
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('measures physical prepare, shake, and strip only on a cache miss', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'styles.js');
+    writeFileSync(
+      entry,
+      [
+        "import { css } from 'test-css-processor';",
+        'export const className = css`color: red;`;',
+      ].join('\n')
+    );
+
+    const emitter = createEmitter();
+    const services = createServices(root, entry, emitter, {
+      tagResolver: (source, tag) =>
+        source === 'test-css-processor' && tag === 'css'
+          ? testCssProcessorFile
+          : null,
+    });
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      loadModule: (payload: {
+        id: string;
+        importerId: string | null;
+        request: string | null;
+      }) => Promise<{ code: string }>;
+      onlyByModule: Map<string, string[]>;
+    };
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+    privateBroker.onlyByModule.set(entry, ['__wywPreval']);
+    const payload = { id: entry, importerId: entry, request: entry };
+
+    try {
+      token!.recordLoadRequest();
+      await privateBroker.loadModule(payload);
+      token!.recordLoadRequest();
+      await privateBroker.loadModule(payload);
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      const [record] = roots;
+      expect(record.loads.cache).toEqual(
+        expect.objectContaining({ hits: 1, misses: 1 })
+      );
+      expect(record.loads.preparation).toEqual(
+        expect.objectContaining({
+          calls: 1,
+          errors: 0,
+          prepareCalls: 1,
+          shakeCalls: 1,
+          stripCalls: 1,
+        })
+      );
+      expect(record.loads.preparation.preparedCodeBytes).toBeGreaterThan(0);
+      expect(record.loads.preparation.artifacts).toEqual([
+        expect.objectContaining({
+          calls: 1,
+          id: entry,
+          onlyShape: 'named',
+          outputRevision: expect.stringMatching(/^[\da-f]{64}$/u),
+        }),
+      ]);
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps LOAD wire output identical while accounting for omission and resend reasons', async () => {
+    const run = async (telemetryEnabled: boolean) => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+      const entry = join(root, 'entry.js');
+      const dependency = 'virtual:dependency.js';
+      writeFileSync(entry, 'export const __wywPreval = {};');
+      const emitter = createEmitter();
+      const records: EvalTelemetryRecord[] = [];
+      const unregister = telemetryEnabled
+        ? registerEvalTelemetryReporter(emitter, (record) => {
+            records.push(record);
+          })
+        : () => {};
+      const services = createServices(root, entry, emitter);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => dependency)
+      );
+      const privateBroker = broker as unknown as {
+        activeEvalTelemetry: EvalTelemetryToken | undefined;
+        handleLoad: (
+          id: string,
+          payload: {
+            id: string;
+            importerId: string | null;
+            request: string | null;
+          }
+        ) => Promise<void>;
+        loadMirror: { snapshot: () => EvalBrokerMirrorSnapshot };
+        loadModule: jest.Mock;
+        runnerInputQueue: { write: (payload: string) => Promise<void> };
+      };
+      const trace: string[] = [];
+      privateBroker.runnerInputQueue = {
+        write: async (payload) => {
+          trace.push(payload);
+        },
+      };
+      const code1 = 'export const value = 1;';
+      const code2 = 'export const value = 2;';
+      const code3 = 'export const value = 3;';
+      const prepared = [
+        { code: code1, hash: 'hash-1', imports: null, only: ['*'] },
+        { code: code1, hash: 'hash-1', imports: null, only: ['*'] },
+        { code: code2, hash: 'hash-2', imports: null, only: ['*'] },
+        { code: code3, hash: 'hash-3', imports: null, only: ['value'] },
+        {
+          code: code3,
+          hash: 'hash-3',
+          imports: null,
+          only: ['value', 'other'],
+        },
+        { code: code3, hash: 'hash-3', imports: null, only: ['*'] },
+        { code: '', hash: 'hash-4', imports: null, only: ['*'] },
+        { code: '', hash: 'hash-5', imports: null, only: [] },
+      ];
+      privateBroker.loadModule = jest.fn(async () => prepared.shift()!);
+      const token = telemetryEnabled
+        ? beginEvalTelemetry(emitter, broker, () => ({ entrypoint: entry }))
+        : undefined;
+      token?.start({ batchIndex: 0, batchSize: 1 });
+      privateBroker.activeEvalTelemetry = token;
+
+      try {
+        for (let index = 0; index < 8; index += 1) {
+          // The mirror state under test is intentionally sequential.
+          // eslint-disable-next-line no-await-in-loop
+          await privateBroker.handleLoad(`load-${index}`, {
+            id: dependency,
+            importerId: entry,
+            request: './dependency.js',
+          });
+        }
+        token?.finish('success', privateBroker.loadMirror.snapshot());
+        return { code1, code2, code3, records, trace };
+      } finally {
+        privateBroker.activeEvalTelemetry = undefined;
+        unregister();
+        broker.dispose();
+        rmSync(root, { recursive: true, force: true });
+      }
+    };
+
+    const withoutTelemetry = await run(false);
+    const withTelemetry = await run(true);
+    expect(withTelemetry.trace).toEqual(withoutTelemetry.trace);
+
+    const wire = withTelemetry.trace.map((line) => JSON.parse(line));
+    expect(wire).toHaveLength(8);
+    expect(wire[0].payload.code).toBe(withTelemetry.code1);
+    expect(wire[1].payload).not.toHaveProperty('code');
+    expect(wire[6].payload).toHaveProperty('code', '');
+    expect(wire[7].payload).toHaveProperty('code', '');
+
+    const roots = withTelemetry.records.filter(
+      (record) => record.type === 'eval-root'
+    );
+    expect(roots).toHaveLength(1);
+    const [record] = roots;
+    expect(record.loads.requests).toBe(8);
+    expect(record.loads.transmission).toEqual(
+      expect.objectContaining({
+        chunkedResults: 0,
+        chunks: 0,
+        codeBytes:
+          Buffer.byteLength(withTelemetry.code1) +
+          Buffer.byteLength(withTelemetry.code2) +
+          Buffer.byteLength(withTelemetry.code3) * 3,
+        emptyCodePayloads: 2,
+        initial: 1,
+        logicalResults: 8,
+        omissions: 1,
+        resendReasons: {
+          'hash-change': 4,
+          'only-widening': 1,
+          'storage-shape-change': 1,
+        },
+        resends: 6,
+        serializedExports: 0,
+        wireMessages: 8,
+      })
+    );
+    expect(record.loads.transmission.wireBytes).toBe(
+      withTelemetry.trace.reduce(
+        (total, line) => total + Buffer.byteLength(line),
+        0
+      )
+    );
+    expect(record.evictions.primaryPressureProxy.shipmentHashChanges).toBe(2);
+    expect(record.evictions.variantPressureProxy.shipmentHashChanges).toBe(2);
+    expect(record.mirror).toEqual({
+      entries: 1,
+      knownCodeBytes: 0,
+      unknownByteEntries: 0,
+    });
+  });
+
+  it('keeps telemetry-only timing and byte scans off the broker fast path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const services = createServices(root, entry, EventEmitter.dummy);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      handleLoad: (
+        id: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      loadModule: jest.Mock;
+      runnerInputQueue: { write: (payload: string) => Promise<void> };
+    };
+    privateBroker.loadModule = jest.fn(async () => ({
+      code: 'export const value = 1;',
+      hash: 'hash-1',
+      imports: new Map([['./nested.js', ['value']]]),
+      only: ['*'],
+    }));
+    privateBroker.runnerInputQueue = { write: async () => {} };
+    const now = jest.spyOn(performance, 'now');
+    const byteLength = jest.spyOn(Buffer, 'byteLength');
+    const nowCallsBefore = now.mock.calls.length;
+    const byteLengthCallsBefore = byteLength.mock.calls.length;
+
+    try {
+      await privateBroker.handleLoad('load-1', {
+        id: join(root, 'dependency.js'),
+        importerId: entry,
+        request: './dependency.js',
+      });
+
+      expect(now.mock.calls).toHaveLength(nowCallsBefore);
+      expect(byteLength.mock.calls).toHaveLength(byteLengthCallsBefore);
+    } finally {
+      now.mockRestore();
+      byteLength.mockRestore();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('accounts for a delivered LOAD error response', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const services = createServices(root, entry, emitter);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      handleMessage: (message: unknown) => void;
+      loadModule: jest.Mock;
+      runnerInputQueue: { write: (payload: string) => Promise<void> };
+    };
+    const trace: string[] = [];
+    privateBroker.runnerInputQueue = {
+      write: async (payload) => {
+        trace.push(payload);
+      },
+    };
+    privateBroker.loadModule = jest.fn(async () => {
+      throw new Error('load-failed');
+    });
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+
+    try {
+      privateBroker.handleMessage({
+        id: 'load-error',
+        payload: {
+          id: 'virtual:broken.js',
+          importerId: entry,
+          request: './broken.js',
+        },
+        type: 'LOAD',
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      token!.finish('error');
+
+      expect(trace).toHaveLength(1);
+      expect(JSON.parse(trace[0]).payload.error).toEqual(
+        expect.objectContaining({ message: 'load-failed' })
+      );
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.requests).toBe(1);
+      expect(roots[0].loads.transmission).toEqual(
+        expect.objectContaining({
+          errors: 1,
+          incompleteResults: 0,
+          logicalResults: 1,
+          wireBytes: Buffer.byteLength(trace[0]),
+          wireMessages: 1,
+        })
+      );
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('records serialized-export LOAD outcomes without preparing code', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    const dependency = join(root, 'dependency.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const services = createServices(root, entry, emitter);
+    services.cache.add('exports', dependency, ['value']);
+    services.cache.add('entrypoints', dependency, {
+      evaluated: true,
+      evaluatedOnly: ['value'],
+      exports: { value: 42 },
+      ignored: false,
+    } as never);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dependency)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      handleLoad: (
+        id: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      onlyByModule: Map<string, string[]>;
+      runnerInputQueue: { write: (payload: string) => Promise<void> };
+    };
+    const trace: string[] = [];
+    privateBroker.runnerInputQueue = {
+      write: async (payload) => {
+        trace.push(payload);
+      },
+    };
+    privateBroker.onlyByModule.set(dependency, ['value']);
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+
+    try {
+      await privateBroker.handleLoad('load-serialized', {
+        id: dependency,
+        importerId: null,
+        request: null,
+      });
+      token!.finish('success');
+
+      expect(trace).toHaveLength(1);
+      expect(JSON.parse(trace[0]).payload).toEqual(
+        expect.objectContaining({
+          exports: expect.objectContaining({ value: expect.any(Object) }),
+        })
+      );
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.cache.serializedExports).toBe(1);
+      expect(roots[0].loads.preparation.calls).toBe(0);
+      expect(roots[0].loads.transmission).toEqual(
+        expect.objectContaining({
+          logicalResults: 1,
+          serializedExports: 1,
+          wireBytes: Buffer.byteLength(trace[0]),
+          wireMessages: 1,
+        })
+      );
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('observes existing poison and reset signals and keeps the mirror exact', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const services = createServices(root, entry, emitter);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      activeEvalTelemetry: EvalTelemetryToken | undefined;
+      handleLoad: (
+        id: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      handleMessage: (message: unknown) => void;
+      loadMirror: { snapshot: () => EvalBrokerMirrorSnapshot };
+      loadModule: jest.Mock;
+      runnerInputQueue: { write: (payload: string) => Promise<void> };
+    };
+    privateBroker.runnerInputQueue = { write: async () => {} };
+    privateBroker.loadModule = jest
+      .fn()
+      .mockResolvedValueOnce({
+        code: 'export const a = 1;',
+        hash: 'hash-a',
+        imports: null,
+        only: ['*'],
+      })
+      .mockResolvedValueOnce({
+        code: 'export const b = 2;',
+        hash: 'hash-b',
+        imports: null,
+        only: ['*'],
+      });
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    privateBroker.activeEvalTelemetry = token;
+
+    try {
+      await privateBroker.handleLoad('load-a', {
+        id: 'virtual:a.js',
+        importerId: entry,
+        request: './a.js',
+      });
+      await privateBroker.handleLoad('load-b', {
+        id: 'virtual:b.js',
+        importerId: entry,
+        request: './b.js',
+      });
+      privateBroker.handleMessage({
+        id: 'eval-result',
+        payload: { evictedIds: ['virtual:a.js', 'virtual:a.js'], values: null },
+        type: 'EVAL_RESULT',
+      });
+      privateBroker.handleMessage({
+        id: 'init-result',
+        modulesReset: true,
+        type: 'INIT_ACK',
+      });
+      token!.finish('success', privateBroker.loadMirror.snapshot());
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].evictions).toEqual(
+        expect.objectContaining({
+          brokerObservedPoisonIds: 1,
+          brokerObservedPoisonSignals: 1,
+          brokerObservedResetSignals: 1,
+        })
+      );
+      expect(roots[0].mirror).toEqual({
+        entries: 0,
+        knownCodeBytes: 0,
+        unknownByteEntries: 0,
+      });
+    } finally {
+      privateBroker.activeEvalTelemetry = undefined;
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('records broker registry create, reuse, and disposal observations', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const services = createServices(root, entry, emitter);
+    const resolve = jest.fn(async () => null);
+
+    try {
+      const first = getEvalBroker(services, resolve, 'stable-key');
+      expect(getEvalBroker(services, resolve, 'stable-key')).toBe(first);
+      disposeEvalBroker(services.cache);
+
+      const lifecycle = records.filter(
+        (record) => record.type === 'eval-lifecycle'
+      );
+      expect(lifecycle.map((record) => record.event)).toEqual([
+        'broker-created',
+        'broker-reused',
+        'broker-dispose-observed',
+      ]);
+      expect(lifecycle.map((record) => record.reason)).toEqual([
+        'constructor',
+        'stable-cache-key',
+        'registry-dispose',
+      ]);
+      expect(lifecycle.every((record) => record.brokerId === 1)).toBe(true);
+    } finally {
+      disposeEvalBroker(services.cache);
+      unregister();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves EvaluateResult and observes the real runner lifecycle', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(
+      entry,
+      ['export const __wywPreval = {', '  value: () => 42,', '};'].join('\n')
+    );
+
+    const run = async (telemetryEnabled: boolean) => {
+      const emitter = createEmitter();
+      const records: EvalTelemetryRecord[] = [];
+      const unregister = telemetryEnabled
+        ? registerEvalTelemetryReporter(emitter, (record) => {
+            records.push(record);
+          })
+        : () => {};
+      const services = createServices(root, entry, emitter);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoint = Entrypoint.createRoot(
+        services,
+        entry,
+        ['__wywPreval'],
+        readFileSync(entry, 'utf8')
+      );
+
+      try {
+        return { records, result: await broker.evaluate(entrypoint) };
+      } finally {
+        broker.dispose('test-complete');
+        unregister();
+      }
+    };
+
+    try {
+      const withoutTelemetry = await run(false);
+      const withTelemetry = await run(true);
+      expect(Array.from(withTelemetry.result.values ?? [])).toEqual(
+        Array.from(withoutTelemetry.result.values ?? [])
+      );
+      expect(withTelemetry.result.dependencies).toEqual(
+        withoutTelemetry.result.dependencies
+      );
+
+      const lifecycle = withTelemetry.records.filter(
+        (record) => record.type === 'eval-lifecycle'
+      );
+      expect(lifecycle.map((record) => [record.event, record.reason])).toEqual([
+        ['broker-created', 'constructor'],
+        ['runner-spawn-attempt', 'ensure'],
+        ['runner-activated', 'ensure'],
+        ['broker-dispose-observed', 'test-complete'],
+        ['runner-stop-requested', 'test-complete'],
+      ]);
+      expect(
+        withTelemetry.records.filter((record) => record.type === 'eval-root')
+      ).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('attributes first runner activation to the services that requested it', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(
+      entry,
+      ['export const __wywPreval = {', '  value: () => 42,', '};'].join('\n')
+    );
+    const previousEmitter = createEmitter();
+    const activeEmitter = createEmitter();
+    const previousRecords: EvalTelemetryRecord[] = [];
+    const activeRecords: EvalTelemetryRecord[] = [];
+    const unregisterPrevious = registerEvalTelemetryReporter(
+      previousEmitter,
+      (record) => previousRecords.push(record)
+    );
+    const unregisterActive = registerEvalTelemetryReporter(
+      activeEmitter,
+      (record) => activeRecords.push(record)
+    );
+    const previousServices = createServices(root, entry, previousEmitter);
+    const activeServices = {
+      ...previousServices,
+      eventEmitter: activeEmitter,
+    };
+    const broker = new EvalBroker(
+      previousServices,
+      jest.fn(async () => null)
+    );
+    const entrypoint = Entrypoint.createRoot(
+      activeServices,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf8')
+    );
+
+    try {
+      await broker.evaluate(entrypoint, activeServices);
+
+      expect(
+        previousRecords
+          .filter((record) => record.type === 'eval-lifecycle')
+          .map((record) => record.event)
+      ).toEqual(['broker-created']);
+      expect(
+        activeRecords
+          .filter((record) => record.type === 'eval-lifecycle')
+          .map((record) => record.event)
+      ).toEqual(['runner-spawn-attempt', 'runner-activated']);
+      expect(
+        activeRecords.filter((record) => record.type === 'eval-root')
+      ).toHaveLength(1);
+    } finally {
+      broker.dispose('test-complete');
+      unregisterPrevious();
+      unregisterActive();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('observes runner replacement and exit without changing child handling', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const services = createServices(root, entry, emitter);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      replaceRunner: (runner: unknown) => void;
+      runner: unknown;
+    };
+    const createFakeRunner = () => {
+      const runner = new NodeEventEmitter() as NodeEventEmitter & {
+        kill: jest.Mock;
+        stderr: PassThrough;
+        stdin: PassThrough;
+        stdout: PassThrough;
+      };
+      runner.kill = jest.fn();
+      runner.stderr = new PassThrough();
+      runner.stdin = new PassThrough();
+      runner.stdout = new PassThrough();
+      return runner;
+    };
+    const previous = createFakeRunner();
+    const next = createFakeRunner();
+    privateBroker.runner = previous;
+
+    try {
+      privateBroker.replaceRunner(next);
+      expect(previous.kill).toHaveBeenCalledTimes(1);
+      next.emit('exit', 17, null);
+
+      const lifecycle = records.filter(
+        (record) => record.type === 'eval-lifecycle'
+      );
+      expect(lifecycle.map((record) => record.event)).toEqual([
+        'broker-created',
+        'runner-stop-requested',
+        'runner-activated',
+        'runner-exit-observed',
+      ]);
+      expect(lifecycle[1]).toEqual(
+        expect.objectContaining({ reason: 'happy-dom-replacement' })
+      );
+      expect(lifecycle[2]).toEqual(
+        expect.objectContaining({
+          reason: 'happy-dom-replacement',
+          restartInferred: false,
+        })
+      );
+      expect(lifecycle[3].reason).toContain('17 / null');
+      expect(privateBroker.runner).toBeNull();
+    } finally {
+      broker.dispose();
+      unregister();
+      [previous, next].forEach((runner) => {
+        runner.stdin.destroy();
+        runner.stdout.destroy();
+        runner.stderr.destroy();
+      });
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('counts physical chunk messages and serialized UTF-8 bytes once', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-telemetry-'));
+    const entry = join(root, 'entry.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const services = createServices(root, entry, emitter);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = broker as unknown as {
+      runnerInputQueue: { write: (payload: string) => Promise<void> };
+      sendLoadResult: (
+        id: string,
+        payload: {
+          code: string;
+          hash: string;
+          id: string;
+          map: null;
+          only: string[];
+        },
+        telemetry: {
+          details: {
+            code: string;
+            imports: Map<string, string[]>;
+            mode: 'initial';
+          };
+          token: EvalTelemetryToken;
+        }
+      ) => Promise<void>;
+    };
+    const trace: string[] = [];
+    privateBroker.runnerInputQueue = {
+      write: async (payload) => {
+        trace.push(payload);
+      },
+    };
+    const token = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: entry,
+    }));
+    expect(token).toBeDefined();
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    const code = 'x'.repeat(10 * 1024 * 1024);
+
+    try {
+      await privateBroker.sendLoadResult(
+        'load-chunked',
+        { code, hash: 'chunked-hash', id: entry, map: null, only: ['*'] },
+        {
+          details: {
+            code,
+            mode: 'initial',
+          },
+          token: token!,
+        }
+      );
+      token!.finish('success');
+
+      expect(trace).toHaveLength(20);
+      const wire = trace.map((line) => JSON.parse(line));
+      expect(wire[0].payload).toEqual(
+        expect.objectContaining({
+          chunkCount: 20,
+          chunkIndex: 0,
+          hash: 'chunked-hash',
+          only: ['*'],
+        })
+      );
+      expect(wire[1].payload).not.toHaveProperty('hash');
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.transmission).toEqual(
+        expect.objectContaining({
+          chunkedResults: 1,
+          chunks: 20,
+          codeBytes: Buffer.byteLength(code),
+          initial: 1,
+          logicalResults: 1,
+          wireBytes: trace.reduce(
+            (total, line) => total + Buffer.byteLength(line),
+            0
+          ),
+          wireMessages: 20,
+        })
+      );
+
+      const partial = beginEvalTelemetry(emitter, broker, () => ({
+        entrypoint: entry,
+      }));
+      expect(partial).toBeDefined();
+      partial!.start({ batchIndex: 0, batchSize: 1 });
+      const partialTrace: string[] = [];
+      let writeAttempt = 0;
+      privateBroker.runnerInputQueue = {
+        write: async (payload) => {
+          writeAttempt += 1;
+          if (writeAttempt === 2) throw new Error('chunk-write-failed');
+          partialTrace.push(payload);
+        },
+      };
+      await expect(
+        privateBroker.sendLoadResult(
+          'load-partial',
+          {
+            code,
+            hash: 'partial-hash',
+            id: entry,
+            map: null,
+            only: ['*'],
+          },
+          {
+            details: { code, mode: 'initial' },
+            token: partial!,
+          }
+        )
+      ).rejects.toThrow('chunk-write-failed');
+      partial!.finish('error');
+
+      const completedRoots = records.filter(
+        (record) => record.type === 'eval-root'
+      );
+      expect(completedRoots).toHaveLength(2);
+      expect(completedRoots[1].loads.transmission).toEqual(
+        expect.objectContaining({
+          chunks: 1,
+          codeBytes: 512 * 1024,
+          incompleteResults: 1,
+          logicalResults: 0,
+          wireBytes: Buffer.byteLength(partialTrace[0]),
+          wireMessages: 1,
+        })
+      );
+
+      const firstWriteFailure = beginEvalTelemetry(emitter, broker, () => ({
+        entrypoint: entry,
+      }));
+      expect(firstWriteFailure).toBeDefined();
+      firstWriteFailure!.start({ batchIndex: 0, batchSize: 1 });
+      privateBroker.runnerInputQueue = {
+        write: async () => {
+          throw new Error('first-write-failed');
+        },
+      };
+      await expect(
+        privateBroker.sendLoadResult(
+          'load-first-write-failure',
+          {
+            code,
+            hash: 'first-write-failure-hash',
+            id: entry,
+            map: null,
+            only: ['*'],
+          },
+          {
+            details: { code, mode: 'initial' },
+            token: firstWriteFailure!,
+          }
+        )
+      ).rejects.toThrow('first-write-failed');
+      firstWriteFailure!.finish('error');
+
+      const allRoots = records.filter((record) => record.type === 'eval-root');
+      expect(allRoots).toHaveLength(3);
+      expect(allRoots[2].loads.transmission).toEqual(
+        expect.objectContaining({
+          chunks: 0,
+          codeBytes: 0,
+          incompleteResults: 1,
+          logicalResults: 0,
+          wireBytes: 0,
+          wireMessages: 0,
+        })
+      );
+    } finally {
+      unregister();
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -4945,7 +4945,7 @@ describe('EvalBroker', () => {
       initRunner: (entrypoint: Entrypoint) => Promise<void>;
       lastInitKey: string | null;
       lastHappyDomEnabled: boolean;
-      lastSentLoadByModule: Map<string, { hash: string; only: string[] }>;
+      loadMirror: { snapshot: () => { entries: number } };
       onlyByModule: Map<string, string[]>;
       request: (
         type: string,
@@ -4998,7 +4998,7 @@ describe('EvalBroker', () => {
     // Switch to a different entrypoint — initKey changes but globals/happyDOM
     // are identical, so the runner keeps moduleCache and our mirror must too.
     await privateBroker.initRunner(entrypointB);
-    expect(privateBroker.lastSentLoadByModule.size).toBeGreaterThan(0);
+    expect(privateBroker.loadMirror.snapshot().entries).toBeGreaterThan(0);
 
     await privateBroker.handleLoad('msg-2', {
       id: dep,

--- a/packages/transform/src/__tests__/eval-lru.test.ts
+++ b/packages/transform/src/__tests__/eval-lru.test.ts
@@ -1,0 +1,29 @@
+import { LruCache } from '../eval/lru';
+
+describe('eval LruCache', () => {
+  it('reports the exact capacity eviction without changing LRU order', () => {
+    const cache = new LruCache<string, number>(2);
+
+    const evictions: Array<{ key: string; value: number }> = [];
+    cache.set('a', 1, (key, value) => evictions.push({ key, value }));
+    cache.set('b', 2, (key, value) => evictions.push({ key, value }));
+    expect(cache.get('a')).toBe(1);
+    cache.set('c', 3, (key, value) => evictions.push({ key, value }));
+    expect(evictions).toEqual([{ key: 'b', value: 2 }]);
+    expect(cache.size).toBe(2);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.has('c')).toBe(true);
+  });
+
+  it('does not report replacement of an existing key as eviction', () => {
+    const cache = new LruCache<string, number>(1);
+
+    cache.set('a', 1);
+    const onEvict = jest.fn();
+    cache.set('a', 2, onEvict);
+    expect(onEvict).not.toHaveBeenCalled();
+    expect(cache.get('a')).toBe(2);
+    expect(cache.size).toBe(1);
+  });
+});

--- a/packages/transform/src/__tests__/evalTelemetry.test.ts
+++ b/packages/transform/src/__tests__/evalTelemetry.test.ts
@@ -1,0 +1,667 @@
+import { EventEmitter } from '../utils/EventEmitter';
+import {
+  beginEvalTelemetry,
+  EVAL_TELEMETRY_SCHEMA,
+  measureCanonicalImportMapBytes,
+  recordEvalBrokerLifecycle,
+  registerEvalTelemetryReporter,
+  type EvalTelemetryRecord,
+} from '../debug/evalTelemetry';
+import { serializeEvalTelemetryJSONl } from '../debug/evalTelemetry.jsonl';
+import { EVAL_PREPARATION_ARTIFACT_LIMIT } from '../debug/evalTelemetry.types';
+
+const createEmitter = () =>
+  new EventEmitter(
+    () => {},
+    (() => 0) as never,
+    () => {}
+  );
+
+describe('eval telemetry', () => {
+  const captureRoot = (entrypoint: string): EvalTelemetryRecord => {
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const token = beginEvalTelemetry(emitter, {}, () => ({ entrypoint }));
+    token!.start({ batchIndex: 0, batchSize: 1 });
+    token!.finish('success');
+    unregister();
+    return records[0];
+  };
+
+  it('does not evaluate lazy metadata without a registered reporter', () => {
+    const emitter = createEmitter();
+    const broker = {};
+    let rootMetadataCalls = 0;
+    let lifecycleMetadataCalls = 0;
+
+    const token = beginEvalTelemetry(emitter, broker, () => {
+      rootMetadataCalls += 1;
+      throw new Error('root metadata must stay lazy');
+    });
+    recordEvalBrokerLifecycle(emitter, broker, () => {
+      lifecycleMetadataCalls += 1;
+      throw new Error('lifecycle metadata must stay lazy');
+    });
+
+    expect(token).toBeUndefined();
+    expect(rootMetadataCalls).toBe(0);
+    expect(lifecycleMetadataCalls).toBe(0);
+  });
+
+  it('keeps root counters isolated and emits exact cache denominators', () => {
+    const emitter = createEmitter();
+    const broker = {};
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+
+    const first = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: '/repo/a.ts',
+    }));
+    const second = beginEvalTelemetry(emitter, broker, () => ({
+      entrypoint: '/repo/b.ts',
+    }));
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    first!.start({ batchIndex: 0, batchSize: 2 });
+    first!.recordLoadRequest();
+    first!.recordLoadCacheOutcome('miss');
+    const preparation = first!.beginPreparation('/repo/dep.ts', ['value']);
+    const shaken = preparation.measureStage('shake', () => 'shaken');
+    const stripped = preparation.measureStage('strip', () => `${shaken}!`);
+    preparation.finish({
+      code: 'export const value = "λ";',
+      imports: new Map([['./nested.ts', ['nested']]]),
+      only: ['value'],
+      outputRevision: 'revision-a',
+    });
+    expect(stripped).toBe('shaken!');
+    first!.finish('success', {
+      entries: 1,
+      knownCodeBytes: 26,
+      unknownByteEntries: 0,
+    });
+
+    second!.start({ batchIndex: 1, batchSize: 2 });
+    second!.recordLoadRequest();
+    second!.recordLoadCacheOutcome('hit');
+    second!.finish('no-values', {
+      entries: 1,
+      knownCodeBytes: 26,
+      unknownByteEntries: 0,
+    });
+    unregister();
+
+    const roots = records.filter((record) => record.type === 'eval-root');
+    expect(roots).toHaveLength(2);
+    expect(roots[0]).toEqual(
+      expect.objectContaining({
+        schemaVersion: 1,
+        root: expect.objectContaining({
+          batchIndex: 0,
+          batchSize: 2,
+          entrypoint: '/repo/a.ts',
+          status: 'success',
+        }),
+        loads: expect.objectContaining({
+          requests: 1,
+          cache: expect.objectContaining({
+            hits: 0,
+            misses: 1,
+          }),
+          preparation: expect.objectContaining({
+            calls: 1,
+            errors: 0,
+            preparedCodeBytes: Buffer.byteLength('export const value = "λ";'),
+            shakeCalls: 1,
+            stripCalls: 1,
+          }),
+        }),
+      })
+    );
+    if (roots[0].type !== 'eval-root') {
+      throw new Error('expected eval-root record');
+    }
+    expect(roots[0].loads.preparation.artifacts).toEqual([
+      expect.objectContaining({
+        calls: 1,
+        id: '/repo/dep.ts',
+        onlyShape: 'named',
+        outputRevision: 'revision-a',
+      }),
+    ]);
+
+    expect(roots[1]).toEqual(
+      expect.objectContaining({
+        root: expect.objectContaining({
+          batchIndex: 1,
+          entrypoint: '/repo/b.ts',
+          status: 'no-values',
+        }),
+        loads: expect.objectContaining({
+          requests: 1,
+          cache: expect.objectContaining({
+            hits: 1,
+            misses: 0,
+          }),
+          preparation: expect.objectContaining({ calls: 0 }),
+        }),
+      })
+    );
+  });
+
+  it('measures synchronous stage success and throw exactly', () => {
+    let clock = 0;
+    const now = jest.spyOn(performance, 'now').mockImplementation(() => clock);
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const failure = new Error('strip failed');
+
+    try {
+      const token = beginEvalTelemetry(emitter, {}, () => ({
+        entrypoint: '/repo/root.ts',
+      }));
+      clock = 5;
+      token!.start({ batchIndex: 0, batchSize: 1 });
+      clock = 10;
+      const preparation = token!.beginPreparation('/repo/dep.ts', ['value']);
+
+      clock = 20;
+      expect(
+        preparation.measureStage('shake', () => {
+          clock = 26;
+          return 'shaken';
+        })
+      ).toBe('shaken');
+
+      clock = 30;
+      expect(() =>
+        preparation.measureStage('strip', () => {
+          clock = 39;
+          throw failure;
+        })
+      ).toThrow(failure);
+
+      clock = 50;
+      preparation.fail();
+      clock = 60;
+      token!.finish('error');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.preparation).toEqual({
+        artifacts: [
+          {
+            calls: 1,
+            durationMs: 40,
+            errors: 1,
+            id: '/repo/dep.ts',
+            importMapBytes: 0,
+            onlyShape: 'named',
+            outputRevision: null,
+            prepareCalls: 0,
+            prepareMs: 0,
+            preparedCodeBytes: 0,
+            shakeCalls: 1,
+            shakeMs: 6,
+            stripCalls: 1,
+            stripMs: 9,
+          },
+        ],
+        calls: 1,
+        droppedArtifacts: 0,
+        durationMs: 40,
+        errors: 1,
+        importMapBytes: 0,
+        prepareCalls: 0,
+        prepareMs: 0,
+        preparedCodeBytes: 0,
+        shakeCalls: 1,
+        shakeMs: 6,
+        stripCalls: 1,
+        stripMs: 9,
+      });
+    } finally {
+      unregister();
+      now.mockRestore();
+    }
+  });
+
+  it('aggregates a repeated preparation before and after adding a distinct artifact', () => {
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const token = beginEvalTelemetry(emitter, {}, () => ({
+      entrypoint: '/repo/root.ts',
+    }));
+    const finishPreparation = (id: string, outputRevision: string) => {
+      token!.beginPreparation(id, ['value']).finish({
+        code: `export const value = '${id}';`,
+        imports: null,
+        only: ['value'],
+        outputRevision,
+      });
+    };
+
+    try {
+      token!.start({ batchIndex: 0, batchSize: 1 });
+      finishPreparation('/repo/repeated.ts', 'revision-a');
+      finishPreparation('/repo/repeated.ts', 'revision-a');
+      finishPreparation('/repo/distinct.ts', 'revision-b');
+      finishPreparation('/repo/repeated.ts', 'revision-a');
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.preparation.artifacts).toEqual([
+        expect.objectContaining({
+          calls: 3,
+          id: '/repo/repeated.ts',
+          outputRevision: 'revision-a',
+        }),
+        expect.objectContaining({
+          calls: 1,
+          id: '/repo/distinct.ts',
+          outputRevision: 'revision-b',
+        }),
+      ]);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('keeps lazy artifact merging equivalent for null and empty revisions', () => {
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const token = beginEvalTelemetry(emitter, {}, () => ({
+      entrypoint: '/repo/root.ts',
+    }));
+
+    try {
+      token!.start({ batchIndex: 0, batchSize: 1 });
+      token!.beginPreparation('/repo/dep.ts', ['value']).fail();
+      token!.beginPreparation('/repo/dep.ts', ['value']).finish({
+        code: 'export const value = 1;',
+        imports: null,
+        only: ['value'],
+        outputRevision: '',
+      });
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.preparation.artifacts).toEqual([
+        expect.objectContaining({
+          calls: 2,
+          errors: 1,
+          id: '/repo/dep.ts',
+          outputRevision: null,
+        }),
+      ]);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('merges existing artifacts and drops only new keys at the artifact limit', () => {
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const token = beginEvalTelemetry(emitter, {}, () => ({
+      entrypoint: '/repo/root.ts',
+    }));
+    const finishPreparation = (id: string, outputRevision: string) => {
+      token!.beginPreparation(id, ['value']).finish({
+        code: `export const value = '${id}';`,
+        imports: null,
+        only: ['value'],
+        outputRevision,
+      });
+    };
+
+    try {
+      token!.start({ batchIndex: 0, batchSize: 1 });
+      for (let index = 0; index < EVAL_PREPARATION_ARTIFACT_LIMIT; index += 1) {
+        finishPreparation(`/repo/dep-${index}.ts`, `revision-${index}`);
+      }
+      finishPreparation('/repo/dep-0.ts', 'revision-0');
+      finishPreparation('/repo/overflow.ts', 'overflow-revision');
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      const [
+        {
+          loads: { preparation },
+        },
+      ] = roots;
+      expect(preparation.artifacts).toHaveLength(
+        EVAL_PREPARATION_ARTIFACT_LIMIT
+      );
+      expect(preparation.artifacts[0]).toEqual(
+        expect.objectContaining({ calls: 2, id: '/repo/dep-0.ts' })
+      );
+      expect(preparation.droppedArtifacts).toBe(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('does not double count a Promise handler that settles and then throws', () => {
+    let clock = 0;
+    const now = jest.spyOn(performance, 'now').mockImplementation(() => clock);
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const failure = new Error('hostile then');
+
+    try {
+      const token = beginEvalTelemetry(emitter, {}, () => ({
+        entrypoint: '/repo/root.ts',
+      }));
+      clock = 5;
+      token!.start({ batchIndex: 0, batchSize: 1 });
+      clock = 8;
+      const preparation = token!.beginPreparation('/repo/dep.ts', ['value']);
+      const hostile = Promise.resolve('value');
+      hostile.then = ((
+        onFulfilled?: ((value: string) => unknown) | null
+      ): never => {
+        clock = 20;
+        onFulfilled?.('value');
+        clock = 30;
+        throw failure;
+      }) as typeof hostile.then;
+
+      clock = 10;
+      expect(() => preparation.measureStage('shake', () => hostile)).toThrow(
+        failure
+      );
+      clock = 40;
+      preparation.fail();
+      clock = 50;
+      token!.finish('error');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].loads.preparation).toEqual(
+        expect.objectContaining({
+          shakeCalls: 1,
+          shakeMs: 10,
+        })
+      );
+    } finally {
+      unregister();
+      now.mockRestore();
+    }
+  });
+
+  it('measures Promise settlement once and ignores settlement after root close', async () => {
+    let clock = 0;
+    const now = jest.spyOn(performance, 'now').mockImplementation(() => clock);
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+    const rejection = new Error('async strip failed');
+
+    try {
+      const token = beginEvalTelemetry(emitter, {}, () => ({
+        entrypoint: '/repo/root.ts',
+      }));
+      clock = 5;
+      token!.start({ batchIndex: 0, batchSize: 1 });
+
+      clock = 10;
+      const resolvedPreparation = token!.beginPreparation('/repo/resolved.ts', [
+        'value',
+      ]);
+      let resolveStage: ((value: string) => void) | undefined;
+      const resolvedStage = new Promise<string>((resolve) => {
+        resolveStage = resolve;
+      });
+      clock = 20;
+      const measuredResolved = resolvedPreparation.measureStage(
+        'shake',
+        () => resolvedStage
+      );
+      expect(measuredResolved).toBe(resolvedStage);
+      clock = 32;
+      resolveStage?.('resolved');
+      await expect(measuredResolved).resolves.toBe('resolved');
+      clock = 40;
+      resolvedPreparation.finish({
+        code: 'export const value = 1;',
+        imports: null,
+        only: ['value'],
+        outputRevision: 'resolved-revision',
+      });
+
+      clock = 50;
+      const rejectedPreparation = token!.beginPreparation('/repo/rejected.ts', [
+        'value',
+      ]);
+      let rejectStage: ((reason?: unknown) => void) | undefined;
+      const rejectedStage = new Promise<never>((_resolve, reject) => {
+        rejectStage = reject;
+      });
+      clock = 60;
+      const measuredRejected = rejectedPreparation.measureStage(
+        'strip',
+        () => rejectedStage
+      );
+      expect(measuredRejected).toBe(rejectedStage);
+      clock = 73;
+      rejectStage?.(rejection);
+      await expect(measuredRejected).rejects.toBe(rejection);
+      clock = 80;
+      rejectedPreparation.fail();
+
+      clock = 90;
+      const latePreparation = token!.beginPreparation('/repo/late.ts', [
+        'value',
+      ]);
+      let resolveLateStage: ((value: string) => void) | undefined;
+      const lateStage = new Promise<string>((resolve) => {
+        resolveLateStage = resolve;
+      });
+      clock = 100;
+      const measuredLate = latePreparation.measureStage(
+        'prepare',
+        () => lateStage
+      );
+      clock = 110;
+      latePreparation.finish({
+        code: 'export const value = 2;',
+        imports: null,
+        only: ['value'],
+        outputRevision: 'late-revision',
+      });
+      clock = 120;
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      const [record] = roots;
+      expect(record.loads.preparation).toEqual(
+        expect.objectContaining({
+          calls: 3,
+          errors: 1,
+          prepareCalls: 1,
+          prepareMs: 0,
+          shakeCalls: 1,
+          shakeMs: 12,
+          stripCalls: 1,
+          stripMs: 13,
+        })
+      );
+      expect(record.loads.preparation.artifacts).toEqual([
+        expect.objectContaining({
+          errors: 0,
+          id: '/repo/resolved.ts',
+          shakeCalls: 1,
+          shakeMs: 12,
+        }),
+        expect.objectContaining({
+          errors: 1,
+          id: '/repo/rejected.ts',
+          stripCalls: 1,
+          stripMs: 13,
+        }),
+        expect.objectContaining({
+          errors: 0,
+          id: '/repo/late.ts',
+          prepareCalls: 1,
+          prepareMs: 0,
+        }),
+      ]);
+
+      const emittedSnapshot = JSON.parse(JSON.stringify(record));
+      now.mockClear();
+      clock = 150;
+      resolveLateStage?.('late');
+      const lateValue = await measuredLate;
+      const clockReadsAfterClose = now.mock.calls.length;
+      expect(lateValue).toBe('late');
+      expect(clockReadsAfterClose).toBe(0);
+      expect(record).toEqual(emittedSnapshot);
+    } finally {
+      unregister();
+      now.mockRestore();
+    }
+  });
+
+  it('separates queue wait from execution duration', () => {
+    const now = jest
+      .spyOn(performance, 'now')
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(25)
+      .mockReturnValueOnce(40);
+    const emitter = createEmitter();
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+
+    try {
+      const token = beginEvalTelemetry(emitter, {}, () => ({
+        entrypoint: '/repo/root.ts',
+      }));
+      token!.start({ batchIndex: 0, batchSize: 1 });
+      token!.finish('success');
+
+      const roots = records.filter((record) => record.type === 'eval-root');
+      expect(roots).toHaveLength(1);
+      expect(roots[0].root.queueWaitMs).toBe(15);
+      expect(roots[0].root.durationMs).toBe(15);
+    } finally {
+      unregister();
+      now.mockRestore();
+    }
+  });
+
+  it('scopes lifecycle inference to the reporter registration window', () => {
+    const emitter = createEmitter();
+    const broker = {};
+    const records: EvalTelemetryRecord[] = [];
+    const unregister = registerEvalTelemetryReporter(emitter, (record) => {
+      records.push(record);
+    });
+
+    recordEvalBrokerLifecycle(emitter, broker, () => ({
+      event: 'broker-created',
+      reason: 'constructor',
+    }));
+    recordEvalBrokerLifecycle(emitter, broker, () => ({
+      event: 'runner-activated',
+      reason: 'ensure',
+    }));
+    recordEvalBrokerLifecycle(emitter, broker, () => ({
+      event: 'runner-activated',
+      reason: 'happy-dom-replacement',
+    }));
+    unregister();
+    recordEvalBrokerLifecycle(emitter, broker, () => ({
+      event: 'broker-dispose-observed',
+      reason: 'after-reporter-close',
+    }));
+
+    const lifecycle = records.filter(
+      (record) => record.type === 'eval-lifecycle'
+    );
+    expect(lifecycle).toHaveLength(3);
+    expect(lifecycle.map((record) => record.brokerId)).toEqual([1, 1, 1]);
+    expect(lifecycle[1]).toEqual(
+      expect.objectContaining({ restartInferred: false })
+    );
+    expect(lifecycle[2]).toEqual(
+      expect.objectContaining({ restartInferred: true })
+    );
+  });
+
+  it.each([
+    ['/work/project/src/root.ts', '/work/project', 'src/root.ts'],
+    ['C:\\work\\project\\src\\root.ts', 'C:\\work\\project', 'src\\root.ts'],
+    ['D:\\private\\root.ts', 'C:\\work\\project', 'root.ts'],
+    [
+      '\\\\server-a\\project\\src\\root.ts',
+      '\\\\server-a\\project',
+      'src\\root.ts',
+    ],
+    ['\\\\server-b\\private\\root.ts', '\\\\server-a\\project', 'root.ts'],
+    ['//server-b/private/root.ts', '//server-a/project', 'root.ts'],
+    ['file:///Users/alice/private/root.ts', '/work/project', 'root.ts'],
+    ['\0virtual:/Users/alice/private/root.ts', '/work/project', 'root.ts'],
+    ['virtual:foo/bar.ts', '/work/project', 'virtual:foo/bar.ts'],
+    ['../private/root.ts', '/work/project', 'root.ts'],
+    ['..\\private\\root.ts', 'C:\\work\\project', 'root.ts'],
+  ])(
+    'serializes %s relative to %s without leaking private paths',
+    (entrypoint, workingDirectory, expected) => {
+      const serialized = serializeEvalTelemetryJSONl(
+        captureRoot(entrypoint),
+        workingDirectory
+      );
+      expect(JSON.parse(serialized).root.entrypoint).toBe(expected);
+    }
+  );
+
+  it('freezes the schema recursively', () => {
+    expect(Object.isFrozen(EVAL_TELEMETRY_SCHEMA)).toBe(true);
+    expect(Object.isFrozen(EVAL_TELEMETRY_SCHEMA.denominators)).toBe(true);
+    expect(Object.isFrozen(EVAL_TELEMETRY_SCHEMA.limitations)).toBe(true);
+  });
+
+  it('measures canonical import maps with sorted, deduplicated UTF-8 tuples', () => {
+    const imports = new Map([
+      ['./β.js', ['z', 'a', 'a']],
+      ['./a.js', ['*', '*']],
+    ]);
+    const canonical = [
+      ['./a.js', ['*']],
+      ['./β.js', ['a', 'z']],
+    ];
+
+    expect(measureCanonicalImportMapBytes(imports)).toBe(
+      Buffer.byteLength(JSON.stringify(canonical))
+    );
+  });
+});

--- a/packages/transform/src/__tests__/fileReporter.test.ts
+++ b/packages/transform/src/__tests__/fileReporter.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { createFileReporter } from '../debug/fileReporter';
+import { beginEvalTelemetry } from '../debug/evalTelemetry';
 import {
   beginPipelineShake,
   finishPipelineShake,
@@ -271,6 +272,90 @@ describe('createFileReporter', () => {
         ],
       ]);
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes eval telemetry schema and flushes an error root immediately', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    const reporter = createFileReporter({ dir });
+    const broker = {};
+    const target = join(dir, 'eval-telemetry.jsonl');
+
+    try {
+      const failed = beginEvalTelemetry(reporter.emitter, broker, () => ({
+        entrypoint: join(dir, 'failed-root.ts'),
+      }));
+      expect(failed).toBeDefined();
+      failed!.start({ batchIndex: 0, batchSize: 1 });
+      failed!.recordLoadRequest();
+      failed!.recordLoadCacheOutcome('miss');
+      const preparation = failed!.beginPreparation(join(dir, 'dep.ts'), [
+        'value',
+      ]);
+      preparation.finish({
+        code: 'export const value = "λ";',
+        imports: null,
+        only: ['value'],
+        outputRevision: 'prepared-hash',
+      });
+      failed!.finish('error');
+
+      await waitFor(() => hasJsonlLines(target, 2));
+
+      const succeeded = beginEvalTelemetry(reporter.emitter, broker, () => ({
+        entrypoint: join(dir, 'cached-root.ts'),
+      }));
+      expect(succeeded).toBeDefined();
+      succeeded!.start({ batchIndex: 0, batchSize: 1 });
+      succeeded!.recordLoadRequest();
+      succeeded!.recordLoadCacheOutcome('hit');
+      succeeded!.finish('success');
+
+      reporter.onDone(dir);
+      reporter.onDone(dir);
+      await waitFor(() => hasJsonlLines(target, 3));
+
+      const events = readJsonl(target);
+      expect(events).toHaveLength(3);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          denominators: expect.any(Object),
+          limitations: expect.any(Object),
+          schemaVersion: 1,
+          type: 'eval-telemetry-schema',
+        })
+      );
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          loads: expect.objectContaining({
+            cache: expect.objectContaining({ misses: 1 }),
+            preparation: expect.objectContaining({ calls: 1 }),
+            requests: 1,
+          }),
+          root: expect.objectContaining({
+            entrypoint: 'failed-root.ts',
+            status: 'error',
+          }),
+          type: 'eval-root',
+        })
+      );
+      expect(events[1].loads.preparation.artifacts[0].id).toBe('dep.ts');
+      expect(events[2]).toEqual(
+        expect.objectContaining({
+          loads: expect.objectContaining({
+            cache: expect.objectContaining({ hits: 1 }),
+            requests: 1,
+          }),
+          root: expect.objectContaining({
+            entrypoint: 'cached-root.ts',
+            status: 'success',
+          }),
+          type: 'eval-root',
+        })
+      );
+    } finally {
+      reporter.onDone(dir);
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/transform/src/debug/evalTelemetry.jsonl.ts
+++ b/packages/transform/src/debug/evalTelemetry.jsonl.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import { URL } from 'node:url';
+
+import type { EvalTelemetryRecord } from './evalTelemetry.types';
+
+const isWindowsPath = (value: string): boolean =>
+  /^(?:[A-Za-z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/u.test(value);
+
+const displayPath = (filename: string, workingDirectory: string): string => {
+  if (filename.startsWith('file:')) {
+    try {
+      const url = new URL(filename);
+      if (url.protocol !== 'file:') return path.basename(filename);
+      const decodedPathname = decodeURIComponent(url.pathname);
+      let filePath = decodedPathname;
+      if (/^[A-Za-z]:\//u.test(decodedPathname.slice(1))) {
+        filePath = decodedPathname.slice(1).replaceAll('/', '\\');
+      } else if (url.hostname) {
+        filePath = `\\\\${url.hostname}${decodedPathname.replaceAll(
+          '/',
+          '\\'
+        )}`;
+      }
+      return displayPath(filePath, workingDirectory);
+    } catch {
+      return filename.split(/[\\/]/u).at(-1) ?? filename;
+    }
+  }
+
+  // Opaque virtual ids stay intact, but an embedded absolute filesystem path
+  // is normalized through the same boundary policy as a regular filename.
+  if (filename.startsWith('\0') || filename.startsWith('virtual:')) {
+    const directPayload = filename.startsWith('virtual:')
+      ? filename.slice('virtual:'.length)
+      : filename.slice(1);
+    const separator = directPayload.indexOf(':');
+    let embeddedPayload: string | null = directPayload;
+    if (
+      !path.posix.isAbsolute(directPayload) &&
+      !path.win32.isAbsolute(directPayload)
+    ) {
+      embeddedPayload =
+        separator >= 0 ? directPayload.slice(separator + 1) : null;
+    }
+    if (
+      embeddedPayload &&
+      (path.posix.isAbsolute(embeddedPayload) ||
+        path.win32.isAbsolute(embeddedPayload))
+    ) {
+      return displayPath(embeddedPayload, workingDirectory);
+    }
+  }
+
+  const pathApi =
+    isWindowsPath(filename) || filename.includes('\\')
+      ? path.win32
+      : path.posix;
+  if (!pathApi.isAbsolute(filename)) {
+    const normalized = pathApi.normalize(filename);
+    return normalized === '..' || normalized.startsWith(`..${pathApi.sep}`)
+      ? pathApi.basename(filename)
+      : filename;
+  }
+  if (!pathApi.isAbsolute(workingDirectory)) {
+    return pathApi.basename(filename);
+  }
+
+  const relative = pathApi.relative(workingDirectory, filename);
+  return pathApi.isAbsolute(relative) || relative.startsWith('..')
+    ? pathApi.basename(filename)
+    : relative;
+};
+
+export const serializeEvalTelemetryJSONl = (
+  record: EvalTelemetryRecord,
+  workingDirectory: string
+): string => {
+  if (record.type === 'eval-lifecycle') {
+    return `${JSON.stringify(record)}\n`;
+  }
+
+  const entrypoint = displayPath(record.root.entrypoint, workingDirectory);
+  return `${JSON.stringify({
+    ...record,
+    loads: {
+      ...record.loads,
+      preparation: {
+        ...record.loads.preparation,
+        artifacts: record.loads.preparation.artifacts.map((artifact) => ({
+          ...artifact,
+          id:
+            artifact.id === record.root.entrypoint
+              ? entrypoint
+              : displayPath(artifact.id, workingDirectory),
+        })),
+      },
+    },
+    root: {
+      ...record.root,
+      entrypoint,
+    },
+  })}\n`;
+};

--- a/packages/transform/src/debug/evalTelemetry.schema.ts
+++ b/packages/transform/src/debug/evalTelemetry.schema.ts
@@ -1,0 +1,50 @@
+import {
+  EVAL_PREPARATION_ARTIFACT_LIMIT,
+  EVAL_TELEMETRY_SCHEMA_VERSION,
+} from './evalTelemetry.types';
+
+const deepFreeze = <T>(value: T): T => {
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+};
+
+export const EVAL_TELEMETRY_SCHEMA = deepFreeze({
+  artifacts: {
+    limit: EVAL_PREPARATION_ARTIFACT_LIMIT,
+    overflow:
+      'droppedArtifacts counts preparation attempts whose new (id, outputRevision, onlyShape) bucket is omitted after the bound; aggregate totals still include them',
+  },
+  denominators: {
+    cache:
+      'loads.requests counts runner LOAD requests attributed to the root. hits + misses + serializedExports partitions terminal host preparation decisions when callers record one terminal outcome per request. inflight-wait and inflight-wait-miss are orthogonal wait events; inflight-hit is a terminal hit. promotions and invalidationMisses are subsets of misses.',
+    evictions:
+      'hostPreparedCache counts exact broker-process prepared-cache removals. brokerObservedResetSignals and brokerObservedPoison* count only existing runner signals observed by the broker. primaryPressureProxy and variantPressureProxy count exact broker shipment hash changes classified by the new result storage shape; they are churn proxies, never claims about runner eviction or capacity.',
+    lifecycle:
+      'events are observations made while this reporter registration is active. brokerId starts at 1 for each registration. restartInferred is true only on the second and later runner-activated event for the same brokerId.',
+    preparation:
+      'calls are physical prepareModuleOnDemand attempts; custom-loader, import-loader, JSON, extension-stub, direct-barrel, serialized-export, and cache-hit paths do not begin preparation. prepareMs measures the end-to-end wrapper and includes nested shake/strip time, so stage durations are not additive. durationMs covers beginPreparation to finish/fail. artifact details aggregate by (id, outputRevision, onlyShape).',
+    root: 'one record is emitted for each begun token that finishes while its reporter registration remains active. queueWaitMs is beginEvalTelemetry to start; durationMs is start to finish.',
+    transmission:
+      'logicalResults counts complete logical LOAD_RESULT responses and partitions into initial + omissions + resends + serializedExports + errors. incompleteResults counts responses whose write failed and is excluded from logicalResults. chunks counts successfully written physical messages carrying codeChunk; chunkedResults counts complete logical responses with chunks. wireMessages and wireBytes count successfully written, already serialized physical messages; telemetry must not serialize transport again.',
+  },
+  encodings: {
+    bytes: 'UTF-8 byte length',
+    filenames:
+      'relative to the reporter working directory; file URLs and absolute paths embedded in virtual IDs follow the same policy; paths outside it and cross-volume paths fall back to basename',
+    importMap:
+      'UTF-8 bytes of JSON.stringify over specifier-sorted tuples whose requested names are deduplicated and sorted',
+    onlyShape:
+      'empty for [], wildcard for any list containing *, otherwise named',
+  },
+  limitations: {
+    attribution:
+      'runner LOAD messages are attributed to the serial root active when the broker receives them. The protocol carries no root id, so a late unawaited LOAD that overlaps a later root cannot be distinguished and may be attributed to that later root; messages received with no active root are omitted',
+    runnerState:
+      'actual runner cache entries, bytes, primary LRU eviction, and variant-limit eviction are unavailable without a runner protocol signal; mirror and pressure fields are explicitly host-observed or inferred proxies',
+  },
+  schemaVersion: EVAL_TELEMETRY_SCHEMA_VERSION,
+  type: 'eval-telemetry-schema' as const,
+});

--- a/packages/transform/src/debug/evalTelemetry.ts
+++ b/packages/transform/src/debug/evalTelemetry.ts
@@ -1,0 +1,673 @@
+import type { EventEmitter } from '../utils/EventEmitter';
+import { serializeEvalTelemetryJSONl } from './evalTelemetry.jsonl';
+import { EVAL_TELEMETRY_SCHEMA } from './evalTelemetry.schema';
+import {
+  EVAL_PREPARATION_ARTIFACT_LIMIT,
+  EVAL_TELEMETRY_SCHEMA_VERSION,
+  type EvalBrokerLifecycleMetadata,
+  type EvalBrokerMirrorSnapshot,
+  type EvalLoadCacheOutcome,
+  type EvalOnlyShape,
+  type EvalPreparationArtifact,
+  type EvalPreparationResult,
+  type EvalPreparationStage,
+  type EvalPreparationToken,
+  type EvalPressureProxy,
+  type EvalRootStatus,
+  type EvalRunnerSignal,
+  type EvalTelemetryRecord,
+  type EvalTelemetryRootRecord,
+  type EvalTelemetryToken,
+} from './evalTelemetry.types';
+
+export {
+  type EvalBrokerLifecycleEvent,
+  type EvalBrokerLifecycleMetadata,
+  type EvalBrokerMirrorSnapshot,
+  type EvalLoadCacheOutcome,
+  type EvalLoadResendReason,
+  type EvalLoadTransmission,
+  type EvalPreparationResult,
+  type EvalPreparationStage,
+  type EvalPreparationToken,
+  type EvalPreparedCacheEviction,
+  type EvalPressureProxy,
+  type EvalRootStatus,
+  type EvalRunnerSignal,
+  type EvalTelemetryLifecycleRecord,
+  type EvalTelemetryRecord,
+  type EvalTelemetryRootRecord,
+  type EvalTelemetryToken,
+} from './evalTelemetry.types';
+export { EVAL_TELEMETRY_SCHEMA };
+
+type EvalTelemetrySink = (record: EvalTelemetryRecord) => void;
+
+type BrokerReporterState = {
+  brokerId: number;
+  runnerActivations: number;
+};
+
+type EvalTelemetryReporter = {
+  active: boolean;
+  allocateBrokerId: () => number;
+  brokers: WeakMap<object, BrokerReporterState>;
+  sink: EvalTelemetrySink;
+};
+
+type MutablePreparationCounters =
+  EvalTelemetryRootRecord['loads']['preparation'] & {
+    artifactByKey: Map<string, EvalPreparationArtifact> | undefined;
+  };
+
+type EvalRootAccumulator = Omit<EvalTelemetryRootRecord, 'loads' | 'root'> & {
+  closed: boolean;
+  poisonIds: Set<string> | undefined;
+  queuedAt: number;
+  reporter: EvalTelemetryReporter;
+  root: {
+    batchIndex: number;
+    batchSize: number;
+    entrypoint: string;
+    startedAt: number | undefined;
+  };
+  loads: Omit<EvalTelemetryRootRecord['loads'], 'preparation'> & {
+    preparation: MutablePreparationCounters;
+  };
+};
+
+const reporterByEmitter = new WeakMap<EventEmitter, EvalTelemetryReporter>();
+
+const INACTIVE_PREPARATION_TOKEN: EvalPreparationToken = {
+  fail: () => {},
+  finish: () => {},
+  measureStage: (_stage, callback) => callback(),
+};
+
+export const hasEvalTelemetryReporter = (emitter: EventEmitter): boolean =>
+  reporterByEmitter.has(emitter);
+
+const EMPTY_MIRROR = (): EvalBrokerMirrorSnapshot => ({
+  entries: 0,
+  knownCodeBytes: 0,
+  unknownByteEntries: 0,
+});
+
+const EMPTY_CACHE_OUTCOMES = (): Record<EvalLoadCacheOutcome, number> => ({
+  hit: 0,
+  'inflight-hit': 0,
+  'inflight-wait': 0,
+  'inflight-wait-miss': 0,
+  'invalidation-miss': 0,
+  miss: 0,
+  promotion: 0,
+  'serialized-exports': 0,
+});
+
+const compareStrings = (left: string, right: string): number => {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+};
+
+export const measureCanonicalImportMapBytes = (
+  imports: ReadonlyMap<string, readonly string[]> | null | undefined
+): number => {
+  if (!imports) return 0;
+
+  const entries = Array.from(
+    imports,
+    ([specifier, names]) =>
+      [specifier, Array.from(new Set(names)).sort(compareStrings)] as const
+  ).sort(([left], [right]) => compareStrings(left, right));
+  return Buffer.byteLength(JSON.stringify(entries));
+};
+
+const getOnlyShape = (only: readonly string[]): EvalOnlyShape => {
+  if (only.length === 0) return 'empty';
+  return only.includes('*') ? 'wildcard' : 'named';
+};
+
+const toCount = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+
+const toDuration = (finishedAt: number, startedAt: number): number =>
+  Math.max(0, finishedAt - startedAt);
+
+const getBrokerState = (
+  reporter: EvalTelemetryReporter,
+  broker: object
+): BrokerReporterState => {
+  const existing = reporter.brokers.get(broker);
+  if (existing) return existing;
+
+  const created: BrokerReporterState = {
+    brokerId: reporter.allocateBrokerId(),
+    runnerActivations: 0,
+  };
+  reporter.brokers.set(broker, created);
+  return created;
+};
+
+const emitRecord = (
+  reporter: EvalTelemetryReporter,
+  record: EvalTelemetryRecord
+): void => {
+  if (!reporter.active) return;
+  try {
+    reporter.sink(record);
+  } catch {
+    // Debug reporting must never change evaluation behavior.
+  }
+};
+
+export const registerEvalTelemetryReporter = (
+  emitter: EventEmitter,
+  sink: EvalTelemetrySink
+): (() => void) => {
+  const previous = reporterByEmitter.get(emitter);
+  if (previous) previous.active = false;
+
+  let nextBrokerId = 1;
+  const reporter: EvalTelemetryReporter = {
+    active: true,
+    allocateBrokerId: () => {
+      const allocated = nextBrokerId;
+      nextBrokerId += 1;
+      return allocated;
+    },
+    brokers: new WeakMap(),
+    sink,
+  };
+  reporterByEmitter.set(emitter, reporter);
+  let registered = true;
+
+  return () => {
+    if (!registered) return;
+    registered = false;
+    reporter.active = false;
+    if (reporterByEmitter.get(emitter) === reporter) {
+      reporterByEmitter.delete(emitter);
+    }
+  };
+};
+
+export const registerEvalTelemetryJSONlReporter = (
+  emitter: EventEmitter,
+  workingDirectory: string,
+  sink: (line: string, record: EvalTelemetryRecord) => void
+): (() => void) =>
+  registerEvalTelemetryReporter(emitter, (record) => {
+    sink(serializeEvalTelemetryJSONl(record, workingDirectory), record);
+  });
+
+export const recordEvalBrokerLifecycle = (
+  emitter: EventEmitter,
+  broker: object,
+  createMetadata: () => EvalBrokerLifecycleMetadata
+): void => {
+  const reporter = reporterByEmitter.get(emitter);
+  if (!reporter) return;
+
+  let metadata: EvalBrokerLifecycleMetadata;
+  try {
+    metadata = createMetadata();
+  } catch {
+    return;
+  }
+
+  const brokerState = getBrokerState(reporter, broker);
+  const isActivation = metadata.event === 'runner-activated';
+  const restartInferred = isActivation && brokerState.runnerActivations > 0;
+  if (isActivation) brokerState.runnerActivations += 1;
+
+  emitRecord(reporter, {
+    ...metadata,
+    brokerId: brokerState.brokerId,
+    observedAtMs: performance.now(),
+    restartInferred,
+    schemaVersion: EVAL_TELEMETRY_SCHEMA_VERSION,
+    type: 'eval-lifecycle',
+  });
+};
+
+const createAccumulator = (
+  reporter: EvalTelemetryReporter,
+  brokerId: number,
+  entrypoint: string
+): EvalRootAccumulator => {
+  return {
+    brokerId,
+    closed: false,
+    evictions: {
+      brokerObservedPoisonIds: 0,
+      brokerObservedPoisonSignals: 0,
+      brokerObservedResetSignals: 0,
+      hostPreparedCache: {
+        capacity: 0,
+        invalidation: 0,
+        knownCodeBytes: 0,
+        replacement: 0,
+        total: 0,
+        unknownByteEntries: 0,
+      },
+      primaryPressureProxy: { shipmentHashChanges: 0 },
+      variantPressureProxy: { shipmentHashChanges: 0 },
+    },
+    loads: {
+      cache: {
+        hits: 0,
+        inflightHits: 0,
+        inflightWaitMisses: 0,
+        inflightWaits: 0,
+        invalidationMisses: 0,
+        misses: 0,
+        outcomes: EMPTY_CACHE_OUTCOMES(),
+        promotions: 0,
+        serializedExports: 0,
+      },
+      preparation: {
+        artifactByKey: undefined,
+        artifacts: [],
+        calls: 0,
+        droppedArtifacts: 0,
+        durationMs: 0,
+        errors: 0,
+        importMapBytes: 0,
+        prepareCalls: 0,
+        prepareMs: 0,
+        preparedCodeBytes: 0,
+        shakeCalls: 0,
+        shakeMs: 0,
+        stripCalls: 0,
+        stripMs: 0,
+      },
+      requests: 0,
+      transmission: {
+        chunkedResults: 0,
+        chunks: 0,
+        codeBytes: 0,
+        emptyCodePayloads: 0,
+        errors: 0,
+        incompleteResults: 0,
+        initial: 0,
+        logicalResults: 0,
+        omissions: 0,
+        resendReasons: {
+          'hash-change': 0,
+          'only-widening': 0,
+          'storage-shape-change': 0,
+        },
+        resends: 0,
+        serializedExports: 0,
+        wireBytes: 0,
+        wireMessages: 0,
+      },
+    },
+    mirror: EMPTY_MIRROR(),
+    poisonIds: undefined,
+    queuedAt: performance.now(),
+    reporter,
+    root: {
+      batchIndex: 0,
+      batchSize: 1,
+      entrypoint,
+      startedAt: undefined,
+    },
+    schemaVersion: EVAL_TELEMETRY_SCHEMA_VERSION,
+    type: 'eval-root',
+  };
+};
+
+const recordCacheOutcome = (
+  accumulator: EvalRootAccumulator,
+  outcome: EvalLoadCacheOutcome
+): void => {
+  const { cache } = accumulator.loads;
+  cache.outcomes[outcome] += 1;
+  switch (outcome) {
+    case 'hit':
+      cache.hits += 1;
+      break;
+    case 'inflight-hit':
+      cache.hits += 1;
+      cache.inflightHits += 1;
+      break;
+    case 'inflight-wait':
+      cache.inflightWaits += 1;
+      break;
+    case 'inflight-wait-miss':
+      cache.inflightWaitMisses += 1;
+      break;
+    case 'invalidation-miss':
+      cache.invalidationMisses += 1;
+      cache.misses += 1;
+      break;
+    case 'miss':
+      cache.misses += 1;
+      break;
+    case 'promotion':
+      cache.misses += 1;
+      cache.promotions += 1;
+      break;
+    case 'serialized-exports':
+      cache.serializedExports += 1;
+      break;
+    default:
+      break;
+  }
+};
+
+const getPreparationArtifactKey = (artifact: EvalPreparationArtifact): string =>
+  `${artifact.id}\0${artifact.outputRevision ?? ''}\0${artifact.onlyShape}`;
+
+const mergeArtifact = (
+  preparation: MutablePreparationCounters,
+  artifact: EvalPreparationArtifact
+): void => {
+  const counters = preparation;
+  let existing: EvalPreparationArtifact | undefined;
+  let key: string | undefined;
+
+  if (counters.artifactByKey) {
+    key = getPreparationArtifactKey(artifact);
+    existing = counters.artifactByKey.get(key);
+  } else if (counters.artifacts.length === 1) {
+    const first = counters.artifacts[0];
+    key = getPreparationArtifactKey(artifact);
+    if (getPreparationArtifactKey(first) === key) {
+      existing = first;
+    } else {
+      counters.artifactByKey = new Map([
+        [getPreparationArtifactKey(first), first],
+      ]);
+    }
+  }
+
+  if (existing) {
+    existing.calls += artifact.calls;
+    existing.durationMs += artifact.durationMs;
+    existing.errors += artifact.errors;
+    existing.importMapBytes += artifact.importMapBytes;
+    existing.prepareCalls += artifact.prepareCalls;
+    existing.prepareMs += artifact.prepareMs;
+    existing.preparedCodeBytes += artifact.preparedCodeBytes;
+    existing.shakeCalls += artifact.shakeCalls;
+    existing.shakeMs += artifact.shakeMs;
+    existing.stripCalls += artifact.stripCalls;
+    existing.stripMs += artifact.stripMs;
+    return;
+  }
+
+  if (counters.artifacts.length >= EVAL_PREPARATION_ARTIFACT_LIMIT) {
+    counters.droppedArtifacts += artifact.calls;
+    return;
+  }
+
+  if (counters.artifactByKey) {
+    counters.artifactByKey.set(
+      key ?? getPreparationArtifactKey(artifact),
+      artifact
+    );
+  }
+  counters.artifacts.push(artifact);
+};
+
+const createPreparationToken = (
+  accumulator: EvalRootAccumulator,
+  id: string,
+  requestedOnly: readonly string[]
+): EvalPreparationToken => {
+  const { preparation } = accumulator.loads;
+  preparation.calls += 1;
+  const startedAt = performance.now();
+  const stageCalls: Record<EvalPreparationStage, number> = {
+    prepare: 0,
+    shake: 0,
+    strip: 0,
+  };
+  const stageMs: Record<EvalPreparationStage, number> = {
+    prepare: 0,
+    shake: 0,
+    strip: 0,
+  };
+  let finished = false;
+
+  const complete = (error: boolean, result?: EvalPreparationResult): void => {
+    if (finished) return;
+    finished = true;
+    if (accumulator.closed) return;
+
+    const durationMs = toDuration(performance.now(), startedAt);
+    const preparedCodeBytes = result ? Buffer.byteLength(result.code) : 0;
+    const importMapBytes = result
+      ? measureCanonicalImportMapBytes(result.imports)
+      : 0;
+    const onlyShape = getOnlyShape(result?.only ?? requestedOnly);
+    preparation.durationMs += durationMs;
+    preparation.errors += error ? 1 : 0;
+    preparation.importMapBytes += importMapBytes;
+    preparation.prepareCalls += stageCalls.prepare;
+    preparation.prepareMs += stageMs.prepare;
+    preparation.preparedCodeBytes += preparedCodeBytes;
+    preparation.shakeCalls += stageCalls.shake;
+    preparation.shakeMs += stageMs.shake;
+    preparation.stripCalls += stageCalls.strip;
+    preparation.stripMs += stageMs.strip;
+
+    mergeArtifact(preparation, {
+      calls: 1,
+      durationMs,
+      errors: error ? 1 : 0,
+      id,
+      importMapBytes,
+      onlyShape,
+      outputRevision: result?.outputRevision ?? null,
+      prepareCalls: stageCalls.prepare,
+      prepareMs: stageMs.prepare,
+      preparedCodeBytes,
+      shakeCalls: stageCalls.shake,
+      shakeMs: stageMs.shake,
+      stripCalls: stageCalls.strip,
+      stripMs: stageMs.strip,
+    });
+  };
+
+  return {
+    fail: () => complete(true),
+    finish: (result) => complete(false, result),
+    measureStage: <T>(stage: EvalPreparationStage, callback: () => T): T => {
+      if (finished || accumulator.closed) return callback();
+      stageCalls[stage] += 1;
+      const stageStartedAt = performance.now();
+      let stageFinished = false;
+
+      try {
+        const result = callback();
+        if (result instanceof Promise) {
+          const finishAsyncStage = (): void => {
+            if (stageFinished || accumulator.closed) return;
+            stageFinished = true;
+            stageMs[stage] += toDuration(performance.now(), stageStartedAt);
+          };
+          result.then(finishAsyncStage, finishAsyncStage);
+        } else if (!accumulator.closed) {
+          stageFinished = true;
+          stageMs[stage] += toDuration(performance.now(), stageStartedAt);
+        }
+        return result;
+      } catch (error) {
+        if (!stageFinished && !accumulator.closed) {
+          stageFinished = true;
+          stageMs[stage] += toDuration(performance.now(), stageStartedAt);
+        }
+        throw error;
+      }
+    },
+  };
+};
+
+const releaseAccumulator = (accumulator: EvalRootAccumulator): void => {
+  accumulator.loads.preparation.artifactByKey?.clear();
+  accumulator.poisonIds?.clear();
+};
+
+const finishRoot = (
+  accumulator: EvalRootAccumulator,
+  status: EvalRootStatus,
+  mirror?: EvalBrokerMirrorSnapshot
+): void => {
+  if (accumulator.closed) return;
+  accumulator.closed = true;
+  const finishedAt = performance.now();
+  const { startedAt } = accumulator.root;
+  if (mirror) accumulator.mirror = { ...mirror };
+
+  const { artifactByKey, ...preparation } = accumulator.loads.preparation;
+  artifactByKey?.clear();
+  const record: EvalTelemetryRootRecord = {
+    brokerId: accumulator.brokerId,
+    evictions: accumulator.evictions,
+    loads: {
+      ...accumulator.loads,
+      preparation,
+    },
+    mirror: accumulator.mirror,
+    root: {
+      batchIndex: accumulator.root.batchIndex,
+      batchSize: accumulator.root.batchSize,
+      durationMs:
+        startedAt === undefined ? 0 : toDuration(finishedAt, startedAt),
+      entrypoint: accumulator.root.entrypoint,
+      queueWaitMs: toDuration(startedAt ?? finishedAt, accumulator.queuedAt),
+      status,
+    },
+    schemaVersion: EVAL_TELEMETRY_SCHEMA_VERSION,
+    type: 'eval-root',
+  };
+  emitRecord(accumulator.reporter, record);
+  releaseAccumulator(accumulator);
+};
+
+export const beginEvalTelemetry = (
+  emitter: EventEmitter,
+  broker: object,
+  createRoot: () => { entrypoint: string }
+): EvalTelemetryToken | undefined => {
+  const reporter = reporterByEmitter.get(emitter);
+  if (!reporter) return undefined;
+
+  let entrypoint: string;
+  try {
+    entrypoint = createRoot().entrypoint;
+  } catch {
+    return undefined;
+  }
+
+  const brokerState = getBrokerState(reporter, broker);
+  const accumulator = createAccumulator(
+    reporter,
+    brokerState.brokerId,
+    entrypoint
+  );
+
+  return {
+    beginPreparation: (id, only) =>
+      accumulator.closed
+        ? INACTIVE_PREPARATION_TOKEN
+        : createPreparationToken(accumulator, id, only),
+    finish: (status, mirror) => finishRoot(accumulator, status, mirror),
+    recordLoadCacheOutcome: (outcome) => {
+      if (!accumulator.closed) recordCacheOutcome(accumulator, outcome);
+    },
+    recordLoadRequest: () => {
+      if (!accumulator.closed) accumulator.loads.requests += 1;
+    },
+    recordLoadTransmission: (transmission) => {
+      if (accumulator.closed) return;
+      const counters = accumulator.loads.transmission;
+      const logicalResults = toCount(
+        transmission.logicalResults ?? (transmission.incomplete ? 0 : 1)
+      );
+      const wireMessages = toCount(transmission.wireMessages);
+      const chunks = toCount(transmission.chunks ?? 0);
+      counters.logicalResults += logicalResults;
+      counters.wireMessages += wireMessages;
+      counters.wireBytes += toCount(transmission.wireBytes);
+      counters.chunks += chunks;
+      counters.incompleteResults += transmission.incomplete ? 1 : 0;
+      if (transmission.codeBytes !== undefined) {
+        counters.codeBytes += toCount(transmission.codeBytes);
+      } else if (typeof transmission.code === 'string') {
+        counters.codeBytes += Buffer.byteLength(transmission.code);
+      }
+      if (transmission.code === '') counters.emptyCodePayloads += 1;
+      if (chunks > 0) {
+        counters.chunkedResults += logicalResults;
+      }
+      switch (transmission.mode) {
+        case 'error':
+          counters.errors += logicalResults;
+          break;
+        case 'initial':
+          counters.initial += logicalResults;
+          break;
+        case 'omission':
+          counters.omissions += logicalResults;
+          break;
+        case 'resend':
+          counters.resends += logicalResults;
+          if (transmission.resendReason) {
+            counters.resendReasons[transmission.resendReason] += logicalResults;
+          }
+          break;
+        case 'serialized-exports':
+          counters.serializedExports += logicalResults;
+          break;
+        default:
+          break;
+      }
+    },
+    recordPreparedCacheEviction: (eviction) => {
+      if (accumulator.closed) return;
+      const counters = accumulator.evictions.hostPreparedCache;
+      counters.total += 1;
+      counters[eviction.reason] += 1;
+      if (eviction.knownCodeBytes === undefined) {
+        counters.unknownByteEntries += 1;
+      } else {
+        counters.knownCodeBytes += toCount(eviction.knownCodeBytes);
+      }
+    },
+    recordPressureProxy: (proxy: EvalPressureProxy) => {
+      if (accumulator.closed) return;
+      const count = toCount(proxy.count ?? 1);
+      const counters =
+        proxy.store === 'primary'
+          ? accumulator.evictions.primaryPressureProxy
+          : accumulator.evictions.variantPressureProxy;
+      counters.shipmentHashChanges += count;
+    },
+    recordRunnerSignal: (signal: EvalRunnerSignal) => {
+      if (accumulator.closed) return;
+      if (signal.type === 'modules-reset') {
+        accumulator.evictions.brokerObservedResetSignals += 1;
+        return;
+      }
+
+      accumulator.evictions.brokerObservedPoisonSignals += 1;
+      const poisonIds =
+        accumulator.poisonIds ?? (accumulator.poisonIds = new Set());
+      signal.ids.forEach((id) => poisonIds.add(id));
+      accumulator.evictions.brokerObservedPoisonIds = poisonIds.size;
+    },
+    start: ({ batchIndex, batchSize }) => {
+      if (accumulator.closed || accumulator.root.startedAt !== undefined) {
+        return;
+      }
+      accumulator.root.batchIndex = toCount(batchIndex);
+      accumulator.root.batchSize = toCount(batchSize);
+      accumulator.root.startedAt = performance.now();
+    },
+  };
+};

--- a/packages/transform/src/debug/evalTelemetry.types.ts
+++ b/packages/transform/src/debug/evalTelemetry.types.ts
@@ -1,0 +1,221 @@
+export const EVAL_TELEMETRY_SCHEMA_VERSION = 1 as const;
+
+export const EVAL_PREPARATION_ARTIFACT_LIMIT = 128;
+
+export type EvalRootStatus = 'error' | 'no-values' | 'success';
+
+export type EvalOnlyShape = 'empty' | 'named' | 'wildcard';
+
+export type EvalPreparationStage = 'prepare' | 'shake' | 'strip';
+
+export type EvalLoadCacheOutcome =
+  | 'hit'
+  | 'inflight-hit'
+  | 'inflight-wait'
+  | 'inflight-wait-miss'
+  | 'invalidation-miss'
+  | 'miss'
+  | 'promotion'
+  | 'serialized-exports';
+
+export type EvalLoadResendReason =
+  | 'hash-change'
+  | 'only-widening'
+  | 'storage-shape-change';
+
+export type EvalLoadTransmission = {
+  /** Physical messages carrying `codeChunk`; zero for an unchunked result. */
+  chunks?: number;
+  /** Code supplied in the logical LOAD_RESULT. An empty string is a payload. */
+  code?: string;
+  /** Successfully written code bytes for an incomplete chunked response. */
+  codeBytes?: number;
+  /** True when the logical response did not finish writing. */
+  incomplete?: boolean;
+  /** One for a normal result, greater than one only if callers coalesce work. */
+  logicalResults?: number;
+  mode: 'error' | 'initial' | 'omission' | 'resend' | 'serialized-exports';
+  resendReason?: EvalLoadResendReason;
+  /** Number of physical LOAD_RESULT messages written for the logical result. */
+  wireMessages: number;
+  /** UTF-8 bytes measured from the already serialized wire messages. */
+  wireBytes: number;
+};
+
+export type EvalPreparedCacheEviction = {
+  id: string;
+  knownCodeBytes?: number;
+  reason: 'capacity' | 'invalidation' | 'replacement';
+};
+
+export type EvalPressureProxy = {
+  count?: number;
+  store: 'primary' | 'variant';
+  type: 'shipment-hash-change';
+};
+
+export type EvalRunnerSignal =
+  | {
+      type: 'modules-reset';
+    }
+  | {
+      ids: readonly string[];
+      type: 'poison-ids';
+    };
+
+export type EvalBrokerMirrorSnapshot = {
+  entries: number;
+  knownCodeBytes: number;
+  unknownByteEntries: number;
+};
+
+export type EvalPreparationResult = {
+  code: string;
+  imports: ReadonlyMap<string, readonly string[]> | null;
+  only: readonly string[];
+  outputRevision: string;
+};
+
+export type EvalPreparationArtifact = {
+  calls: number;
+  durationMs: number;
+  errors: number;
+  id: string;
+  importMapBytes: number;
+  onlyShape: EvalOnlyShape;
+  outputRevision: string | null;
+  prepareCalls: number;
+  prepareMs: number;
+  preparedCodeBytes: number;
+  shakeCalls: number;
+  shakeMs: number;
+  stripCalls: number;
+  stripMs: number;
+};
+
+export type EvalTelemetryRootRecord = {
+  brokerId: number;
+  evictions: {
+    brokerObservedPoisonIds: number;
+    brokerObservedPoisonSignals: number;
+    brokerObservedResetSignals: number;
+    hostPreparedCache: {
+      capacity: number;
+      invalidation: number;
+      knownCodeBytes: number;
+      replacement: number;
+      total: number;
+      unknownByteEntries: number;
+    };
+    primaryPressureProxy: {
+      shipmentHashChanges: number;
+    };
+    variantPressureProxy: {
+      shipmentHashChanges: number;
+    };
+  };
+  loads: {
+    cache: {
+      hits: number;
+      inflightHits: number;
+      inflightWaitMisses: number;
+      inflightWaits: number;
+      invalidationMisses: number;
+      misses: number;
+      outcomes: Record<EvalLoadCacheOutcome, number>;
+      promotions: number;
+      serializedExports: number;
+    };
+    preparation: {
+      artifacts: EvalPreparationArtifact[];
+      calls: number;
+      droppedArtifacts: number;
+      durationMs: number;
+      errors: number;
+      importMapBytes: number;
+      prepareCalls: number;
+      prepareMs: number;
+      preparedCodeBytes: number;
+      shakeCalls: number;
+      shakeMs: number;
+      stripCalls: number;
+      stripMs: number;
+    };
+    requests: number;
+    transmission: {
+      chunkedResults: number;
+      chunks: number;
+      codeBytes: number;
+      emptyCodePayloads: number;
+      errors: number;
+      incompleteResults: number;
+      initial: number;
+      logicalResults: number;
+      omissions: number;
+      resendReasons: Record<EvalLoadResendReason, number>;
+      resends: number;
+      serializedExports: number;
+      wireBytes: number;
+      wireMessages: number;
+    };
+  };
+  mirror: EvalBrokerMirrorSnapshot;
+  root: {
+    batchIndex: number;
+    batchSize: number;
+    durationMs: number;
+    entrypoint: string;
+    queueWaitMs: number;
+    status: EvalRootStatus;
+  };
+  schemaVersion: typeof EVAL_TELEMETRY_SCHEMA_VERSION;
+  type: 'eval-root';
+};
+
+export type EvalBrokerLifecycleEvent =
+  | 'broker-created'
+  | 'broker-dispose-observed'
+  | 'broker-reused'
+  | 'runner-activated'
+  | 'runner-exit-observed'
+  | 'runner-spawn-attempt'
+  | 'runner-stop-requested';
+
+export type EvalBrokerLifecycleMetadata = {
+  event: EvalBrokerLifecycleEvent;
+  reason: string;
+  mirror?: EvalBrokerMirrorSnapshot;
+};
+
+export type EvalTelemetryLifecycleRecord = EvalBrokerLifecycleMetadata & {
+  brokerId: number;
+  observedAtMs: number;
+  restartInferred: boolean;
+  schemaVersion: typeof EVAL_TELEMETRY_SCHEMA_VERSION;
+  type: 'eval-lifecycle';
+};
+
+export type EvalTelemetryRecord =
+  | EvalTelemetryLifecycleRecord
+  | EvalTelemetryRootRecord;
+
+export type EvalPreparationToken = {
+  fail: () => void;
+  finish: (result: EvalPreparationResult) => void;
+  measureStage: <T>(stage: EvalPreparationStage, callback: () => T) => T;
+};
+
+export type EvalTelemetryToken = {
+  beginPreparation: (
+    id: string,
+    only: readonly string[]
+  ) => EvalPreparationToken;
+  finish: (status: EvalRootStatus, mirror?: EvalBrokerMirrorSnapshot) => void;
+  recordLoadCacheOutcome: (outcome: EvalLoadCacheOutcome) => void;
+  recordLoadRequest: () => void;
+  recordLoadTransmission: (transmission: EvalLoadTransmission) => void;
+  recordPreparedCacheEviction: (eviction: EvalPreparedCacheEviction) => void;
+  recordPressureProxy: (proxy: EvalPressureProxy) => void;
+  recordRunnerSignal: (signal: EvalRunnerSignal) => void;
+  start: (batch: { batchIndex: number; batchSize: number }) => void;
+};

--- a/packages/transform/src/debug/fileReporter.ts
+++ b/packages/transform/src/debug/fileReporter.ts
@@ -15,6 +15,10 @@ import {
   PIPELINE_TELEMETRY_SCHEMA,
   registerPipelineTelemetryJSONlReporter,
 } from './pipelineTelemetry';
+import {
+  EVAL_TELEMETRY_SCHEMA,
+  registerEvalTelemetryJSONlReporter,
+} from './evalTelemetry';
 
 type Timings = Map<string, Map<string, number>>;
 
@@ -101,9 +105,9 @@ const writeJSONl = (stream: NodeJS.WritableStream, data: unknown) => {
   stream.write(`${JSON.stringify(data, replacer)}\n`);
 };
 
-const PIPELINE_TELEMETRY_WRITE_CHUNK_CHARS = 256 * 1024;
+const TELEMETRY_WRITE_CHUNK_CHARS = 256 * 1024;
 
-const createPipelineTelemetryJSONlWriter = (stream: NodeJS.WritableStream) => {
+const createTelemetryJSONlWriter = (stream: NodeJS.WritableStream) => {
   let bufferedChars = 0;
   let bufferedLines: string[] = [];
   let closed = false;
@@ -133,7 +137,7 @@ const createPipelineTelemetryJSONlWriter = (stream: NodeJS.WritableStream) => {
       if (closed || !stream.writable) return;
       bufferedLines.push(line);
       bufferedChars += line.length;
-      if (bufferedChars >= PIPELINE_TELEMETRY_WRITE_CHUNK_CHARS) flush();
+      if (bufferedChars >= TELEMETRY_WRITE_CHUNK_CHARS) flush();
     },
   };
 };
@@ -234,10 +238,17 @@ export const createFileReporter = (
     options.dir,
     'pipeline-telemetry.jsonl'
   );
-  const pipelineTelemetryWriter = createPipelineTelemetryJSONlWriter(
+  const pipelineTelemetryWriter = createTelemetryJSONlWriter(
     pipelineTelemetryStream
   );
   writeJSONl(pipelineTelemetryStream, PIPELINE_TELEMETRY_SCHEMA);
+
+  const evalTelemetryStream = createReportStream(
+    options.dir,
+    'eval-telemetry.jsonl'
+  );
+  const evalTelemetryWriter = createTelemetryJSONlWriter(evalTelemetryStream);
+  writeJSONl(evalTelemetryStream, EVAL_TELEMETRY_SCHEMA);
 
   const startedAt = performance.now();
   const timings: Timings = new Map();
@@ -370,6 +381,16 @@ export const createFileReporter = (
       if (status === 'error') pipelineTelemetryWriter.flush();
     }
   );
+  let unregisterEvalTelemetry = registerEvalTelemetryJSONlReporter(
+    emitter,
+    workingDir,
+    (line, record) => {
+      evalTelemetryWriter.write(line);
+      if (record.type === 'eval-root' && record.root.status === 'error') {
+        evalTelemetryWriter.flush();
+      }
+    }
+  );
   let done = false;
 
   return {
@@ -380,6 +401,9 @@ export const createFileReporter = (
       unregisterPipelineTelemetry();
       unregisterPipelineTelemetry = () => {};
       pipelineTelemetryWriter.end();
+      unregisterEvalTelemetry();
+      unregisterEvalTelemetry = () => {};
+      evalTelemetryWriter.end();
 
       if (options.print) {
         printTimings(timings, startedAt, sourceRoot);
@@ -396,6 +420,7 @@ export const createFileReporter = (
         perfSpanStream,
         evalFilesStream,
         pipelineTelemetryStream,
+        evalTelemetryStream,
       ].forEach((stream) => {
         if (stream.writable) {
           stream.end();

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -6,8 +6,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 
-import { invariant } from 'ts-invariant';
-
 import type {
   EvalOptionsV2,
   EvalWarning,
@@ -38,6 +36,13 @@ import {
 import { isSuperSet, mergeOnly } from '../transform/Entrypoint.helpers';
 import { oxcShaker } from '../shaker';
 import { analyzeOxcBarrelFile } from '../transform/oxcBarrelManifest';
+import {
+  beginEvalTelemetry,
+  hasEvalTelemetryReporter,
+  recordEvalBrokerLifecycle,
+  type EvalBrokerLifecycleEvent,
+  type EvalTelemetryToken,
+} from '../debug/evalTelemetry';
 
 import {
   type EvalRunnerInitPayload,
@@ -61,6 +66,28 @@ import {
   type SerializedValue,
 } from './serialize';
 import { createWriteQueue, type WriteQueue, writeToStream } from './writeQueue';
+import {
+  BrokerLoadMirror,
+  createLoadTransmissionTelemetry,
+  getRunnerStorage,
+  hasSameBrokerStorageShape,
+  hasSameRunnerStorageShape,
+  sendEvalMessage,
+  sendEvalLoadResult,
+  type LoadTransmissionTelemetry,
+} from './brokerTelemetry';
+import {
+  debugAction,
+  debugEvalEnabled,
+  dumpEvalCode,
+  flushDebugStreams,
+  getDebugValuesStatus,
+  serializedExportsToDebugValues,
+  toBase64,
+  toJsonBase64,
+  type DebugEvalValueStatus,
+} from './debugEval';
+import { getStableInitPayloadHash } from './stable-init-hash';
 
 const DefaultModuleImplementation = NativeModule as typeof NativeModule & {
   builtinModules?: string[];
@@ -334,8 +361,6 @@ const DEFAULT_EVAL_OPTIONS: Required<
   resolver: 'bundler',
 };
 
-const MAX_MESSAGE_SIZE = 10 * 1024 * 1024;
-const MAX_CHUNK_SIZE = 512 * 1024;
 const RESOLVE_CACHE_SIZE = 5000;
 const LOAD_CACHE_SIZE = 1000;
 const IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/u;
@@ -434,22 +459,16 @@ type EvalFileDebugLine = {
   request: string | null;
   type: 'eval-file';
   valuesBase64: string | null;
-  valueStatus: 'mixed' | 'none' | 'serialized' | 'stringified';
+  valueStatus: DebugEvalValueStatus;
 };
 
 type PendingEval = {
   entrypoint: Entrypoint;
   services: Services | undefined;
+  telemetry: EvalTelemetryToken | undefined;
   resolve: (value: EvaluateResult) => void;
   reject: (reason?: unknown) => void;
 };
-
-// Mirrors runner.js `isFullModuleLoad`: wildcard `['*']` (or empty) is the
-// only shape stored in the runner's moduleCache; everything else lands in
-// moduleVariants. The shipped-code dedup must respect this shape because the
-// runner picks its lookup map based on the LoadResult's `only`.
-const isWildcardOnly = (only: string[] | undefined | null): boolean =>
-  !only || only.length === 0 || (only.length === 1 && only[0] === '*');
 
 const isEvalTimeoutError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false;
@@ -458,132 +477,6 @@ const isEvalTimeoutError = (error: unknown): boolean => {
   }
   return false;
 };
-
-// ---------------------------------------------------------------------------
-// WYW_DEBUG eval dump
-// ---------------------------------------------------------------------------
-
-const resolveDebugEvalDir = (): string | undefined => {
-  const override = process.env.WYW_DUMP_EVALS_DIR;
-  if (override) {
-    return path.resolve(override);
-  }
-
-  const base = process.env.WYW_DUMP_EVALS;
-  if (!base) {
-    return undefined;
-  }
-
-  const ts = new Date()
-    .toISOString()
-    .slice(0, 19)
-    .replace(/[-:T]/g, (c) => (c === 'T' ? '-' : ''));
-  const root = base === '1' || base === 'true' ? './tmp' : base;
-  return path.resolve(root, `wyw-dump-evals-${ts}`);
-};
-
-const debugEvalDir = resolveDebugEvalDir();
-let debugEvalDirReady = false;
-
-const toBase64 = (value: string): string =>
-  Buffer.from(value, 'utf8').toString('base64');
-
-const toJsonBase64 = (value: unknown): string =>
-  toBase64(JSON.stringify(value));
-
-const serializedExportsToDebugValues = (
-  serializedExports: Record<string, SerializedValue>
-): DebugEvalFileValues => ({
-  exports: Object.fromEntries(
-    Object.entries(serializedExports).map(([key, serialized]) => [
-      key,
-      {
-        serialized,
-        status: 'serialized' as const,
-      },
-    ])
-  ),
-});
-
-const getDebugValuesStatus = (
-  values: DebugEvalFileValues | undefined
-): EvalFileDebugLine['valueStatus'] => {
-  const statuses = [
-    ...Object.values(values?.exports ?? {}),
-    ...Object.values(values?.preval ?? {}),
-  ].map((value) => value.status);
-
-  if (statuses.length === 0) {
-    return 'none';
-  }
-
-  const hasSerialized = statuses.includes('serialized');
-  const hasStringified = statuses.includes('stringified');
-  if (hasSerialized && hasStringified) {
-    return 'mixed';
-  }
-
-  return hasStringified ? 'stringified' : 'serialized';
-};
-
-const ensureDebugEvalDir = () => {
-  if (!debugEvalDir || debugEvalDirReady) {
-    return;
-  }
-  fs.mkdirSync(debugEvalDir, { recursive: true });
-  debugEvalDirReady = true;
-};
-
-let debugEvalSeq = 0;
-
-const dumpEvalCode = (
-  id: string,
-  code: string,
-  only: string[],
-  source: string,
-  evalSeq: number
-) => {
-  if (!debugEvalDir) {
-    return;
-  }
-  ensureDebugEvalDir();
-  const seq = String(++debugEvalSeq).padStart(5, '0');
-  const eSeq = String(evalSeq).padStart(5, '0');
-  const relId = path.relative(process.cwd(), stripQueryAndHash(id));
-  const safeName = relId.replace(/[/\\]/g, '__').replace(/^__/, '');
-  const filename = `seq${seq}_eval${eSeq}_${safeName}.js`;
-  const header = [
-    `// id: ${id}`,
-    `// only: ${JSON.stringify(only)}`,
-    `// source: ${source}`,
-    `// seq: ${seq}`,
-    `// eval: #${eSeq}`,
-    '',
-  ].join('\n');
-  fs.writeFileSync(path.join(debugEvalDir, filename), header + code);
-};
-
-let debugActionStream: fs.WriteStream | null = null;
-
-const debugAction = (event: Record<string, unknown>) => {
-  if (!debugEvalDir) {
-    return;
-  }
-  ensureDebugEvalDir();
-  if (!debugActionStream) {
-    debugActionStream = fs.createWriteStream(
-      path.join(debugEvalDir, 'actions.jsonl')
-    );
-  }
-  debugActionStream.write(`${JSON.stringify(event)}\n`);
-};
-
-const flushDebugStreams = () => {
-  debugActionStream?.end();
-  debugActionStream = null;
-};
-
-// ---------------------------------------------------------------------------
 
 const warnedUnknownImportsByServices = new WeakMap<Services, Set<string>>();
 
@@ -1156,40 +1049,6 @@ const buildDirectOxcBarrelProxy = (
   };
 };
 
-const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const canonicalizeForHash = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
-    return value.map((item) => canonicalizeForHash(item));
-  }
-
-  if (isPlainObject(value)) {
-    return Object.fromEntries(
-      Object.keys(value)
-        .sort()
-        .map((key) => [key, canonicalizeForHash(value[key])])
-    );
-  }
-
-  return value;
-};
-
-// Hash everything in the init payload that affects whether the runner needs
-// a fresh INIT — i.e. everything except `entrypoint` (which only affects
-// __filename/__dirname rebinding, not context reuse). The broker memoizes
-// this per-services so we replace per-evaluate SHA-256 of the full payload
-// with one SHA-256 of the stable bits + a cheap string concat per
-// entrypoint.
-const getStableInitPayloadHash = (payload: EvalRunnerInitPayload): string => {
-  const { entrypoint, ...stable } = payload;
-  void entrypoint;
-
-  return createHash('sha256')
-    .update(JSON.stringify(canonicalizeForHash(stable)))
-    .digest('hex');
-};
-
 // Memoize encodeGlobals on input reference. The user's globals object is
 // stable across a build, so we can encode it once instead of per evaluate.
 // If the input ref changes, fall through to a fresh encode (and reset the
@@ -1269,23 +1128,14 @@ export class EvalBroker {
   // to scope `mergeKnownDependencyOnly` to entrypoints that share the
   // current runner's VM, instead of unioning across every cached
   // entrypoint project-wide. Cleared whenever the runner is killed or
-  // respawned (mirrors lastSentLoadByModule).
+  // respawned (mirrors loadMirror).
   private readonly sessionLinkGraph = new Set<string>();
 
   private readonly runtimeDependenciesByModule = new Map<string, Set<string>>();
 
   private readonly emittedDependencies = new Set<string>();
 
-  // Mirrors the runner's view: for each module id, the (hash, mergedOnly) of
-  // the most recent LoadResult we shipped with non-empty `code`. Subsequent
-  // loads with a matching hash and a subset `only` skip the code transmission
-  // (and the eval dump) — the runner's hash-match branch returns its cached
-  // SourceTextModule. Cleared whenever the runner is killed/respawned so the
-  // mirror cannot drift from the runner's actual moduleCache.
-  private readonly lastSentLoadByModule = new Map<
-    string,
-    { hash: string; only: string[] }
-  >();
+  private readonly loadMirror = new BrokerLoadMirror();
 
   // Batch queue: concurrent evaluate() callers (e.g. parallel webpack-loader
   // transform() invocations) pile up here within one event-loop turn, then a
@@ -1319,7 +1169,14 @@ export class EvalBroker {
 
   private activeResolveRootId: string | null = null;
 
+  private activeEvalTelemetry: EvalTelemetryToken | undefined;
+
   private currentServices: Services;
+
+  private readonly sendLoadMessage = (
+    message: MainToRunnerMessage,
+    onSerialized?: (bytes: number) => void
+  ): Promise<void> => this.sendMessage(message, onSerialized);
 
   constructor(
     private readonly services: Services,
@@ -1330,6 +1187,21 @@ export class EvalBroker {
     ) => Promise<string | null>
   ) {
     this.currentServices = services;
+    this.recordBrokerLifecycle('broker-created', 'constructor');
+  }
+
+  private recordBrokerLifecycle(
+    event: EvalBrokerLifecycleEvent,
+    reason: string,
+    includeMirror = false
+  ): void {
+    const { eventEmitter } = this.currentServices;
+    if (!hasEvalTelemetryReporter(eventEmitter)) return;
+    recordEvalBrokerLifecycle(eventEmitter, this, () => ({
+      event,
+      reason,
+      ...(includeMirror ? { mirror: this.loadMirror.snapshot() } : {}),
+    }));
   }
 
   private ensureImportsMapping(
@@ -1425,8 +1297,20 @@ export class EvalBroker {
     entrypoint: Entrypoint,
     services?: Services
   ): Promise<EvaluateResult> {
+    const activeServices = services ?? this.currentServices;
+    const telemetry = hasEvalTelemetryReporter(activeServices.eventEmitter)
+      ? beginEvalTelemetry(activeServices.eventEmitter, this, () => ({
+          entrypoint: entrypoint.name,
+        }))
+      : undefined;
     return new Promise<EvaluateResult>((resolve, reject) => {
-      this.pendingEvals.push({ entrypoint, services, resolve, reject });
+      this.pendingEvals.push({
+        entrypoint,
+        services,
+        telemetry,
+        resolve,
+        reject,
+      });
       this.scheduleEvalFlush();
     });
   }
@@ -1445,20 +1329,37 @@ export class EvalBroker {
 
   private async runEvalBatch(batch: PendingEval[]): Promise<void> {
     try {
+      this.currentServices = batch[0].services ?? this.currentServices;
       await this.ensureRunner();
     } catch (error) {
-      for (const member of batch) member.reject(error);
+      for (const [batchIndex, member] of batch.entries()) {
+        member.telemetry?.start({ batchIndex, batchSize: batch.length });
+        member.telemetry?.finish('error', this.loadMirror.snapshot());
+        member.reject(error);
+      }
       return;
     }
-    for (const member of batch) {
+    for (const [batchIndex, member] of batch.entries()) {
+      const { telemetry } = member;
+      telemetry?.start({ batchIndex, batchSize: batch.length });
+      this.activeEvalTelemetry = telemetry;
       try {
         const result = await this.runOneEntrypoint(
           member.entrypoint,
           member.services
         );
+        telemetry?.finish(
+          result.values ? 'success' : 'no-values',
+          this.loadMirror.snapshot()
+        );
         member.resolve(result);
       } catch (error) {
+        telemetry?.finish('error', this.loadMirror.snapshot());
         member.reject(error);
+      } finally {
+        if (this.activeEvalTelemetry === telemetry) {
+          this.activeEvalTelemetry = undefined;
+        }
       }
     }
   }
@@ -1475,7 +1376,7 @@ export class EvalBroker {
     this.evalSeq += 1;
     this.evalFileDebugLines = activeServices.eventEmitter.enabled ? [] : null;
 
-    if (debugEvalDir) {
+    if (debugEvalEnabled) {
       debugAction({
         type: 'eval:start',
         evalSeq: this.evalSeq,
@@ -1495,7 +1396,7 @@ export class EvalBroker {
 
       this.flushEvalFileDebugLines(payload.debugEvalFiles);
 
-      if (debugEvalDir) {
+      if (debugEvalEnabled) {
         debugAction({
           type: 'eval:finish',
           evalSeq: this.evalSeq,
@@ -1652,8 +1553,10 @@ export class EvalBroker {
     });
   }
 
-  public dispose() {
+  public dispose(reason = 'explicit') {
+    this.recordBrokerLifecycle('broker-dispose-observed', reason, true);
     if (this.runner) {
+      this.recordBrokerLifecycle('runner-stop-requested', reason, true);
       this.runner.removeAllListeners();
       this.runner.kill();
       this.runner = null;
@@ -1662,13 +1565,14 @@ export class EvalBroker {
     }
     this.lastInitKey = null;
     this.lastHappyDomEnabled = false;
-    this.lastSentLoadByModule.clear();
+    this.loadMirror.clear();
     this.sessionLinkGraph.clear();
     this.stableInitHashCache = null;
     flushDebugStreams();
   }
 
-  private createRunnerProcess(): ChildProcessWithoutNullStreams {
+  private createRunnerProcess(reason: string): ChildProcessWithoutNullStreams {
+    this.recordBrokerLifecycle('runner-spawn-attempt', reason);
     const runnerPath = buildRunnerPath();
     const nodeBinary =
       process.env.WYW_NODE_BINARY ||
@@ -1705,13 +1609,14 @@ export class EvalBroker {
       const reason = `Eval runner exited (${code ?? 'null'} / ${
         signal ?? 'null'
       })`;
+      this.recordBrokerLifecycle('runner-exit-observed', reason, true);
       this.rejectAllPending(new Error(reason));
       this.runner = null;
       this.runnerInputQueue = null;
       this.runnerReady = null;
       this.lastInitKey = null;
       this.lastHappyDomEnabled = false;
-      this.lastSentLoadByModule.clear();
+      this.loadMirror.clear();
       this.sessionLinkGraph.clear();
     });
   }
@@ -1722,7 +1627,7 @@ export class EvalBroker {
       return;
     }
 
-    this.runner = this.createRunnerProcess();
+    this.runner = this.createRunnerProcess('ensure');
     this.runnerInputQueue = createWriteQueue(
       this.runner.stdin,
       'eval runner stdin'
@@ -1730,13 +1635,14 @@ export class EvalBroker {
     this.attachRunnerListeners(this.runner);
     this.runnerReady = Promise.resolve();
     await this.runnerReady;
+    this.recordBrokerLifecycle('runner-activated', 'ensure');
   }
 
   private async initIsolatedRunner(
     payload: EvalRunnerInitPayload,
     timeoutMs: number
   ): Promise<ChildProcessWithoutNullStreams> {
-    const runner = this.createRunnerProcess();
+    const runner = this.createRunnerProcess('happy-dom-candidate');
     const requestId = `candidate-init-${++this.nextId}`;
     let buffer = '';
 
@@ -1854,6 +1760,11 @@ export class EvalBroker {
 
   private replaceRunner(nextRunner: ChildProcessWithoutNullStreams) {
     if (this.runner) {
+      this.recordBrokerLifecycle(
+        'runner-stop-requested',
+        'happy-dom-replacement',
+        true
+      );
       this.runner.removeAllListeners();
       this.runner.kill();
     }
@@ -1867,8 +1778,9 @@ export class EvalBroker {
     this.runnerReady = Promise.resolve();
     // New process ⇒ runner's moduleCache/moduleHashes are empty, so our mirror
     // of "what we already shipped" is stale.
-    this.lastSentLoadByModule.clear();
+    this.loadMirror.clear();
     this.sessionLinkGraph.clear();
+    this.recordBrokerLifecycle('runner-activated', 'happy-dom-replacement');
   }
 
   private getStableInitHash(
@@ -1981,7 +1893,7 @@ export class EvalBroker {
       ) {
         this.happyDomDisabled = true;
         this.warnHappyDomDisabledOnce(timeoutMs);
-        this.dispose();
+        this.dispose('happy-dom-timeout-recovery');
         await this.ensureRunner();
         const fallbackFeatures = this.getRunnerFeatures();
         const fallbackPayload = buildRunnerInitPayload(
@@ -2073,6 +1985,11 @@ export class EvalBroker {
       case 'INIT_ACK':
         if (message.error) {
           this.rejectPending(message.id, message.error);
+          this.recordBrokerLifecycle(
+            'runner-stop-requested',
+            'init-error',
+            true
+          );
           this.runner?.kill();
           return;
         }
@@ -2080,23 +1997,30 @@ export class EvalBroker {
           // Runner just cleared its moduleCache during this INIT (full
           // context rebuild or reuseModules:false). Drop our shipped-code
           // mirror so handleLoad ships fresh code on the next LOAD.
-          this.lastSentLoadByModule.clear();
+          this.loadMirror.clear();
           this.sessionLinkGraph.clear();
+          this.activeEvalTelemetry?.recordRunnerSignal({
+            type: 'modules-reset',
+          });
         }
         this.resolvePending(message.id, {});
         return;
       case 'EVAL_RESULT': {
         // Runner reports any ids it dropped from its caches during this
         // session (e.g. modules whose link errored after a transient missing
-        // import). Mirror those evictions here — otherwise lastSentLoadByModule
+        // import). Mirror those evictions here — otherwise loadMirror
         // would keep claiming the runner has them and handleLoad would ship
         // empty `code` on the next session, leaving the runner stuck.
         const evictedIds = (
           message.payload as { evictedIds?: readonly string[] } | null
         )?.evictedIds;
         if (evictedIds && evictedIds.length > 0) {
+          this.activeEvalTelemetry?.recordRunnerSignal({
+            ids: evictedIds,
+            type: 'poison-ids',
+          });
           for (const evictedId of evictedIds) {
-            this.lastSentLoadByModule.delete(evictedId);
+            this.loadMirror.delete(evictedId);
           }
         }
         if (message.error) {
@@ -2118,18 +2042,24 @@ export class EvalBroker {
           }).catch((sendError) => this.handleSendMessageError(sendError));
         });
         return;
-      case 'LOAD':
-        this.handleLoad(message.id, message.payload).catch((error) => {
-          void this.sendMessage({
-            type: 'LOAD_RESULT',
-            id: message.id,
-            payload: {
-              id: message.payload.id,
-              error: toSerializedError(error),
-            },
-          }).catch((sendError) => this.handleSendMessageError(sendError));
-        });
+      case 'LOAD': {
+        const telemetry = this.activeEvalTelemetry;
+        this.handleLoad(message.id, message.payload, telemetry).catch(
+          (error) => {
+            void this.sendLoadResult(
+              message.id,
+              {
+                id: message.payload.id,
+                error: toSerializedError(error),
+              },
+              telemetry
+                ? { details: { mode: 'error' }, token: telemetry }
+                : undefined
+            ).catch((sendError) => this.handleSendMessageError(sendError));
+          }
+        );
         return;
+      }
       case 'WARN':
         this.handleWarn(message.payload);
         break;
@@ -2164,7 +2094,7 @@ export class EvalBroker {
   private async handleResolve(id: string, payload: ResolveRequestPayload) {
     const result = await this.resolveImport(payload);
 
-    if (debugEvalDir) {
+    if (debugEvalEnabled) {
       debugAction({
         type: 'resolve',
         evalSeq: this.evalSeq,
@@ -2877,8 +2807,13 @@ export class EvalBroker {
     }
   }
 
-  private async handleLoad(id: string, payload: LoadRequestPayload) {
-    const prepared = await this.loadModule(payload);
+  private async handleLoad(
+    id: string,
+    payload: LoadRequestPayload,
+    telemetry = this.activeEvalTelemetry
+  ) {
+    telemetry?.recordLoadRequest();
+    const prepared = await this.loadModule(payload, telemetry);
 
     // Decide once whether the runner already has this exact prepared variant.
     // The runner caches by id and short-circuits when the LoadResult hash
@@ -2886,17 +2821,17 @@ export class EvalBroker {
     // shipment under the same hash already covered the requested `only`,
     // re-shipping the code is pure waste — both over IPC and to the dump dir.
     const previouslySent = prepared.hash
-      ? this.lastSentLoadByModule.get(payload.id)
+      ? this.loadMirror.get(payload.id)
       : undefined;
-    // Runner stores by hash but classifies storage by `only` shape: wildcard
-    // (`['*']`) ⇒ moduleCache, anything else ⇒ moduleVariants (runner.js
-    // isFullModuleLoad / runner.js:1832-1842). Reusing across shapes would
-    // hit the wrong map and miss. Require the same shape AND the prepared
-    // `only` to be a subset of what we already shipped — same hash already
-    // implies identical bytes.
+    // Legacy broker dedup and telemetry use separate shape classifiers because
+    // the runner stores `only=[]` as a variant, not as wildcard coverage.
     const sameStorageShape = Boolean(
       previouslySent &&
-        isWildcardOnly(previouslySent.only) === isWildcardOnly(prepared.only)
+        hasSameBrokerStorageShape(previouslySent.only, prepared.only)
+    );
+    const sameRunnerStorageShape = Boolean(
+      previouslySent &&
+        hasSameRunnerStorageShape(previouslySent.only, prepared.only)
     );
     const runnerHasCachedVariant = Boolean(
       prepared.hash &&
@@ -2905,19 +2840,29 @@ export class EvalBroker {
         sameStorageShape &&
         isSuperSet(previouslySent.only, prepared.only)
     );
-    // `prepared.code` is a plain string, never absent — a module whose
-    // runtime footprint is genuinely nothing (types-only, or a barrel's
-    // `export *` target that shakes to zero bytes) legitimately prepares to
-    // ''. Gating on its truthiness treated that real payload the same as
-    // "nothing to ship", so the first request for such a module shipped ''
-    // with no prior variant for the runner to fall back on. Ship whenever
-    // the runner doesn't already have an equivalent variant cached; only
-    // omit the field (see the LoadResult below) when it does.
+    // Empty prepared code is a legitimate payload. Ship it unless the runner
+    // has an equivalent variant; only an omitted field means cache reuse.
     const shouldShipCode = Boolean(
       !prepared.exports && !runnerHasCachedVariant
     );
+    const shippedCodeBytes =
+      telemetry && shouldShipCode
+        ? Buffer.byteLength(prepared.code)
+        : undefined;
+    const transmissionTelemetry = telemetry
+      ? createLoadTransmissionTelemetry({
+          code: prepared.code,
+          codeBytes: shippedCodeBytes,
+          hash: prepared.hash,
+          hasSerializedExports: Boolean(prepared.exports),
+          previouslySent,
+          sameStorageShape: sameRunnerStorageShape,
+          shouldShipCode,
+          token: telemetry,
+        })
+      : undefined;
 
-    if (debugEvalDir) {
+    if (debugEvalEnabled) {
       if (shouldShipCode) {
         dumpEvalCode(
           payload.id,
@@ -2944,27 +2889,44 @@ export class EvalBroker {
 
     this.recordEvalFileDebugLine(payload, prepared, shouldShipCode);
 
-    await this.sendLoadResult(id, {
-      id: payload.id,
-      // Omit `code` entirely — rather than sending '' — when we're not
-      // shipping. '' is a legitimate LoadResult for a runtime-empty module;
-      // only an *absent* field means "reuse what you already have".
-      ...(shouldShipCode ? { code: prepared.code } : {}),
-      map: null,
-      hash: prepared.hash,
-      only: prepared.only,
-      exports: prepared.exports,
-    });
+    await this.sendLoadResult(
+      id,
+      {
+        id: payload.id,
+        // Omit `code` entirely — rather than sending '' — when we're not
+        // shipping. '' is a legitimate LoadResult for a runtime-empty module;
+        // only an *absent* field means "reuse what you already have".
+        ...(shouldShipCode ? { code: prepared.code } : {}),
+        map: null,
+        hash: prepared.hash,
+        only: prepared.only,
+        exports: prepared.exports,
+      },
+      transmissionTelemetry
+    );
 
     if (shouldShipCode && prepared.hash) {
       const merged =
         previouslySent?.hash === prepared.hash
           ? mergeOnly(previouslySent.only, prepared.only)
           : [...prepared.only];
-      this.lastSentLoadByModule.set(payload.id, {
+      this.loadMirror.set(payload.id, {
+        ...(shippedCodeBytes === undefined
+          ? {}
+          : { codeBytes: shippedCodeBytes }),
         hash: prepared.hash,
         only: merged,
       });
+      if (
+        telemetry &&
+        previouslySent &&
+        previouslySent.hash !== prepared.hash
+      ) {
+        telemetry.recordPressureProxy({
+          store: getRunnerStorage(prepared.only),
+          type: 'shipment-hash-change',
+        });
+      }
     }
     // Session link graph tracks every module that's been admitted into
     // the current runner's VM. mergeKnownDependencyOnly uses this to
@@ -2976,27 +2938,33 @@ export class EvalBroker {
     }
   }
 
-  private async loadModule({
-    id,
-    importerId,
-    request,
-  }: LoadRequestPayload): Promise<PreparedCacheEntry> {
+  private async loadModule(
+    { id, importerId, request }: LoadRequestPayload,
+    telemetry = this.activeEvalTelemetry
+  ): Promise<PreparedCacheEntry> {
     const actionEntrypoint = importerId ?? id;
     return this.services.eventEmitter.action(
       'eval:loadModule',
       `${actionEntrypoint}\0${id}`,
       actionEntrypoint,
-      () => this.loadModuleImpl({ id, importerId, request })
+      () => this.loadModuleImpl({ id, importerId, request }, telemetry)
     );
   }
 
-  private async loadModuleImpl({
-    id,
-    importerId,
-    request,
-  }: LoadRequestPayload): Promise<PreparedCacheEntry> {
+  private async loadModuleImpl(
+    { id, importerId, request }: LoadRequestPayload,
+    telemetry = this.activeEvalTelemetry
+  ): Promise<PreparedCacheEntry> {
     let cached = this.loadCache.get(id);
-    if (this.services.cache.consumeInvalidation(id)) {
+    const invalidated = this.services.cache.consumeInvalidation(id);
+    if (invalidated) {
+      if (telemetry && cached) {
+        telemetry.recordPreparedCacheEviction({
+          id,
+          knownCodeBytes: Buffer.byteLength(cached.code),
+          reason: 'invalidation',
+        });
+      }
       this.loadCache.delete(id);
       cached = undefined;
     }
@@ -3065,6 +3033,7 @@ export class EvalBroker {
         );
         if (serialized) {
           const hash = hashContent(`exports:${JSON.stringify(serialized)}`);
+          telemetry?.recordLoadCacheOutcome('serialized-exports');
           return {
             code: '',
             imports: null,
@@ -3084,18 +3053,32 @@ export class EvalBroker {
     // entrypoint when its source is unchanged; my IPC dedup mirror then
     // suppresses re-shipping to the runner.
     if (cached && isPreparedCacheHit(cached, requiredOnly)) {
+      telemetry?.recordLoadCacheOutcome('hit');
       this.ensureImportsMapping(id, cached.imports);
       return cached;
     }
 
     const inflight = this.loadInFlight.get(id);
+    let inflightWaitMiss = false;
     if (inflight) {
+      telemetry?.recordLoadCacheOutcome('inflight-wait');
       const result = await inflight;
       if (isPreparedCacheHit(result, requiredOnly)) {
+        telemetry?.recordLoadCacheOutcome('inflight-hit');
         this.ensureImportsMapping(id, result.imports);
         return result;
       }
+      inflightWaitMiss = true;
+      telemetry?.recordLoadCacheOutcome('inflight-wait-miss');
     }
+
+    telemetry?.recordLoadCacheOutcome(
+      invalidated
+        ? 'invalidation-miss'
+        : cached || inflightWaitMiss
+        ? 'promotion'
+        : 'miss'
+    );
 
     const slowImportWarningsEnabled = isWarningEnabled(
       process.env.WYW_WARN_SLOW_IMPORTS
@@ -3212,7 +3195,30 @@ export class EvalBroker {
         requiredOnly.includes('__wywPreval') || !cached
           ? requiredOnly
           : mergeOnly(cached.only, requiredOnly);
-      const prepared = prepareModuleOnDemand(this.services, id, prepareOnly);
+      const preparationTelemetry = telemetry?.beginPreparation(id, prepareOnly);
+      let prepared: PreparedModule;
+      try {
+        prepared = preparationTelemetry
+          ? preparationTelemetry.measureStage('prepare', () =>
+              prepareModuleOnDemand(
+                this.services,
+                id,
+                prepareOnly,
+                preparationTelemetry
+              )
+            )
+          : prepareModuleOnDemand(this.services, id, prepareOnly);
+      } catch (error) {
+        preparationTelemetry?.fail();
+        throw error;
+      }
+      const hash = hashContent(prepared.code);
+      preparationTelemetry?.finish({
+        code: prepared.code,
+        imports: prepared.imports,
+        only: prepared.only,
+        outputRevision: hash,
+      });
 
       this.ensureImportsMapping(id, prepared.imports);
 
@@ -3251,7 +3257,6 @@ export class EvalBroker {
         }
       }
 
-      const hash = hashContent(prepared.code);
       return { ...prepared, hash };
     })();
 
@@ -3264,75 +3269,46 @@ export class EvalBroker {
       // ensureImportsMapping, so getLoadRequestOnly can't determine what a barrel
       // module imports from its sub-dependencies.
       this.ensureImportsMapping(id, result.imports);
-      this.loadCache.set(id, result);
+      const replaced = telemetry ? this.loadCache.peek(id) : undefined;
+      if (replaced) {
+        telemetry?.recordPreparedCacheEviction({
+          id,
+          knownCodeBytes: Buffer.byteLength(replaced.code),
+          reason: 'replacement',
+        });
+      }
+      this.loadCache.set(
+        id,
+        result,
+        telemetry
+          ? (evictedId, evicted) => {
+              telemetry.recordPreparedCacheEviction({
+                id: evictedId,
+                knownCodeBytes: Buffer.byteLength(evicted.code),
+                reason: 'capacity',
+              });
+            }
+          : undefined
+      );
       return result;
     } finally {
       this.loadInFlight.delete(id);
     }
   }
 
-  private async sendLoadResult(
+  private sendLoadResult(
     id: string,
-    payload: Omit<LoadResultPayload, 'chunkIndex' | 'chunkCount' | 'codeChunk'>
-  ) {
-    if (!payload.code) {
-      await this.sendMessage({
-        type: 'LOAD_RESULT',
-        id,
-        payload,
-      });
-      return;
-    }
-
-    const message: MainToRunnerMessage = {
-      type: 'LOAD_RESULT',
-      id,
-      payload,
-    };
-    const serialized = JSON.stringify(message);
-    if (serialized.length < MAX_MESSAGE_SIZE) {
-      await this.sendMessage(message);
-      return;
-    }
-
-    const { code } = payload;
-    const chunkCount = Math.ceil(code.length / MAX_CHUNK_SIZE);
-    for (let index = 0; index < chunkCount; index += 1) {
-      const start = index * MAX_CHUNK_SIZE;
-      const end = start + MAX_CHUNK_SIZE;
-      const codeChunk = code.slice(start, end);
-      const chunkPayload: LoadResultPayload = {
-        id: payload.id,
-        codeChunk,
-        chunkIndex: index,
-        chunkCount,
-      };
-
-      if (index === 0) {
-        chunkPayload.map = payload.map;
-        chunkPayload.hash = payload.hash;
-        chunkPayload.only = payload.only;
-        chunkPayload.exports = payload.exports;
-        chunkPayload.error = payload.error;
-      }
-
-      await this.sendMessage({
-        type: 'LOAD_RESULT',
-        id,
-        payload: chunkPayload,
-      });
-    }
+    payload: Omit<LoadResultPayload, 'chunkIndex' | 'chunkCount' | 'codeChunk'>,
+    telemetry?: LoadTransmissionTelemetry
+  ): Promise<void> {
+    return sendEvalLoadResult(id, payload, telemetry, this.sendLoadMessage);
   }
 
-  private sendMessage(message: MainToRunnerMessage): Promise<void> {
-    const payload = `${JSON.stringify(message)}\n`;
-    invariant(payload.length < MAX_MESSAGE_SIZE, 'Message too large');
-
-    if (!this.runnerInputQueue) {
-      return Promise.reject(new Error('Eval runner is not ready'));
-    }
-
-    return this.runnerInputQueue.write(payload);
+  private sendMessage(
+    message: MainToRunnerMessage,
+    onSerialized?: (bytes: number) => void
+  ): Promise<void> {
+    return sendEvalMessage(this.runnerInputQueue, message, onSerialized);
   }
 
   private handleSendMessageError(error: unknown, id?: string) {
@@ -3345,6 +3321,7 @@ export class EvalBroker {
       this.rejectPending(id, serialized);
     }
 
+    this.recordBrokerLifecycle('runner-stop-requested', 'send-error', true);
     this.runner?.kill();
   }
 
@@ -3364,6 +3341,11 @@ export class EvalBroker {
     return new Promise<TPayload>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(id);
+        this.recordBrokerLifecycle(
+          'runner-stop-requested',
+          `request-timeout:${type}`,
+          true
+        );
         this.runner?.kill();
         const error = new Error(
           `[wyw-in-js] Eval runner timed out for ${type}`
@@ -3476,7 +3458,7 @@ const evalBrokers = new WeakMap<
 export const disposeEvalBroker = (cache: Services['cache']) => {
   const cached = evalBrokers.get(cache);
   if (!cached) return;
-  cached.broker.dispose();
+  cached.broker.dispose('registry-dispose');
   evalBrokers.delete(cache);
 };
 
@@ -3490,10 +3472,19 @@ export const getEvalBroker = (
   cacheKey: string
 ) => {
   const cached = evalBrokers.get(services.cache);
-  if (cached && cached.key === cacheKey) return cached.broker;
+  if (cached && cached.key === cacheKey) {
+    if (hasEvalTelemetryReporter(services.eventEmitter)) {
+      recordEvalBrokerLifecycle(services.eventEmitter, cached.broker, () => ({
+        event: 'broker-reused',
+        reason: 'stable-cache-key',
+      }));
+    }
+    return cached.broker;
+  }
 
   if (cached) {
-    disposeEvalBroker(services.cache);
+    cached.broker.dispose('cache-key-change');
+    evalBrokers.delete(services.cache);
   }
   const broker = new EvalBroker(services, asyncResolve);
   evalBrokers.set(services.cache, { key: cacheKey, broker });

--- a/packages/transform/src/eval/brokerTelemetry.ts
+++ b/packages/transform/src/eval/brokerTelemetry.ts
@@ -1,0 +1,303 @@
+/* eslint-disable no-await-in-loop, no-void */
+import { invariant } from 'ts-invariant';
+
+import type {
+  EvalBrokerMirrorSnapshot,
+  EvalLoadTransmission,
+  EvalTelemetryToken,
+} from '../debug/evalTelemetry';
+
+import type { LoadResultPayload, MainToRunnerMessage } from './protocol';
+import type { WriteQueue } from './writeQueue';
+
+export const EVAL_MAX_MESSAGE_SIZE = 10 * 1024 * 1024;
+const EVAL_MAX_CHUNK_SIZE = 512 * 1024;
+
+export type BrokerMirrorEntry = {
+  codeBytes?: number;
+  hash: string;
+  only: string[];
+};
+
+// Existing shipped-code dedup treats an empty `only` like wildcard coverage.
+// Keep this compatibility rule separate from the runner's actual storage
+// classifier so telemetry never presents it as runner state.
+export const hasSameBrokerStorageShape = (
+  left: string[] | undefined | null,
+  right: string[] | undefined | null
+): boolean => {
+  const isWildcard = (only: string[] | undefined | null): boolean =>
+    !only || only.length === 0 || (only.length === 1 && only[0] === '*');
+  return isWildcard(left) === isWildcard(right);
+};
+
+export const getRunnerStorage = (
+  only: string[] | undefined | null
+): 'primary' | 'variant' =>
+  !only || (only.length === 1 && only[0] === '*') ? 'primary' : 'variant';
+
+export const hasSameRunnerStorageShape = (
+  left: string[] | undefined | null,
+  right: string[] | undefined | null
+): boolean => getRunnerStorage(left) === getRunnerStorage(right);
+
+export type LoadTransmissionTelemetry = {
+  details: Omit<EvalLoadTransmission, 'chunks' | 'wireBytes' | 'wireMessages'>;
+  token: EvalTelemetryToken;
+};
+
+export class BrokerLoadMirror {
+  private readonly entries = new Map<string, BrokerMirrorEntry>();
+
+  private cachedSnapshot: EvalBrokerMirrorSnapshot | null = null;
+
+  public clear(): void {
+    this.entries.clear();
+    if (!this.cachedSnapshot) return;
+    this.cachedSnapshot = {
+      entries: 0,
+      knownCodeBytes: 0,
+      unknownByteEntries: 0,
+    };
+  }
+
+  public delete(id: string): void {
+    const previous = this.entries.get(id);
+    if (!previous || !this.entries.delete(id)) return;
+    if (!this.cachedSnapshot) return;
+
+    this.cachedSnapshot.entries = this.entries.size;
+    if (previous.codeBytes === undefined) {
+      this.cachedSnapshot.unknownByteEntries -= 1;
+    } else {
+      this.cachedSnapshot.knownCodeBytes -= previous.codeBytes;
+    }
+  }
+
+  public get(id: string): BrokerMirrorEntry | undefined {
+    return this.entries.get(id);
+  }
+
+  public set(id: string, entry: BrokerMirrorEntry): void {
+    const previous = this.entries.get(id);
+    this.entries.set(id, entry);
+    if (!this.cachedSnapshot) return;
+
+    if (previous) {
+      if (previous.codeBytes === undefined) {
+        this.cachedSnapshot.unknownByteEntries -= 1;
+      } else {
+        this.cachedSnapshot.knownCodeBytes -= previous.codeBytes;
+      }
+    }
+    if (entry.codeBytes === undefined) {
+      this.cachedSnapshot.unknownByteEntries += 1;
+    } else {
+      this.cachedSnapshot.knownCodeBytes += entry.codeBytes;
+    }
+    this.cachedSnapshot.entries = this.entries.size;
+  }
+
+  public snapshot(): EvalBrokerMirrorSnapshot {
+    if (!this.cachedSnapshot) {
+      let knownCodeBytes = 0;
+      let unknownByteEntries = 0;
+      this.entries.forEach((entry) => {
+        if (entry.codeBytes === undefined) unknownByteEntries += 1;
+        else knownCodeBytes += entry.codeBytes;
+      });
+      this.cachedSnapshot = {
+        entries: this.entries.size,
+        knownCodeBytes,
+        unknownByteEntries,
+      };
+    }
+
+    return { ...this.cachedSnapshot };
+  }
+}
+
+export const createLoadTransmissionTelemetry = ({
+  code,
+  codeBytes,
+  hash,
+  hasSerializedExports,
+  previouslySent,
+  sameStorageShape,
+  shouldShipCode,
+  token,
+}: {
+  code: string;
+  codeBytes: number | undefined;
+  hash: string | undefined;
+  hasSerializedExports: boolean;
+  previouslySent: BrokerMirrorEntry | undefined;
+  sameStorageShape: boolean;
+  shouldShipCode: boolean;
+  token: EvalTelemetryToken;
+}): LoadTransmissionTelemetry => {
+  let mode: EvalLoadTransmission['mode'];
+  let resendReason: EvalLoadTransmission['resendReason'];
+  if (hasSerializedExports) {
+    mode = 'serialized-exports';
+  } else if (!shouldShipCode) {
+    mode = 'omission';
+  } else if (!previouslySent) {
+    mode = 'initial';
+  } else {
+    mode = 'resend';
+    if (previouslySent.hash !== hash) {
+      resendReason = 'hash-change';
+    } else if (!sameStorageShape) {
+      resendReason = 'storage-shape-change';
+    } else {
+      resendReason = 'only-widening';
+    }
+  }
+
+  return {
+    details: {
+      ...(shouldShipCode ? { code, codeBytes } : {}),
+      mode,
+      ...(resendReason ? { resendReason } : {}),
+    },
+    token,
+  };
+};
+
+type SendMessage = (
+  message: MainToRunnerMessage,
+  onSerialized?: (bytes: number) => void
+) => Promise<void>;
+
+export const sendEvalMessage = (
+  queue: WriteQueue | null,
+  message: MainToRunnerMessage,
+  onSerialized?: (bytes: number) => void
+): Promise<void> => {
+  const payload = `${JSON.stringify(message)}\n`;
+  invariant(payload.length < EVAL_MAX_MESSAGE_SIZE, 'Message too large');
+
+  if (!queue) {
+    return Promise.reject(new Error('Eval runner is not ready'));
+  }
+
+  const written = queue.write(payload);
+  if (!onSerialized) return written;
+  return written.then(() => {
+    try {
+      onSerialized(Buffer.byteLength(payload));
+    } catch {
+      // Debug accounting must not change transport behavior.
+    }
+  });
+};
+
+export const sendEvalLoadResult = async (
+  id: string,
+  payload: Omit<LoadResultPayload, 'chunkIndex' | 'chunkCount' | 'codeChunk'>,
+  telemetry: LoadTransmissionTelemetry | undefined,
+  sendMessage: SendMessage
+): Promise<void> => {
+  let wireBytes = 0;
+  let wireMessages = 0;
+  let successfulChunkCodeBytes = 0;
+  let chunked = false;
+  const recordWirePayload = telemetry
+    ? (bytes: number) => {
+        wireBytes += bytes;
+        wireMessages += 1;
+      }
+    : undefined;
+  const finishTelemetry = telemetry
+    ? (chunks: number, incomplete = false) => {
+        if (incomplete) {
+          const { code, ...detailsWithoutCode } = telemetry.details;
+          void code;
+          telemetry.token.recordLoadTransmission({
+            ...detailsWithoutCode,
+            chunks,
+            codeBytes: successfulChunkCodeBytes,
+            incomplete: true,
+            logicalResults: 0,
+            wireBytes,
+            wireMessages,
+          });
+          return;
+        }
+
+        telemetry.token.recordLoadTransmission({
+          ...telemetry.details,
+          chunks,
+          wireBytes,
+          wireMessages,
+        });
+      }
+    : undefined;
+
+  try {
+    if (!payload.code) {
+      await sendMessage(
+        {
+          type: 'LOAD_RESULT',
+          id,
+          payload,
+        },
+        recordWirePayload
+      );
+      finishTelemetry?.(0);
+      return;
+    }
+
+    const message: MainToRunnerMessage = {
+      type: 'LOAD_RESULT',
+      id,
+      payload,
+    };
+    const serialized = JSON.stringify(message);
+    if (serialized.length < EVAL_MAX_MESSAGE_SIZE) {
+      await sendMessage(message, recordWirePayload);
+      finishTelemetry?.(0);
+      return;
+    }
+
+    chunked = true;
+    const { code } = payload;
+    const chunkCount = Math.ceil(code.length / EVAL_MAX_CHUNK_SIZE);
+    for (let index = 0; index < chunkCount; index += 1) {
+      const start = index * EVAL_MAX_CHUNK_SIZE;
+      const end = start + EVAL_MAX_CHUNK_SIZE;
+      const codeChunk = code.slice(start, end);
+      const chunkPayload: LoadResultPayload = {
+        id: payload.id,
+        codeChunk,
+        chunkIndex: index,
+        chunkCount,
+      };
+
+      if (index === 0) {
+        chunkPayload.map = payload.map;
+        chunkPayload.hash = payload.hash;
+        chunkPayload.only = payload.only;
+        chunkPayload.exports = payload.exports;
+        chunkPayload.error = payload.error;
+      }
+
+      await sendMessage(
+        {
+          type: 'LOAD_RESULT',
+          id,
+          payload: chunkPayload,
+        },
+        recordWirePayload
+      );
+      if (telemetry) {
+        successfulChunkCodeBytes += Buffer.byteLength(codeChunk);
+      }
+    }
+    finishTelemetry?.(chunkCount);
+  } catch (error) {
+    finishTelemetry?.(chunked ? wireMessages : 0, true);
+    throw error;
+  }
+};

--- a/packages/transform/src/eval/debugEval.ts
+++ b/packages/transform/src/eval/debugEval.ts
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import path from 'path';
+
+import { stripQueryAndHash } from '../utils/parseRequest';
+import type { DebugEvalFileValues } from './protocol';
+import type { SerializedValue } from './serialize';
+
+export type DebugEvalValueStatus =
+  | 'mixed'
+  | 'none'
+  | 'serialized'
+  | 'stringified';
+
+const resolveDebugEvalDir = (): string | undefined => {
+  const override = process.env.WYW_DUMP_EVALS_DIR;
+  if (override) {
+    return path.resolve(override);
+  }
+
+  const base = process.env.WYW_DUMP_EVALS;
+  if (!base) {
+    return undefined;
+  }
+
+  const ts = new Date()
+    .toISOString()
+    .slice(0, 19)
+    .replace(/[-:T]/g, (character) => (character === 'T' ? '-' : ''));
+  const root = base === '1' || base === 'true' ? './tmp' : base;
+  return path.resolve(root, `wyw-dump-evals-${ts}`);
+};
+
+const debugEvalDir = resolveDebugEvalDir();
+let debugEvalDirReady = false;
+
+export const debugEvalEnabled = debugEvalDir !== undefined;
+
+export const toBase64 = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64');
+
+export const toJsonBase64 = (value: unknown): string =>
+  toBase64(JSON.stringify(value));
+
+export const serializedExportsToDebugValues = (
+  serializedExports: Record<string, SerializedValue>
+): DebugEvalFileValues => ({
+  exports: Object.fromEntries(
+    Object.entries(serializedExports).map(([key, serialized]) => [
+      key,
+      {
+        serialized,
+        status: 'serialized' as const,
+      },
+    ])
+  ),
+});
+
+export const getDebugValuesStatus = (
+  values: DebugEvalFileValues | undefined
+): DebugEvalValueStatus => {
+  const statuses = [
+    ...Object.values(values?.exports ?? {}),
+    ...Object.values(values?.preval ?? {}),
+  ].map((value) => value.status);
+
+  if (statuses.length === 0) {
+    return 'none';
+  }
+
+  const hasSerialized = statuses.includes('serialized');
+  const hasStringified = statuses.includes('stringified');
+  if (hasSerialized && hasStringified) {
+    return 'mixed';
+  }
+
+  return hasStringified ? 'stringified' : 'serialized';
+};
+
+const ensureDebugEvalDir = () => {
+  if (!debugEvalDir || debugEvalDirReady) {
+    return;
+  }
+  fs.mkdirSync(debugEvalDir, { recursive: true });
+  debugEvalDirReady = true;
+};
+
+let debugEvalSeq = 0;
+
+export const dumpEvalCode = (
+  id: string,
+  code: string,
+  only: string[],
+  source: string,
+  evalSeq: number
+) => {
+  if (!debugEvalDir) {
+    return;
+  }
+  ensureDebugEvalDir();
+  debugEvalSeq += 1;
+  const seq = String(debugEvalSeq).padStart(5, '0');
+  const evalSequence = String(evalSeq).padStart(5, '0');
+  const relativeId = path.relative(process.cwd(), stripQueryAndHash(id));
+  const safeName = relativeId.replace(/[/\\]/g, '__').replace(/^__/, '');
+  const filename = `seq${seq}_eval${evalSequence}_${safeName}.js`;
+  const header = [
+    `// id: ${id}`,
+    `// only: ${JSON.stringify(only)}`,
+    `// source: ${source}`,
+    `// seq: ${seq}`,
+    `// eval: #${evalSequence}`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(debugEvalDir, filename), header + code);
+};
+
+let debugActionStream: fs.WriteStream | null = null;
+
+export const debugAction = (event: Record<string, unknown>) => {
+  if (!debugEvalDir) {
+    return;
+  }
+  ensureDebugEvalDir();
+  if (!debugActionStream) {
+    debugActionStream = fs.createWriteStream(
+      path.join(debugEvalDir, 'actions.jsonl')
+    );
+  }
+  debugActionStream.write(`${JSON.stringify(event)}\n`);
+};
+
+export const flushDebugStreams = () => {
+  debugActionStream?.end();
+  debugActionStream = null;
+};

--- a/packages/transform/src/eval/lru.ts
+++ b/packages/transform/src/eval/lru.ts
@@ -7,6 +7,14 @@ export class LruCache<K, V> {
     this.maxSize = Math.max(1, maxSize);
   }
 
+  public get size(): number {
+    return this.map.size;
+  }
+
+  public peek(key: K): V | undefined {
+    return this.map.get(key);
+  }
+
   public get(key: K): V | undefined {
     const value = this.map.get(key);
     if (value === undefined) return undefined;
@@ -16,7 +24,11 @@ export class LruCache<K, V> {
     return value;
   }
 
-  public set(key: K, value: V): void {
+  public set(
+    key: K,
+    value: V,
+    onEvict?: (evictedKey: K, evictedValue: V) => void
+  ): void {
     if (this.map.has(key)) {
       this.map.delete(key);
     }
@@ -26,7 +38,9 @@ export class LruCache<K, V> {
     if (this.map.size > this.maxSize) {
       const firstKey = this.map.keys().next().value as K | undefined;
       if (firstKey !== undefined) {
+        const evictedValue = this.map.get(firstKey)!;
         this.map.delete(firstKey);
+        onEvict?.(firstKey, evictedValue);
       }
     }
   }

--- a/packages/transform/src/eval/prepareModuleOnDemand.ts
+++ b/packages/transform/src/eval/prepareModuleOnDemand.ts
@@ -3,6 +3,7 @@ import type { Services } from '../transform/types';
 import { Entrypoint } from '../transform/Entrypoint';
 import { collectOxcImportMap } from '../utils/oxcImportMap';
 import { prepareCodeForEvalRuntime } from '../transform/generators/transform';
+import type { EvalPreparationToken } from '../debug/evalTelemetry.types';
 
 export type PreparedModule = {
   code: string;
@@ -13,7 +14,8 @@ export type PreparedModule = {
 export function prepareModuleOnDemand(
   services: Services,
   id: string,
-  only: string[]
+  only: string[],
+  telemetry?: EvalPreparationToken
 ): PreparedModule {
   const entrypoint = Entrypoint.createRoot(services, id, only, undefined, {
     mergeCachedOnly: !only.includes('__wywPreval'),
@@ -50,7 +52,12 @@ export function prepareModuleOnDemand(
       : (entrypoint.loadedAndParsed.ast as Parameters<
           typeof prepareCodeForEvalRuntime
         >[2]);
-  const [code, imports] = prepareCodeForEvalRuntime(services, entrypoint, ast);
+  const [code, imports] = prepareCodeForEvalRuntime(
+    services,
+    entrypoint,
+    ast,
+    telemetry
+  );
 
   return {
     code,

--- a/packages/transform/src/eval/stable-init-hash.ts
+++ b/packages/transform/src/eval/stable-init-hash.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-void */
+import { createHash } from 'crypto';
+
+import type { EvalRunnerInitPayload } from './protocol';
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const canonicalizeForHash = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeForHash(item));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalizeForHash(value[key])])
+    );
+  }
+
+  return value;
+};
+
+// Hash everything in the init payload that affects whether the runner needs
+// a fresh INIT. `entrypoint` only controls __filename/__dirname rebinding and
+// is deliberately excluded so callers can memoize the stable configuration.
+export const getStableInitPayloadHash = (
+  payload: EvalRunnerInitPayload
+): string => {
+  const { entrypoint, ...stable } = payload;
+  void entrypoint;
+
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalizeForHash(stable)))
+    .digest('hex');
+};

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -28,6 +28,7 @@ import {
   finishPipelineShake,
   recordPipelineLateNoMetadata,
 } from '../../debug/pipelineTelemetry';
+import type { EvalPreparationToken } from '../../debug/evalTelemetry.types';
 
 const EMPTY_FILE = '=== empty file ===';
 
@@ -85,6 +86,7 @@ export const emitCurrentStaticPlanDebug = (
 
 type PrepareCodeOptions = {
   emitCommonJS?: boolean;
+  evalTelemetry?: EvalPreparationToken;
   shortCircuitOnMissingMetadata?: boolean;
   stripForEvalRuntime?: boolean;
 };
@@ -217,7 +219,12 @@ const prepareOxcCodeImpl = (
   ) {
     log('[evaluator:end] no metadata');
     recordPipelineLateNoMetadata(filename, only, 'preeval');
-    const strippedCode = stripTypesAndJsxWithOxc(preevalCode, filename).code;
+    const strippedCode = options.evalTelemetry
+      ? options.evalTelemetry.measureStage(
+          'strip',
+          () => stripTypesAndJsxWithOxc(preevalCode, filename).code
+        )
+      : stripTypesAndJsxWithOxc(preevalCode, filename).code;
 
     return [
       normalizeOxcPreparedESM(strippedCode),
@@ -237,22 +244,42 @@ const prepareOxcCodeImpl = (
   );
   let shaken: ReturnType<typeof shakeOxcToESM>;
   if (!shakeToken) {
-    shaken = eventEmitter.perf('transform:evaluator', () =>
-      shakeOxcToESM(preevalCode, filename, {
-        importOverrides: pluginOptions.importOverrides,
-        onlyExports: only,
-        root,
-      })
-    );
+    shaken = options.evalTelemetry
+      ? options.evalTelemetry.measureStage('shake', () =>
+          eventEmitter.perf('transform:evaluator', () =>
+            shakeOxcToESM(preevalCode, filename, {
+              importOverrides: pluginOptions.importOverrides,
+              onlyExports: only,
+              root,
+            })
+          )
+        )
+      : eventEmitter.perf('transform:evaluator', () =>
+          shakeOxcToESM(preevalCode, filename, {
+            importOverrides: pluginOptions.importOverrides,
+            onlyExports: only,
+            root,
+          })
+        );
   } else {
     try {
-      shaken = eventEmitter.perf('transform:evaluator', () =>
-        shakeOxcToESM(preevalCode, filename, {
-          importOverrides: pluginOptions.importOverrides,
-          onlyExports: only,
-          root,
-        })
-      );
+      shaken = options.evalTelemetry
+        ? options.evalTelemetry.measureStage('shake', () =>
+            eventEmitter.perf('transform:evaluator', () =>
+              shakeOxcToESM(preevalCode, filename, {
+                importOverrides: pluginOptions.importOverrides,
+                onlyExports: only,
+                root,
+              })
+            )
+          )
+        : eventEmitter.perf('transform:evaluator', () =>
+            shakeOxcToESM(preevalCode, filename, {
+              importOverrides: pluginOptions.importOverrides,
+              onlyExports: only,
+              root,
+            })
+          );
       finishPipelineShake(shakeToken, shaken.code, false);
     } catch (error) {
       finishPipelineShake(shakeToken, null, true);
@@ -263,9 +290,15 @@ const prepareOxcCodeImpl = (
   log('[evaluator:end]');
 
   if (!options.emitCommonJS) {
-    const preparedCode = options.stripForEvalRuntime
-      ? stripTypesAndJsxWithOxc(shaken.code, filename).code
-      : shaken.code;
+    let preparedCode = shaken.code;
+    if (options.stripForEvalRuntime) {
+      preparedCode = options.evalTelemetry
+        ? options.evalTelemetry.measureStage(
+            'strip',
+            () => stripTypesAndJsxWithOxc(shaken.code, filename).code
+          )
+        : stripTypesAndJsxWithOxc(shaken.code, filename).code;
+    }
 
     return [
       normalizeOxcPreparedESM(preparedCode),
@@ -314,9 +347,11 @@ export const prepareCode = (
 export const prepareCodeForEvalRuntime = (
   services: Services,
   item: Entrypoint,
-  originalAst: unknown | null
+  originalAst: unknown | null,
+  evalTelemetry?: EvalPreparationToken
 ): ReturnType<PrepareCodeFn> =>
   prepareCodeImpl(services, item, originalAst, {
+    evalTelemetry,
     shortCircuitOnMissingMetadata: true,
     stripForEvalRuntime: true,
   });


### PR DESCRIPTION
## Summary

- add default-off evaluation broker and runner diagnostics to file reporter output
- record cache, preparation, transport, eviction, mirror, and lifecycle counters in schema-versioned JSONL with path redaction
- keep the evaluation protocol, results, and public event stream unchanged while avoiding producer work when reporting is disabled

## Validation

- transform suite: 1,785 passed; existing skip and todo unchanged
- differential transform corpus: 53 passed
- package lint and type build
- full integration coverage with unchanged generated CSS
- 15-pair, 900-root reporter on/off benchmark showed no regression: wall mean -0.34%, median -0.34%; CPU mean -0.09%