### PR TITLE
fix(transform): don't report equivalent styled targets as a PrevalPayload disagreement

### DIFF
--- a/.changeset/preval-opaque-component-agreement.md
+++ b/.changeset/preval-opaque-component-agreement.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Stop reporting a false `PrevalPayload disagreement` for `styled(X)` targets whose evaluated and static values describe the same selector chain. The hybrid evaluator spells a proven opaque component as a bare function stub, while the static resolver spells it as `null`; these representations are now treated as equivalent only for helpers that the static analysis identified as opaque and for matching generated `__wyw_meta` chains. Static precedence is unchanged, and malformed metadata, extra value fields, or genuine selector drift are still reported.

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -12,7 +12,7 @@ import { dirname, join, resolve } from 'path';
 import dedent from 'dedent';
 
 import { TransformCacheCollection } from '../cache';
-import { disposeEvalBroker } from '../eval/broker';
+import { disposeEvalBroker, EvalBroker } from '../eval/broker';
 import { transform } from '../transform';
 import type { PluginOptions } from '../types';
 import { EventEmitter } from '../utils/EventEmitter';
@@ -4078,6 +4078,104 @@ describe('transform static import value inlining', () => {
       expect(result.dependencies).toContain(baseFile);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('merges retained eval stubs with statically proven opaque styled targets', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'StyledLink.js');
+    const linkFile = join(root, 'Link.js');
+    const themeFile = join(root, 'runtime-theme.js');
+    const cache = new TransformCacheCollection();
+    let opaqueNames: string[] = [];
+    const evaluateSpy = jest
+      .spyOn(EvalBroker.prototype, 'evaluate')
+      .mockImplementation(async (entrypoint) => {
+        const preevalResult = entrypoint.getPreevalResult();
+        const staticValues = preevalResult?.staticValueCache;
+        opaqueNames = preevalResult?.staticNullWYWMetaExtendsHelpers ?? [];
+        expect(opaqueNames).toHaveLength(1);
+        expect(staticValues).toBeDefined();
+        if (!preevalResult || !staticValues) {
+          throw new Error('expected a resolved static preeval result');
+        }
+
+        const toEvaluatedValue = (value: unknown): unknown => {
+          if (
+            typeof value !== 'object' ||
+            value === null ||
+            !('__wyw_meta' in value)
+          ) {
+            return value;
+          }
+
+          const meta = value.__wyw_meta as {
+            className: string;
+            extends: unknown;
+          };
+          return {
+            displayName:
+              'displayName' in value
+                ? value.displayName
+                : 'RetainedStyledValue',
+            __wyw_meta: {
+              className: meta.className,
+              extends:
+                meta.extends === null
+                  ? () => {}
+                  : toEvaluatedValue(meta.extends),
+            },
+          };
+        };
+        const values = new Map<string, unknown>(
+          (preevalResult.dependencyNames ?? []).map((name) => [name, 'red'])
+        );
+        staticValues.forEach((value, name) => {
+          values.set(
+            name,
+            opaqueNames.includes(name) ? () => {} : toEvaluatedValue(value)
+          );
+        });
+
+        return { dependencies: [], values };
+      });
+
+    writeFileSync(linkFile, 'export const Link = () => null;\n');
+    writeFileSync(
+      themeFile,
+      "export const color = Date.now() > 0 ? 'red' : 'blue';\n"
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Link } from './Link.js';
+        import { color } from './runtime-theme.js';
+
+        const StyledLink = styled(Link)\`
+          display: flex;
+        \`;
+
+        export const StyledTextLink = styled(StyledLink)\`
+          color: \${color};
+        \`;
+      `
+    );
+
+    try {
+      const transformed = await runTransform(root, entryFile, cache);
+
+      expect(evaluateSpy).toHaveBeenCalledTimes(1);
+      expect(opaqueNames).toHaveLength(1);
+      expect(transformed.cssText).toContain('display:flex');
+      expect(transformed.cssText).toContain('color:red');
+      expect(transformed.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*color:red;[^}]*\}/s
+      );
+    } finally {
+      evaluateSpy.mockRestore();
+      disposeEvalBroker(cache);
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/transform/src/transform/__tests__/prevalPayload.test.ts
+++ b/packages/transform/src/transform/__tests__/prevalPayload.test.ts
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import { createPrevalPayload } from '../prevalPayload';
+import { deserializeValue, serializePreval } from '../../eval/serialize';
 
 const filename = '/project/src/entry.tsx';
 
@@ -138,6 +139,50 @@ describe('createPrevalPayload', () => {
     ).toThrow('[wyw-in-js] PrevalPayload disagreement');
   });
 
