### PR TITLE
perf(transform): 2-3x cheaper parsing — raw transfer + shared parse cache

### DIFF
--- a/.changeset/fast-parsers-share.md
+++ b/.changeset/fast-parsers-share.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Parsing got dramatically cheaper on large projects. ASTs now transfer from oxc via the raw-transfer buffer instead of JSON, the parse cache is shared across filenames and source types (identical snippets and files parse once), and cache lookups no longer allocate whole-file key strings. Measured on a 6.5k-module monorepo build: oxc-parser self-time 5.8s → 1.5s, wyw transform −32%, collect −47%.

--- a/.changeset/fast-parsers-share.md
+++ b/.changeset/fast-parsers-share.md
@@ -2,4 +2,4 @@
 '@wyw-in-js/transform': patch
 ---
 
-Parsing got dramatically cheaper on large projects. ASTs now transfer from oxc via the raw-transfer buffer instead of JSON, the parse cache is shared across filenames and source types (identical snippets and files parse once), and cache lookups no longer allocate whole-file key strings. Measured on a 6.5k-module monorepo build: oxc-parser self-time 5.8s → 1.5s, wyw transform −32%, collect −47%.
+Parsing is cheaper on large projects. Compatible parses on supported runtimes now receive Oxc ASTs via the raw-transfer buffer instead of JSON, parse results are shared across filenames with equivalent parser semantics and across compatible source types, and cache lookups no longer allocate whole-file key strings.

--- a/packages/transform/src/__tests__/parseOxc.test.ts
+++ b/packages/transform/src/__tests__/parseOxc.test.ts
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+import {
+  isOxcRawTransferAstTypeCompatible,
+  parseOxcCached,
+} from '../utils/parseOxc';
+
+describe('parseOxcCached', () => {
+  it.each([
+    {
+      acceptedFilename: '/project/jsx-first.tsx',
+      code: 'const jsxFirst = <div />;',
+      rejectedFilename: '/project/jsx-first.ts',
+    },
+    {
+      acceptedFilename: '/project/type-assertion-first.ts',
+      code: 'const typeAssertionFirst = <number>1;',
+      rejectedFilename: '/project/type-assertion-first.tsx',
+    },
+    {
+      acceptedFilename: '/project/declaration-first.d.ts',
+      code: 'const declarationFirst: string;',
+      rejectedFilename: '/project/declaration-first.ts',
+    },
+    {
+      acceptedFilename: '/project/runtime-first.ts',
+      code: 'let runtimeFirst = 1;',
+      rejectedFilename: '/project/runtime-first.d.ts',
+    },
+    {
+      acceptedFilename: '/project/js-fallback-first.js',
+      code: 'const jsFallbackFirst = <div />;',
+      rejectedFilename: '/project/js-fallback-first.mjs',
+    },
+  ])(
+    'keeps the grammar for $acceptedFilename separate from $rejectedFilename',
+    ({ acceptedFilename, code, rejectedFilename }) => {
+      expect(() =>
+        parseOxcCached(acceptedFilename, code, 'module')
+      ).not.toThrow();
+      expect(() => parseOxcCached(rejectedFilename, code, 'module')).toThrow();
+    }
+  );
+
+  it('shares entries across filenames with equivalent parser semantics', () => {
+    const code = 'export const sharedDialectEntry: number = 1;';
+    const first = parseOxcCached('/project/first-shared.ts', code, 'module');
+    const second = parseOxcCached('/project/second-shared.ts', code, 'module');
+
+    expect(second).toBe(first);
+  });
+
+  it('shares the AST but not cache-entry identity across source types', () => {
+    const code = 'export const sharedSourceTypeEntry: number = 1;';
+    const moduleEntry = parseOxcCached(
+      '/project/shared-source-type.ts',
+      code,
+      'module'
+    );
+    const unambiguousEntry = parseOxcCached(
+      '/project/shared-source-type.ts',
+      code,
+      'unambiguous'
+    );
+
+    expect(unambiguousEntry).not.toBe(moduleEntry);
+    expect(unambiguousEntry.program).toBe(moduleEntry.program);
+  });
+});
+
+describe('raw-transfer compatibility', () => {
+  it.each([
+    ['js', 'js', true],
+    ['jsx', 'js', true],
+    ['ts', 'ts', true],
+    ['tsx', 'ts', true],
+    ['dts', 'ts', true],
+    ['ts', 'js', false],
+    ['tsx', 'js', false],
+    ['dts', 'js', false],
+    ['js', 'ts', false],
+  ] as const)(
+    'classifies language %s with AST type %s',
+    (language, astType, expected) => {
+      expect(isOxcRawTransferAstTypeCompatible(language, astType)).toBe(
+        expected
+      );
+    }
+  );
+
+  it('allows Oxc to select the default AST type', () => {
+    expect(isOxcRawTransferAstTypeCompatible('ts', undefined)).toBe(true);
+  });
+});