+  it('treats accessor-based metadata as a disagreement', () => {
+    process.env.NODE_ENV = 'test';
+    const evaluated = {};
+    Object.defineProperty(evaluated, '__wyw_meta', {
+      enumerable: true,
+      get() {
+        throw new Error('unavailable eval metadata');
+      },
+    });
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', evaluated]]),
+        filename,
+        staticValues: new Map([
+          ['_exp', { __wyw_meta: { className: 'a_1', extends: null } }],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('treats an unavailable nested extends value as a disagreement', () => {
+    process.env.NODE_ENV = 'test';
+    const meta = { className: 'a_1' };
+    Object.defineProperty(meta, 'extends', {
+      enumerable: true,
+      get() {
+        throw new Error('unavailable extends value');
+      },
+    });
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', { __wyw_meta: meta }]]),
+        filename,
+        staticValues: new Map([
+          ['_exp', { __wyw_meta: { className: 'a_1', extends: null } }],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
   it('warns and keeps static precedence on hybrid disagreement in production', () => {
     process.env.NODE_ENV = 'production';
     const warnings: string[] = [];
@@ -186,6 +231,331 @@ describe('createPrevalPayload', () => {
     expect(warnings[0]).toContain('eval: <unprintable>');
     expect(payload.values.get('_exp')).toBe(staticValue);
     expect(payload.sources.get('_exp')).toBe('static');
+  });
+
+  it('warns and keeps static precedence when metadata access is unsafe', () => {
+    process.env.NODE_ENV = 'production';
+    const warnings: string[] = [];
+    const evaluated = {};
+    Object.defineProperty(evaluated, '__wyw_meta', {
+      enumerable: true,
+      get() {
+        throw new Error('unavailable eval metadata');
+      },
+    });
+    const staticValue = {
+      __wyw_meta: { className: 'a_1', extends: null },
+    };
+
+    const payload = createPrevalPayload({
+      emitWarning: (message) => warnings.push(message),
+      evalValues: new Map([['_exp', evaluated]]),
+      filename,
+      staticValues: new Map([['_exp', staticValue]]),
+      strategy: 'hybrid',
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('PrevalPayload disagreement');
+    expect(payload.values.get('_exp')).toBe(staticValue);
+    expect(payload.sources.get('_exp')).toBe('static');
+  });
+
+  it('treats an evaluated component stub and a static opaque null as agreement', () => {
+    process.env.NODE_ENV = 'test';
+    const warnings: string[] = [];
+    const stub = () => {};
+
+    const payload = createPrevalPayload({
+      emitWarning: (message) => warnings.push(message),
+      evalValues: new Map([['_exp', stub]]),
+      filename,
+      staticNullWYWMetaExtendsHelpers: ['_exp'],
+      staticValues: new Map([['_exp', null]]),
+      strategy: 'hybrid',
+    });
+
+    expect(warnings).toHaveLength(0);
+    expect(payload.values).toEqual(new Map([['_exp', null]]));
+    expect(payload.sources).toEqual(new Map([['_exp', 'static']]));
+  });
+
+  it('still reports an unproven function after eval IPC against a static null', () => {
+    process.env.NODE_ENV = 'test';
+    const styledLike = Object.assign(() => {}, {
+      __wyw_meta: { className: 'x', extends: null },
+    });
+    const evaluated = deserializeValue(
+      serializePreval({ styledLike }).styledLike
+    );
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', evaluated]]),
+        filename,
+        staticValues: new Map([['_exp', null]]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('treats equal __wyw_meta chains with differently spelled opaque ends as agreement', () => {
+    process.env.NODE_ENV = 'test';
+    const warnings: string[] = [];
+    const evaluated = {
+      displayName: 'StyledLink',
+      __wyw_meta: { className: 'StyledLink_s1', extends: () => {} },
+    };
+    const resolved = {
+      __wyw_meta: { className: 'StyledLink_s1', extends: null },
+    };
+
+    const payload = createPrevalPayload({
+      emitWarning: (message) => warnings.push(message),
+      evalValues: new Map([['_exp7', evaluated]]),
+      filename,
+      staticValues: new Map([['_exp7', resolved]]),
+      strategy: 'hybrid',
+    });
+
+    expect(warnings).toHaveLength(0);
+    expect(payload.values.get('_exp7')).toBe(resolved);
+    expect(payload.sources.get('_exp7')).toBe('static');
+  });
+
+  it('does not treat an explicit null displayName as an omitted displayName', () => {
+    process.env.NODE_ENV = 'test';
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([
+          [
+            '_exp',
+            {
+              displayName: 'StyledLink',
+              __wyw_meta: { className: 'StyledLink_s1', extends: () => {} },
+            },
+          ],
+        ]),
+        filename,
+        staticValues: new Map([
+          [
+            '_exp',
+            {
+              displayName: null,
+              __wyw_meta: { className: 'StyledLink_s1', extends: null },
+            },
+          ],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('treats nested equal __wyw_meta chains as agreement', () => {
+    process.env.NODE_ENV = 'test';
+    const evaluated = {
+      displayName: 'Outer',
+      __wyw_meta: {
+        className: 'Outer_o1',
+        extends: {
+          displayName: 'Inner',
+          __wyw_meta: { className: 'Inner_i1', extends: () => {} },
+        },
+      },
+    };
+    const resolved = {
+      __wyw_meta: {
+        className: 'Outer_o1',
+        extends: { __wyw_meta: { className: 'Inner_i1', extends: null } },
+      },
+    };
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', evaluated]]),
+        filename,
+        staticValues: new Map([['_exp', resolved]]),
+        strategy: 'hybrid',
+      })
+    ).not.toThrow();
+  });
+
+  it('treats matching metadata chains deeper than 32 nodes as agreement', () => {
+    process.env.NODE_ENV = 'test';
+    const buildChain = (end: unknown, withDisplayNames: boolean) => {
+      let value = end;
+      for (let index = 0; index < 64; index += 1) {
+        value = {
+          ...(withDisplayNames ? { displayName: `Styled${index}` } : {}),
+          __wyw_meta: { className: `class_${index}`, extends: value },
+        };
+      }
+      return value;
+    };
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', buildChain(() => {}, true)]]),
+        filename,
+        staticValues: new Map([['_exp', buildChain(null, false)]]),
+        strategy: 'hybrid',
+      })
+    ).not.toThrow();
+  });
+
+  it('still reports metadata values with differing extra fields', () => {
+    process.env.NODE_ENV = 'test';
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([
+          [
+            '_exp',
+            {
+              variant: 'red',
+              __wyw_meta: { className: 'a_1', extends: () => {} },
+            },
+          ],
+        ]),
+        filename,
+        staticValues: new Map([
+          [
+            '_exp',
+            {
+              variant: 'blue',
+              __wyw_meta: { className: 'a_1', extends: null },
+            },
+          ],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('still reports inherited metadata values', () => {
+    process.env.NODE_ENV = 'test';
+    const evaluated = Object.create({
+      __wyw_meta: { className: 'a_1', extends: () => {} },
+    });
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', evaluated]]),
+        filename,
+        staticValues: new Map([
+          ['_exp', { __wyw_meta: { className: 'a_1', extends: null } }],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('still reports a function carrying metadata inside a chain', () => {
+    process.env.NODE_ENV = 'test';
+    const styledLike = Object.assign(() => {}, {
+      __wyw_meta: { className: 'inner_1', extends: null },
+    });
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([
+          [
+            '_exp',
+            {
+              __wyw_meta: { className: 'outer_1', extends: styledLike },
+            },
+          ],
+        ]),
+        filename,
+        staticValues: new Map([
+          [
+            '_exp',
+            {
+              __wyw_meta: {
+                className: 'outer_1',
+                extends: {
+                  __wyw_meta: { className: 'inner_1', extends: null },
+                },
+              },
+            },
+          ],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('still reports __wyw_meta chains whose class names differ', () => {
+    process.env.NODE_ENV = 'test';
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([
+          ['_exp', { __wyw_meta: { className: 'a_1', extends: () => {} } }],
+        ]),
+        filename,
+        staticValues: new Map([
+          ['_exp', { __wyw_meta: { className: 'a_2', extends: null } }],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('still reports __wyw_meta chains of different length', () => {
+    process.env.NODE_ENV = 'test';
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([
+          [
+            '_exp',
+            {
+              __wyw_meta: {
+                className: 'a_1',
+                extends: { __wyw_meta: { className: 'b_1', extends: null } },
+              },
+            },
+          ],
+        ]),
+        filename,
+        staticValues: new Map([
+          ['_exp', { __wyw_meta: { className: 'a_1', extends: null } }],
+        ]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('still reports an evaluated function carrying __wyw_meta against a static null', () => {
+    process.env.NODE_ENV = 'test';
+    const styledLike = Object.assign(() => {}, {
+      __wyw_meta: { className: 'x', extends: null },
+    });
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', styledLike]]),
+        filename,
+        staticValues: new Map([['_exp', null]]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
+  });
+
+  it('still reports an evaluated object against a static null', () => {
+    process.env.NODE_ENV = 'test';
+    const lazyLike = { $$typeof: Symbol.for('react.lazy') };
+
+    expect(() =>
+      createPrevalPayload({
+        evalValues: new Map([['_exp', lazyLike]]),
+        filename,
+        staticValues: new Map([['_exp', null]]),
+        strategy: 'hybrid',
+      })
+    ).toThrow('[wyw-in-js] PrevalPayload disagreement');
   });
 
   it('deduplicates selected dependencies in hybrid mode', () => {

--- a/packages/transform/src/transform/generators/evalFile.ts
+++ b/packages/transform/src/transform/generators/evalFile.ts
@@ -28,6 +28,8 @@ export async function* evalFile(
       filename,
       strategy,
       staticDependencies: preevalResult.staticDependencies,
+      staticNullWYWMetaExtendsHelpers:
+        preevalResult.staticNullWYWMetaExtendsHelpers,
       staticValues: preevalResult.staticValueCache,
     });
     log(`<< skipped evaluate __wywPreval %O`, prevalPayload.values);
@@ -72,6 +74,8 @@ export async function* evalFile(
     filename,
     strategy,
     staticDependencies: preevalResult?.staticDependencies,
+    staticNullWYWMetaExtendsHelpers:
+      preevalResult?.staticNullWYWMetaExtendsHelpers,
     staticValues: preevalResult?.staticValueCache,
   });
 

--- a/packages/transform/src/transform/prevalPayload.ts
+++ b/packages/transform/src/transform/prevalPayload.ts
@@ -17,12 +17,162 @@ export type CreatePrevalPayloadInput = {
   filename: string;
   strategy: EvalStrategy;
   staticDependencies?: readonly string[];
+  staticNullWYWMetaExtendsHelpers?: readonly string[];
   staticValues?: Map<string, unknown> | null;
 };
 
 const addUnique = <T>(target: T[], value: T): void => {
   if (!target.includes(value)) {
     target.push(value);
+  }
+};
+
+type OwnDataProperty = { exists: false } | { exists: true; value: unknown };
+
+type WywMetaNode = {
+  className: string;
+  displayName: string | undefined;
+  extends: unknown;
+  value: object;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return (
+    prototype === null ||
+    prototype === Object.prototype ||
+    Object.getPrototypeOf(prototype) === null
+  );
+};
+
+const getOwnDataProperty = (
+  value: object,
+  key: PropertyKey
+): OwnDataProperty | null => {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor) {
+    return { exists: false };
+  }
+
+  return 'value' in descriptor
+    ? { exists: true, value: descriptor.value }
+    : null;
+};
+
+const hasOnlyOwnKeys = (value: object, allowed: readonly string[]): boolean =>
+  Reflect.ownKeys(value).every(
+    (key) => typeof key === 'string' && allowed.includes(key)
+  );
+
+const getWywMetaNode = (value: unknown): WywMetaNode | null => {
+  if (
+    !isPlainObject(value) ||
+    !hasOnlyOwnKeys(value, ['__wyw_meta', 'displayName'])
+  ) {
+    return null;
+  }
+
+  const metaProperty = getOwnDataProperty(value, '__wyw_meta');
+  if (
+    !metaProperty?.exists ||
+    !isPlainObject(metaProperty.value) ||
+    !hasOnlyOwnKeys(metaProperty.value, ['className', 'extends'])
+  ) {
+    return null;
+  }
+
+  const className = getOwnDataProperty(metaProperty.value, 'className');
+  const extended = getOwnDataProperty(metaProperty.value, 'extends');
+  const displayName = getOwnDataProperty(value, 'displayName');
+  const displayNameValue = displayName?.exists ? displayName.value : undefined;
+  if (
+    !className?.exists ||
+    typeof className.value !== 'string' ||
+    !extended?.exists ||
+    displayName === null ||
+    (displayNameValue !== undefined && typeof displayNameValue !== 'string')
+  ) {
+    return null;
+  }
+
+  return {
+    className: className.value,
+    displayName: displayNameValue,
+    extends: extended.value,
+    value,
+  };
+};
+
+// End of an `extends` chain that carries no Linaria meta: `null` is the
+// static model's spelling of an opaque component, a meta-less function is the
+// evaluator's (it shakes a plain component to a bare stub). Objects are not
+// accepted here on purpose: a React.lazy value is an object and changes the
+// emitted selector, so losing it to `null` must still be reported.
+const isMetaFreeFunction = (value: unknown): value is () => unknown =>
+  typeof value === 'function' && !('__wyw_meta' in value);
+
+const haveEquivalentOpaqueEnds = (
+  evalValue: unknown,
+  staticValue: unknown
+): boolean =>
+  (evalValue === null && staticValue === null) ||
+  (isMetaFreeFunction(evalValue) && staticValue === null);
+
+// Under the hybrid strategy the two rounds can spell the same styled target
+// differently: the evaluator produces `{ displayName, __wyw_meta }` objects
+// whose chain ends in a stub function, the static resolver produces bare
+// `{ __wyw_meta }` objects whose chain ends in `null`. Every consumer walks
+// `__wyw_meta.className` / `__wyw_meta.extends` and stops at the first value
+// without meta, so two values with the same class-name chain and an opaque
+// end on both sides are agreement, not drift.
+const haveEquivalentWywMetaChains = (
+  evalValue: unknown,
+  staticValue: unknown,
+  allowOpaqueRoot: boolean
+): boolean => {
+  try {
+    const seenEval = new Set<object>();
+    const seenStatic = new Set<object>();
+    let currentEval = evalValue;
+    let currentStatic = staticValue;
+    let depth = 0;
+
+    for (;;) {
+      const evalNode = getWywMetaNode(currentEval);
+      const staticNode = getWywMetaNode(currentStatic);
+      if (evalNode || staticNode) {
+        if (
+          !evalNode ||
+          !staticNode ||
+          seenEval.has(evalNode.value) ||
+          seenStatic.has(staticNode.value) ||
+          evalNode.className !== staticNode.className ||
+          (staticNode.displayName !== undefined &&
+            evalNode.displayName !== staticNode.displayName)
+        ) {
+          return false;
+        }
+
+        seenEval.add(evalNode.value);
+        seenStatic.add(staticNode.value);
+        currentEval = evalNode.extends;
+        currentStatic = staticNode.extends;
+        depth += 1;
+      } else {
+        return (
+          (depth > 0 || allowOpaqueRoot) &&
+          haveEquivalentOpaqueEnds(currentEval, currentStatic)
+        );
+      }
+    }
+  } catch {
+    // Deferred IPC fields and hostile accessors/proxies are not proof of
+    // equivalence. Fall through to the regular disagreement path.
+    return false;
   }
 };
 
@@ -87,11 +237,13 @@ export const createPrevalPayload = ({
   filename,
   strategy,
   staticDependencies = [],
+  staticNullWYWMetaExtendsHelpers = [],
   staticValues,
 }: CreatePrevalPayloadInput): PrevalPayload => {
   const dependencies: string[] = [];
   const sources = new Map<string, PrevalPayloadSource>();
   const values: ValueCache = new Map();
+  const staticOpaqueValueNames = new Set(staticNullWYWMetaExtendsHelpers);
 
   if (strategy !== 'static') {
     evalDependencies.forEach((dependency) =>
@@ -110,7 +262,12 @@ export const createPrevalPayload = ({
     staticValues?.forEach((value, name) => {
       if (
         values.has(name) &&
-        !isSafelyDeepStrictEqual(values.get(name), value)
+        !isSafelyDeepStrictEqual(values.get(name), value) &&
+        !haveEquivalentWywMetaChains(
+          values.get(name),
+          value,
+          staticOpaqueValueNames.has(String(name))
+        )
       ) {
         handleDisagreement(
           filename,


### PR DESCRIPTION
Fixes #412.

## Motivation

With the `hybrid` strategy, an evaluated value retained from an earlier pass and a later static result can describe the same `styled(X)` target differently. The evaluator ends an opaque component chain in a bare function stub, while the static resolver records `null`. A deep equality check treats those representations as different and reports a `PrevalPayload disagreement`, even though they produce the same selector chain.

The comparison cannot safely treat every function and `null` as interchangeable: doing so would hide real selector drift or malformed metadata.

## What changed

- Carry the static resolver's opaque-component provenance into `createPrevalPayload` in both evaluated and skipped-evaluation paths.
- Treat an evaluator function and static `null` as equivalent only for the exact helper that static analysis proved opaque, either at the root or at the end of otherwise matching generated `__wyw_meta` chains.
- Compare metadata fail-closed: only plain own data properties and the expected keys are accepted; class names and compatible display names must match. Extra or inherited fields, accessors, proxies, nested function metadata, malformed values, and cycles remain disagreements.
- Keep static precedence and source bookkeeping unchanged.

## Test plan

- `bun test packages/transform/src`: 2,004 passed, 1 skipped, 1 todo.
- `bun run --filter @wyw-in-js/transform build:types`.
- `bun run --filter @wyw-in-js/transform lint`.
- Added focused payload-comparison coverage for valid opaque ends and fail-closed edge cases, including explicit `displayName: null`, deep chains, accessors, inherited fields, proxies, and cycles.
- Added a transform-level regression using the real static resolver and `evalFile` path; it reproduces the disagreement on `main` and verifies the emitted two-class selector after the fix.
- End-to-end consumer typechecks/builds passed, and generated CSS matched the checked-in baselines.