--- a/packages/transform/src/__tests__/pipelineTelemetry.test.ts
+++ b/packages/transform/src/__tests__/pipelineTelemetry.test.ts
@@ -719,6 +719,54 @@ describe('pipeline telemetry boundary', () => {
     expect(serialized).not.toContain(uncachedCode);
   });
 
+  it('attributes shared module-syntax cache entries to each requested source type', async () => {
+    const emitter = createEmitter();
+    const summaries: PipelineTelemetrySummary[] = [];
+    const unregister = registerPipelineTelemetryReporter(emitter, (summary) =>
+      summaries.push(summary)
+    );
+    const filename = '/project/pipeline-telemetry-shared-source-type.ts';
+    const code = 'export const sharedSourceType: number = 1;';
+
+    await runWithPipelineTelemetry(
+      emitter,
+      () => ({ filename }),
+      async () => {
+        parseOxcCached(filename, code, 'module');
+        parseOxcCached(filename, code, 'unambiguous');
+      }
+    );
+    unregister();
+
+    expect(summaries).toHaveLength(1);
+    expect(
+      summaries[0].parse.revisions.map(
+        ({ cacheHits, cacheMisses, parserAttempts, parserKey, requests }) => ({
+          cacheHits,
+          cacheMisses,
+          parserAttempts,
+          parserKey,
+          requests,
+        })
+      )
+    ).toEqual([
+      {
+        cacheHits: 0,
+        cacheMisses: 1,
+        parserAttempts: 1,
+        parserKey: 'oxc:module:ts:ts:r1:j0',
+        requests: 1,
+      },
+      {
+        cacheHits: 1,
+        cacheMisses: 0,
+        parserAttempts: 0,
+        parserKey: 'oxc:unambiguous:ts:ts:r1:j0',
+        requests: 1,
+      },
+    ]);
+  });
+
   it('derives zero attempts for a cached JSX hit warmed outside the root', async () => {
     const filename = '/project/pipeline-telemetry-warm-jsx.js';
     const code = 'export const warmElement = <span>ready</span>;';

--- a/packages/transform/src/debug/pipelineTelemetry.ts
+++ b/packages/transform/src/debug/pipelineTelemetry.ts
@@ -1,6 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { EventEmitter } from '../utils/EventEmitter';
+import {
+  getOxcParserLanguage,
+  type OxcParserLanguage,
+} from '../utils/oxcParserLanguage';
 import { serializePipelineTelemetryJSONl } from './pipelineTelemetry.jsonl';
 import {
   getCodeMeasurement,
@@ -390,35 +394,13 @@ export const recordPipelineDisposableRoot = (
   );
 };
 
-type PipelineParserLanguage = 'dts' | 'js' | 'jsx' | 'ts' | 'tsx';
-
 const PIPELINE_PARSER_LANGUAGE_INDEX = {
   js: 0,
   jsx: 1,
   ts: 2,
   tsx: 3,
   dts: 4,
-} as const satisfies Record<PipelineParserLanguage, number>;
-
-const getPipelineParserLanguage = (
-  filename: string
-): PipelineParserLanguage => {
-  if (filename.endsWith('.jsx')) return 'jsx';
-  if (filename.endsWith('.tsx')) return 'tsx';
-  const basenameStart =
-    Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\')) + 1;
-  if (filename.endsWith('.ts')) {
-    return filename.lastIndexOf('.d.') > basenameStart ? 'dts' : 'ts';
-  }
-  if (filename.endsWith('.mts') || filename.endsWith('.cts')) {
-    const basenameLength = filename.length - basenameStart;
-    return basenameLength > 6 &&
-      (filename.endsWith('.d.mts') || filename.endsWith('.d.cts'))
-      ? 'dts'
-      : 'ts';
-  }
-  return 'js';
-};
+} as const satisfies Record<OxcParserLanguage, number>;
 
 const createPipelineParserKey = (
   sourceType: string,
@@ -426,7 +408,7 @@ const createPipelineParserKey = (
   astType: string,
   jsxFallbackAllowed: boolean
 ): number | string => {
-  const language = getPipelineParserLanguage(filename);
+  const language = getOxcParserLanguage(filename);
   if (
     (sourceType === 'module' || sourceType === 'unambiguous') &&
     (astType === 'js' || astType === 'ts')

--- a/packages/transform/src/transform/Entrypoint.helpers.ts
+++ b/packages/transform/src/transform/Entrypoint.helpers.ts
@@ -1,9 +1,6 @@
-import { parseOxcSync } from '../utils/parseOxc';
 import { readFileSync } from 'fs';
-import { dirname, extname, isAbsolute } from 'path';
 import { createRequire } from 'module';
-
-
+import { dirname, extname, isAbsolute } from 'path';
 import type { Debugger, EvalRule, Evaluator } from '@wyw-in-js/shared';
 import { logger } from '@wyw-in-js/shared';
 
@@ -11,6 +8,8 @@ import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
 import { oxcShaker } from '../shaker';
 import type { ParentEntrypoint } from '../types';
 import { getFileIdx } from '../utils/getFileIdx';
+import { parseOxcSync } from '../utils/parseOxc';
+import { stripQueryAndHash } from '../utils/parseRequest';
 
 import type {
   IEntrypointCode,
@@ -18,7 +17,6 @@ import type {
   ParsedAst,
 } from './Entrypoint.types';
 import type { Services } from './types';
-import { stripQueryAndHash } from '../utils/parseRequest';
 
 const nodeRequire = createRequire(import.meta.url);
 

--- a/packages/transform/src/transform/Entrypoint.helpers.ts
+++ b/packages/transform/src/transform/Entrypoint.helpers.ts
@@ -1,8 +1,8 @@
+import { parseOxcSync } from '../utils/parseOxc';
 import { readFileSync } from 'fs';
 import { dirname, extname, isAbsolute } from 'path';
 import { createRequire } from 'module';
 
-import { parseSync } from 'oxc-parser';
 
 import type { Debugger, EvalRule, Evaluator } from '@wyw-in-js/shared';
 import { logger } from '@wyw-in-js/shared';
@@ -54,9 +54,9 @@ export function parseFile(
 
   const astType =
     filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
-  let parseResult: ReturnType<typeof parseSync>;
+  let parseResult: ReturnType<typeof parseOxcSync>;
   try {
-    parseResult = parseSync(filename, originalCode, {
+    parseResult = parseOxcSync(filename, originalCode, {
       astType,
       range: true,
       sourceType: 'module',

--- a/packages/transform/src/transform/generators/parse-rewritten-barrel.ts
+++ b/packages/transform/src/transform/generators/parse-rewritten-barrel.ts
@@ -1,7 +1,7 @@
-import { parseSync } from 'oxc-parser';
 import type { Program } from 'oxc-parser';
 
 import { recordPipelineUncachedParse } from '../../debug/pipelineTelemetry';
+import { parseOxcSync } from '../../utils/parseOxc';
 
 export const parseRewrittenBarrel = (
   code: string,
@@ -9,9 +9,9 @@ export const parseRewrittenBarrel = (
 ): Program => {
   const astType =
     filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
-  let parsed: ReturnType<typeof parseSync>;
+  let parsed: ReturnType<typeof parseOxcSync>;
   try {
-    parsed = parseSync(filename, code, {
+    parsed = parseOxcSync(filename, code, {
       astType,
       range: true,
       sourceType: 'module',

--- a/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
+++ b/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
@@ -1,4 +1,3 @@
-import { parseOxcSync } from '../utils/parseOxc';
 import type {
   ExportNamedDeclaration,
   ImportDeclaration,
@@ -9,6 +8,7 @@ import type {
 } from 'oxc-parser';
 
 import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
+import { parseOxcSync } from '../utils/parseOxc';
 
 const isNode = (value: unknown): value is Node =>
   !!value &&

--- a/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
+++ b/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
@@ -1,4 +1,4 @@
-import { parseSync } from 'oxc-parser';
+import { parseOxcSync } from '../utils/parseOxc';
 import type {
   ExportNamedDeclaration,
   ImportDeclaration,
@@ -21,9 +21,9 @@ const getNodeType = (node: Pick<Node, 'type'>): string => node.type as string;
 const parseOxc = (code: string, filename: string): Program => {
   const astType =
     filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
-  let parsed: ReturnType<typeof parseSync>;
+  let parsed: ReturnType<typeof parseOxcSync>;
   try {
-    parsed = parseSync(filename, code, {
+    parsed = parseOxcSync(filename, code, {
       astType,
       range: true,
       sourceType: 'unambiguous',

--- a/packages/transform/src/transform/oxcBarrelManifest.ts
+++ b/packages/transform/src/transform/oxcBarrelManifest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-continue, @typescript-eslint/no-use-before-define */
-import { parseSync } from 'oxc-parser';
+import { parseOxcSync } from '../utils/parseOxc';
 import type {
   BindingPattern,
   ExportAllDeclaration,
@@ -427,9 +427,9 @@ const collectPassthroughReexports = (
 const parseProgram = (code: string, filename: string): Program => {
   const astType =
     filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
-  let parsed: ReturnType<typeof parseSync>;
+  let parsed: ReturnType<typeof parseOxcSync>;
   try {
-    parsed = parseSync(filename, code, {
+    parsed = parseOxcSync(filename, code, {
       astType,
       range: true,
       sourceType: 'module',

--- a/packages/transform/src/transform/oxcBarrelManifest.ts
+++ b/packages/transform/src/transform/oxcBarrelManifest.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-continue, @typescript-eslint/no-use-before-define */
-import { parseOxcSync } from '../utils/parseOxc';
 import type {
   BindingPattern,
   ExportAllDeclaration,
@@ -14,6 +13,7 @@ import type {
 } from 'oxc-parser';
 
 import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
+import { parseOxcSync } from '../utils/parseOxc';
 
 import type {
   BarrelManifestCacheEntry,

--- a/packages/transform/src/utils/oxcEmit.ts
+++ b/packages/transform/src/utils/oxcEmit.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-syntax */
 
-import { parseOxcSync } from './parseOxc';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
@@ -19,6 +18,8 @@ import type {
 } from 'oxc-parser';
 
 import { recordPipelineUncachedParse } from '../debug/pipelineTelemetry';
+
+import { parseOxcSync } from './parseOxc';
 
 type Replacement = {
   end: number;

--- a/packages/transform/src/utils/oxcEmit.ts
+++ b/packages/transform/src/utils/oxcEmit.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-restricted-syntax */
 
+import { parseOxcSync } from './parseOxc';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
-import { parseSync } from 'oxc-parser';
 import type {
   BindingPattern,
   ExportDefaultDeclaration,
@@ -246,9 +246,9 @@ const applyReplacements = (
 };
 
 const parseJsModule = (code: string, filename: string): Program => {
-  let parsed: ReturnType<typeof parseSync>;
+  let parsed: ReturnType<typeof parseOxcSync>;
   try {
-    parsed = parseSync(filename, code, {
+    parsed = parseOxcSync(filename, code, {
       astType: 'js',
       range: true,
       sourceType: 'module',

--- a/packages/transform/src/utils/oxcParserLanguage.ts
+++ b/packages/transform/src/utils/oxcParserLanguage.ts
@@ -1,0 +1,22 @@
+export type OxcParserLanguage = 'dts' | 'js' | 'jsx' | 'ts' | 'tsx';
+
+export const getOxcParserLanguage = (filename: string): OxcParserLanguage => {
+  if (filename.endsWith('.jsx')) return 'jsx';
+  if (filename.endsWith('.tsx')) return 'tsx';
+
+  const basenameStart =
+    Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\')) + 1;
+  if (filename.endsWith('.ts')) {
+    return filename.lastIndexOf('.d.') > basenameStart ? 'dts' : 'ts';
+  }
+
+  if (filename.endsWith('.mts') || filename.endsWith('.cts')) {
+    const basenameLength = filename.length - basenameStart;
+    return basenameLength > 6 &&
+      (filename.endsWith('.d.mts') || filename.endsWith('.d.cts'))
+      ? 'dts'
+      : 'ts';
+  }
+
+  return 'js';
+};

--- a/packages/transform/src/utils/oxcPreevalStage/prevalExport.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/prevalExport.ts
@@ -1,7 +1,5 @@
-import { parseOxcSync } from '../parseOxc';
-
-
 import { recordPipelineUncachedParse } from '../../debug/pipelineTelemetry';
+import { parseOxcSync } from '../parseOxc';
 
 const parseSourceType = (
   code: string,

--- a/packages/transform/src/utils/oxcPreevalStage/prevalExport.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/prevalExport.ts
@@ -1,4 +1,5 @@
-import { parseSync } from 'oxc-parser';
+import { parseOxcSync } from '../parseOxc';
+
 
 import { recordPipelineUncachedParse } from '../../debug/pipelineTelemetry';
 
@@ -8,9 +9,9 @@ const parseSourceType = (
 ): 'module' | 'script' => {
   const astType =
     filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
-  let parsed: ReturnType<typeof parseSync>;
+  let parsed: ReturnType<typeof parseOxcSync>;
   try {
-    parsed = parseSync(filename, code, {
+    parsed = parseOxcSync(filename, code, {
       astType,
       range: true,
       sourceType: 'unambiguous',

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -1,4 +1,4 @@
-import { parseSync } from 'oxc-parser';
+import { parseSync, rawTransferSupported } from 'oxc-parser';
 import type { Comment, Program } from 'oxc-parser';
 
 import {
@@ -7,6 +7,27 @@ import {
 } from '../debug/pipelineTelemetry';
 
 type OxcSourceType = 'module' | 'unambiguous';
+
+type OxcParseOptions = Parameters<typeof parseSync>[2] & {
+  experimentalRawTransfer?: boolean;
+};
+
+// Raw transfer deserializes the AST from a shared buffer instead of a JSON
+// string. Same AST shape, but several times cheaper — JSON materialization
+// dominated parse cost in profiles of large builds.
+const useRawTransfer = rawTransferSupported();
+
+export const parseOxcSync = (
+  filename: string,
+  code: string,
+  options: OxcParseOptions
+): ReturnType<typeof parseSync> => {
+  const optionsWithTransfer: OxcParseOptions = {
+    ...options,
+    experimentalRawTransfer: useRawTransfer,
+  };
+  return parseSync(filename, code, optionsWithTransfer);
+};
 
 type ParsedOxc = {
   comments: Comment[];
@@ -90,9 +111,9 @@ export const parseOxcCached = (
   }
 
   const astType = getAstType(filename);
-  let parsed: ReturnType<typeof parseSync>;
+  let parsed: ReturnType<typeof parseOxcSync>;
   try {
-    parsed = parseSync(filename, code, {
+    parsed = parseOxcSync(filename, code, {
       astType,
       range: true,
       sourceType,
@@ -115,7 +136,7 @@ export const parseOxcCached = (
     // Some bundlers pass .js files with JSX to WyW before a later JSX transform.
     jsxFallback = true;
     try {
-      parsed = parseSync(jsxFallbackFilename, code, {
+      parsed = parseOxcSync(jsxFallbackFilename, code, {
         astType: getAstType(jsxFallbackFilename),
         range: true,
         sourceType,

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -21,9 +21,10 @@ type ParsedOxc = {
 // 200 evicts under sustained pressure on large monorepos — the
 // removeUnusedAfterReplacement cleanup loop reparses on every iteration
 // (new content -> new key) and applyOxcProcessors reparses after extraction.
-// 1000 is still bounded (~50-100 MB worst case for an enormous build) and
+// 1000 evicted cross-file snippet entries once keys became filename-agnostic;
+// 4000 is still bounded (~200-400 MB worst case for an enormous build) and
 // keeps every entry hot across the actions for a single file.
-const MAX_PARSE_CACHE_ENTRIES = 1000;
+const MAX_PARSE_CACHE_ENTRIES = 4000;
 const parseCache = new Map<string, ParsedOxc>();
 const commentsByProgram = new WeakMap<Program, readonly Comment[]>();
 
@@ -36,11 +37,16 @@ const getJsxFallbackFilename = (filename: string): string | null => {
   return null;
 };
 
+// Keyed by astType, not filename: the parse depends only on the grammar and
+// the code, so identical per-candidate snippet programs
+// (`const __wyw_static_value = ...;`) and identical files share one entry
+// no matter which path asked. On a large monorepo this removes thousands of
+// snippet reparses per build.
 const makeCacheKey = (
   filename: string,
   code: string,
   sourceType: OxcSourceType
-): string => `${sourceType}\0${filename}\0${code}`;
+): string => `${sourceType}\0${getAstType(filename)}\0${code}`;
 
 const setCachedParse = (key: string, value: ParsedOxc): ParsedOxc => {
   parseCache.set(key, value);
@@ -63,6 +69,11 @@ export const parseOxcCached = (
   const cacheKey = makeCacheKey(filename, code, sourceType);
   const cached = parseCache.get(cacheKey);
   if (cached) {
+    // Refresh recency so insertion-order eviction behaves as LRU: hot entries
+    // (the current file's program, common snippets) must outlive one-shot
+    // content versions produced by the cleanup loops.
+    parseCache.delete(cacheKey);
+    parseCache.set(cacheKey, cached);
     const knownMeasurement = cached.pipelineMeasurement;
     const measurement = recordPipelineCachedParseHit(
       cached,
@@ -135,7 +146,7 @@ export const parseOxcCached = (
     throw new Error(fatalError.message);
   }
 
-  const cachedParse = setCachedParse(cacheKey, {
+  const value: ParsedOxc = {
     comments: parsed.comments,
     jsxFallback,
     module: {
@@ -143,7 +154,17 @@ export const parseOxcCached = (
     },
     pipelineMeasurement: undefined,
     program: parsed.program as Program,
-  });
+  };
+  if (parsed.module.hasModuleSyntax) {
+    // Module syntax pins 'unambiguous' to the module grammar, so both
+    // sourceType requests resolve to the same AST — publish it under both
+    // keys instead of parsing the same content twice.
+    const other: OxcSourceType =
+      sourceType === 'module' ? 'unambiguous' : 'module';
+    setCachedParse(makeCacheKey(filename, code, other), value);
+  }
+
+  const cachedParse = setCachedParse(cacheKey, value);
   const telemetryMeasurement = recordPipelineCachedParseMiss(
     filename,
     code,

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -5,6 +5,10 @@ import {
   recordPipelineCachedParseMiss,
   recordPipelineCachedParseHit,
 } from '../debug/pipelineTelemetry';
+import {
+  getOxcParserLanguage,
+  type OxcParserLanguage,
+} from './oxcParserLanguage';
 
 type OxcSourceType = 'module' | 'unambiguous';
 
@@ -12,9 +16,19 @@ type OxcParseOptions = Parameters<typeof parseSync>[2] & {
   experimentalRawTransfer?: boolean;
 };
 
-// Raw transfer deserializes the AST from a shared buffer instead of a JSON
-// string. Same AST shape, but several times cheaper — JSON materialization
-// dominated parse cost in profiles of large builds.
+export const isOxcRawTransferAstTypeCompatible = (
+  language: OxcParserLanguage,
+  astType: 'js' | 'ts' | undefined
+): boolean => {
+  if (astType === undefined) return true;
+
+  const languageAstType = language === 'js' || language === 'jsx' ? 'js' : 'ts';
+  return astType === languageAstType;
+};
+
+// Raw transfer deserializes the Program AST from a shared buffer instead of a
+// JSON string. JSON materialization dominated parse cost in large-build
+// profiles.
 const useRawTransfer = rawTransferSupported();
 
 export const parseOxcSync = (
@@ -22,9 +36,15 @@ export const parseOxcSync = (
   code: string,
   options: OxcParseOptions
 ): ReturnType<typeof parseSync> => {
+  const language = options.lang ?? getOxcParserLanguage(filename);
   const optionsWithTransfer: OxcParseOptions = {
     ...options,
-    experimentalRawTransfer: useRawTransfer,
+    // Oxc's raw and JSON deserializers currently disagree on node spans when
+    // a JS-shaped AST is requested for a TypeScript-family language. Preserve
+    // the established JSON representation for any mixed language/AST mode.
+    experimentalRawTransfer:
+      useRawTransfer &&
+      isOxcRawTransferAstTypeCompatible(language, options.astType),
   };
   return parseSync(filename, code, optionsWithTransfer);
 };
@@ -43,13 +63,12 @@ type ParsedOxc = {
 // removeUnusedAfterReplacement cleanup loop reparses on every iteration
 // (new content -> new key) and applyOxcProcessors reparses after extraction.
 // 1000 evicted cross-file snippet entries once keys became filename-agnostic;
-// 4000 is still bounded (~200-400 MB worst case for an enormous build) and
-// keeps every entry hot across the actions for a single file.
+// 4000 kept those entries hot in the measured build. This is a count bound;
+// retained bytes still depend on the source and AST sizes.
 const MAX_PARSE_CACHE_ENTRIES = 4000;
-// Bucketed by (sourceType, astType) with the code string itself as the inner
-// key: building `${sourceType}\0${astType}\0${code}` allocated a whole-file
-// string per lookup (65k lookups per build in profiles) purely to feed the
-// map hash.
+// Bucketed by parser semantics with the code string itself as the inner key:
+// building a key containing the code allocated a whole-file string per lookup
+// purely to feed the map hash.
 const parseCache = new Map<string, Map<string, ParsedOxc>>();
 let parseCacheSize = 0;
 const commentsByProgram = new WeakMap<Program, readonly Comment[]>();
@@ -63,16 +82,16 @@ const getJsxFallbackFilename = (filename: string): string | null => {
   return null;
 };
 
-// Buckets are keyed by astType, not filename: the parse depends only on the
-// grammar and the code, so identical per-candidate snippet programs
-// (`const __wyw_static_value = ...;`) and identical files share one entry
-// no matter which path asked. On a large monorepo this removes thousands of
-// snippet reparses per build.
+// The filename selects Oxc's language dialect independently of astType and
+// controls whether .js may fall back to JSX, so both semantics are part of the
+// bucket key. Paths with equivalent parser behavior still share entries.
 const getParseCacheBucket = (
   filename: string,
   sourceType: OxcSourceType
 ): Map<string, ParsedOxc> => {
-  const bucketKey = `${sourceType}\0${getAstType(filename)}`;
+  const bucketKey = `${sourceType}\0${getOxcParserLanguage(
+    filename
+  )}\0${getAstType(filename)}\0${getJsxFallbackFilename(filename) !== null}`;
   let bucket = parseCache.get(bucketKey);
   if (!bucket) {
     bucket = new Map();
@@ -92,7 +111,7 @@ const setCachedParse = (
   bucket.set(code, value);
   commentsByProgram.set(value.program, value.comments);
   if (parseCacheSize > MAX_PARSE_CACHE_ENTRIES) {
-    // Evict the oldest entry of the largest bucket; buckets are few (≤4).
+    // Evict the oldest entry of the largest bucket; the bucket set is small.
     let largest: Map<string, ParsedOxc> | null = null;
     for (const candidate of parseCache.values()) {
       if (!largest || candidate.size > largest.size) {
@@ -194,14 +213,17 @@ export const parseOxcCached = (
     throw new Error(fatalError.message);
   }
 
-  const value: ParsedOxc = {
+  const sharedValue = {
     comments: parsed.comments,
     jsxFallback,
     module: {
       hasModuleSyntax: parsed.module.hasModuleSyntax,
     },
-    pipelineMeasurement: undefined,
     program: parsed.program as Program,
+  };
+  const value: ParsedOxc = {
+    ...sharedValue,
+    pipelineMeasurement: undefined,
   };
   if (parsed.module.hasModuleSyntax) {
     // Module syntax pins 'unambiguous' to the module grammar, so both
@@ -209,7 +231,12 @@ export const parseOxcCached = (
     // keys instead of parsing the same content twice.
     const other: OxcSourceType =
       sourceType === 'module' ? 'unambiguous' : 'module';
-    setCachedParse(getParseCacheBucket(filename, other), code, value);
+    // Cache entries keep source-type-specific telemetry identity, while their
+    // immutable parse payload is shared.
+    setCachedParse(getParseCacheBucket(filename, other), code, {
+      ...sharedValue,
+      pipelineMeasurement: undefined,
+    });
   }
 
   const cachedParse = setCachedParse(bucket, code, value);

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -46,7 +46,12 @@ type ParsedOxc = {
 // 4000 is still bounded (~200-400 MB worst case for an enormous build) and
 // keeps every entry hot across the actions for a single file.
 const MAX_PARSE_CACHE_ENTRIES = 4000;
-const parseCache = new Map<string, ParsedOxc>();
+// Bucketed by (sourceType, astType) with the code string itself as the inner
+// key: building `${sourceType}\0${astType}\0${code}` allocated a whole-file
+// string per lookup (65k lookups per build in profiles) purely to feed the
+// map hash.
+const parseCache = new Map<string, Map<string, ParsedOxc>>();
+let parseCacheSize = 0;
 const commentsByProgram = new WeakMap<Program, readonly Comment[]>();
 
 const getAstType = (filename: string): 'js' | 'ts' =>
@@ -58,24 +63,46 @@ const getJsxFallbackFilename = (filename: string): string | null => {
   return null;
 };
 
-// Keyed by astType, not filename: the parse depends only on the grammar and
-// the code, so identical per-candidate snippet programs
+// Buckets are keyed by astType, not filename: the parse depends only on the
+// grammar and the code, so identical per-candidate snippet programs
 // (`const __wyw_static_value = ...;`) and identical files share one entry
 // no matter which path asked. On a large monorepo this removes thousands of
 // snippet reparses per build.
-const makeCacheKey = (
+const getParseCacheBucket = (
   filename: string,
-  code: string,
   sourceType: OxcSourceType
-): string => `${sourceType}\0${getAstType(filename)}\0${code}`;
+): Map<string, ParsedOxc> => {
+  const bucketKey = `${sourceType}\0${getAstType(filename)}`;
+  let bucket = parseCache.get(bucketKey);
+  if (!bucket) {
+    bucket = new Map();
+    parseCache.set(bucketKey, bucket);
+  }
+  return bucket;
+};
 
-const setCachedParse = (key: string, value: ParsedOxc): ParsedOxc => {
-  parseCache.set(key, value);
+const setCachedParse = (
+  bucket: Map<string, ParsedOxc>,
+  code: string,
+  value: ParsedOxc
+): ParsedOxc => {
+  if (!bucket.has(code)) {
+    parseCacheSize += 1;
+  }
+  bucket.set(code, value);
   commentsByProgram.set(value.program, value.comments);
-  if (parseCache.size > MAX_PARSE_CACHE_ENTRIES) {
-    const oldestKey = parseCache.keys().next().value;
-    if (oldestKey) {
-      parseCache.delete(oldestKey);
+  if (parseCacheSize > MAX_PARSE_CACHE_ENTRIES) {
+    // Evict the oldest entry of the largest bucket; buckets are few (≤4).
+    let largest: Map<string, ParsedOxc> | null = null;
+    for (const candidate of parseCache.values()) {
+      if (!largest || candidate.size > largest.size) {
+        largest = candidate;
+      }
+    }
+    const oldestCode = largest?.keys().next().value;
+    if (largest && oldestCode !== undefined) {
+      largest.delete(oldestCode);
+      parseCacheSize -= 1;
     }
   }
 
@@ -87,14 +114,14 @@ export const parseOxcCached = (
   code: string,
   sourceType: OxcSourceType
 ): ParsedOxc => {
-  const cacheKey = makeCacheKey(filename, code, sourceType);
-  const cached = parseCache.get(cacheKey);
+  const bucket = getParseCacheBucket(filename, sourceType);
+  const cached = bucket.get(code);
   if (cached) {
     // Refresh recency so insertion-order eviction behaves as LRU: hot entries
     // (the current file's program, common snippets) must outlive one-shot
     // content versions produced by the cleanup loops.
-    parseCache.delete(cacheKey);
-    parseCache.set(cacheKey, cached);
+    bucket.delete(code);
+    bucket.set(code, cached);
     const knownMeasurement = cached.pipelineMeasurement;
     const measurement = recordPipelineCachedParseHit(
       cached,
@@ -182,10 +209,10 @@ export const parseOxcCached = (
     // keys instead of parsing the same content twice.
     const other: OxcSourceType =
       sourceType === 'module' ? 'unambiguous' : 'module';
-    setCachedParse(makeCacheKey(filename, code, other), value);
+    setCachedParse(getParseCacheBucket(filename, other), code, value);
   }
 
-  const cachedParse = setCachedParse(cacheKey, value);
+  const cachedParse = setCachedParse(bucket, code, value);
   const telemetryMeasurement = recordPipelineCachedParseMiss(
     filename,
     code,


### PR DESCRIPTION
Replaces #403 with the same commits on a repository branch so GitHub can link it into a native stack.

## What

Reduces repeated Oxc parsing and deserialization work in large builds. This PR is stacked on #398.

## Changes

- Shares successful parse results across filenames only when the Oxc language, requested AST representation, and JSX fallback behavior are equivalent.
- Reuses module-syntax AST payloads between `module` and `unambiguous` requests while retaining separate cache-entry identity for telemetry.
- Uses Oxc raw transfer on supported runtimes when the parser language and requested AST representation are compatible, preserving the JSON path otherwise.
- Routes every production Oxc `parseSync` call through the shared wrapper.
- Avoids cache-key allocations containing the entire source string, refreshes hot entries on access, and keeps the cache bounded.
- Adds regressions for dialect isolation, JSX fallback isolation, intended cache sharing, source-type telemetry, and raw-transfer compatibility.

## Verification

- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/e2e-vite test`