### PR TITLE
fix(transform): run actions with the services of the current transform

### DIFF
--- a/.changeset/action-services-from-run.md
+++ b/.changeset/action-services-from-run.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Run actions and entrypoint lifecycle updates with the services of the transform run that created them, instead of the services captured when an entrypoint first entered a shared cache. This prevents reused entrypoints from applying an earlier importer's filename, source map, output path, warning handler, or event emitter to the current file. Nested actions inherit their parent's run services by default, while internal analysis actions can retain their intentionally isolated cache and telemetry scope.

--- a/packages/transform/src/__tests__/barrel-optimization.test.ts
+++ b/packages/transform/src/__tests__/barrel-optimization.test.ts
@@ -19,7 +19,11 @@ import {
 } from '../transform/generators/resolveImports';
 import { loadWywOptions } from '../transform/helpers/loadWywOptions';
 import { withDefaultServices } from '../transform/helpers/withDefaultServices';
-import type { IResolveImportsAction } from '../transform/types';
+import type {
+  IGetExportsAction,
+  IResolveImportsAction,
+  Services,
+} from '../transform/types';
 import { EventEmitter, type EntrypointEvent } from '../utils/EventEmitter';
 
 const extensions = [
@@ -126,7 +130,8 @@ const runEntrypoint = (
   filename: string,
   cache: TransformCacheCollection,
   eventEmitter: EventEmitter,
-  resolve = createResolver(root)
+  resolve = createResolver(root),
+  onGetExports?: (services: Services) => void
 ) => {
   const services = createServices(root, filename, cache, eventEmitter);
   const entrypoint = Entrypoint.createRoot(
@@ -141,6 +146,10 @@ const runEntrypoint = (
 
   const handlers = {
     ...baseProcessingHandlers,
+    getExports(this: IGetExportsAction) {
+      onGetExports?.(this.services);
+      return baseProcessingHandlers.getExports.call(this);
+    },
     processEntrypoint,
     resolveImports(this: IResolveImportsAction) {
       return syncResolveImports.call(this, resolve);
@@ -351,15 +360,28 @@ describe('barrel optimization', () => {
         `export * from './mid';\nexport { thing } from './mid';\n`
       );
 
+      const cache = new TransformCacheCollection();
+      const recorder = createRecorder();
+      const getExportsServices: Services[] = [];
       const entrypoint = runEntrypoint(
         root,
         consumerFile,
-        new TransformCacheCollection(),
-        createRecorder().eventEmitter
+        cache,
+        recorder.eventEmitter,
+        createResolver(root),
+        (services) => getExportsServices.push(services)
       );
 
       expect(entrypoint.transformedCode).toContain(baseFile);
       expect(entrypoint.transformedCode).not.toContain(midFile);
+      expect(getExportsServices.length).toBeGreaterThan(0);
+      expect(
+        getExportsServices.every(
+          (services) =>
+            services.cache !== cache &&
+            services.eventEmitter === EventEmitter.dummy
+        )
+      ).toBe(true);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/packages/transform/src/__tests__/module.test.ts
+++ b/packages/transform/src/__tests__/module.test.ts
@@ -198,6 +198,35 @@ it('keeps a strong entrypoint reference when WeakRef eval mode is disabled', asy
   }
 });
 
+it('uses the module services for evaluated and ignored child entrypoints', async () => {
+  const entrypointServices = createServices({});
+  const moduleServices = createServices({});
+  const entrypoint = createEntrypoint(entrypointServices, filename, ['*'], '');
+  moduleServices.cache.add('entrypoints', filename, entrypoint);
+  const mod = new Module(moduleServices, entrypoint);
+  const createEvaluatedSpy = jest.spyOn(entrypoint, 'createEvaluated');
+
+  await mod.evaluate();
+
+  expect(createEvaluatedSpy).toHaveBeenCalledWith(moduleServices);
+
+  const createChildSpy = jest.spyOn(entrypoint, 'createChild');
+  (mod as unknown as { ignored: boolean }).ignored = true;
+  const childFilename = path.resolve(
+    __dirname,
+    './__fixtures__/sample-script.js'
+  );
+
+  mod.getEntrypoint(childFilename, ['*'], logger);
+
+  expect(createChildSpy).toHaveBeenCalledWith(
+    childFilename,
+    ['*'],
+    fs.readFileSync(childFilename, 'utf-8'),
+    moduleServices
+  );
+});
+
 it('requires .js files', async () => {
   const { mod } = create`
     const answer = require('./sample-script');

--- a/packages/transform/src/__tests__/transform.action-services.test.ts
+++ b/packages/transform/src/__tests__/transform.action-services.test.ts
@@ -1,0 +1,112 @@
+import path from 'path';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { Services } from '../transform/types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const filename = path.join(__dirname, '__fixtures__', 'foo.js');
+const code = 'export const foo = 1;';
+
+type Captured = { emitWarning: Services['emitWarning'] };
+
+const runWith = (
+  cache: TransformCacheCollection,
+  emitWarning: (message: string) => void,
+  captured: { workflow: Captured[]; nested: Captured[] } | null,
+  eventEmitter: EventEmitter
+) =>
+  transform(
+    {
+      // a stable key keeps one eval session across runs, as the loaders do
+      asyncResolveKey: 'transform.action-services.test',
+      cache,
+      emitWarning,
+      eventEmitter,
+      options: {
+        filename,
+        root: __dirname,
+        pluginOptions: {
+          configFile: false,
+          // share `cache` between runs, as the bundler loaders do
+          features: { globalCache: true },
+          babelOptions: { babelrc: false, configFile: false },
+        },
+      },
+    },
+    code,
+    async () => {
+      throw new Error('no imports expected');
+    },
+    {
+      // eslint-disable-next-line require-yield
+      *workflow() {
+        if (captured) {
+          captured.workflow.push({ emitWarning: this.services.emitWarning });
+          yield* this.getNext(
+            'processEntrypoint',
+            this.entrypoint,
+            undefined,
+            null
+          );
+        }
+        return { code: '', sourceMap: null };
+      },
+      // eslint-disable-next-line require-yield
+      *transform() {
+        captured?.nested.push({ emitWarning: this.services.emitWarning });
+        return { code, metadata: null };
+      },
+    } as Parameters<typeof transform>[3]
+  );
+
+describe('actions of a transform run', () => {
+  it('use the services of the run that created them, not those of the cached entrypoint', async () => {
+    const cache = new TransformCacheCollection();
+    const warnA = () => {};
+    const warnB = () => {};
+    let emitterAClosed = false;
+    const assertEmitterAOpen = () => {
+      if (emitterAClosed) {
+        throw new Error('run A emitter was used after its transform');
+      }
+    };
+    const emitterA = new EventEmitter(
+      assertEmitterAOpen,
+      () => {
+        assertEmitterAOpen();
+        return 0;
+      },
+      assertEmitterAOpen
+    );
+    const eventsB: string[] = [];
+    const emitterB = new EventEmitter(
+      () => {},
+      () => 0,
+      (_sequenceId, _timestamp, event) => eventsB.push(event.type)
+    );
+
+    // Run A leaves a root entrypoint for `filename` in the shared cache that
+    // was created with A's services and never processed, which is the state
+    // the eval broker's on-demand preparation of a dependency leaves behind.
+    await runWith(cache, warnA, null, emitterA);
+    emitterAClosed = true;
+
+    // Run B transforms the same, unchanged file. `innerCreate` reuses the
+    // cached entrypoint as is (not changed, not evaluated, `only` covered).
+    const captured = { workflow: [] as Captured[], nested: [] as Captured[] };
+    await runWith(cache, warnB, captured, emitterB);
+
+    const tagOf = (c: Captured) => (c.emitWarning === warnB ? 'B' : 'A');
+    expect(captured.workflow.map(tagOf)).toEqual(['B']);
+    expect(captured.nested.map(tagOf)).toEqual(['B']);
+    expect(eventsB).toEqual(
+      expect.arrayContaining([
+        'actionCreated',
+        'actionCreated',
+        'actionCreated',
+        'setTransformResult',
+      ])
+    );
+  });
+});

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1788,7 +1788,7 @@ export class EvalBroker {
       const target =
         cached.evaluated || !('createEvaluated' in cached)
           ? cached
-          : cached.createEvaluated();
+          : cached.createEvaluated(this.currentServices);
 
       const exportsProxy = target.exports;
       Object.entries(serializedExports).forEach(([key, serialized]) => {

--- a/packages/transform/src/module.ts
+++ b/packages/transform/src/module.ts
@@ -426,7 +426,7 @@ export class Module {
       this.cache.add(
         'entrypoints',
         entrypoint.name,
-        entrypoint.createEvaluated()
+        entrypoint.createEvaluated(this.services)
       );
       evaluatedCreated = true;
     }
@@ -535,7 +535,8 @@ export class Module {
       const newEntrypoint = this.entrypoint.createChild(
         filename,
         ['*'],
-        fs.readFileSync(strippedFilename, 'utf-8')
+        fs.readFileSync(strippedFilename, 'utf-8'),
+        this.services
       );
 
       if (newEntrypoint === 'loop') {

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -106,7 +106,8 @@ const executeTransform = async (
       'workflow',
       undefined,
       null,
-      actionContext
+      actionContext,
+      services
     );
 
     const result = await asyncActionRunner(workflowAction, {

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -210,7 +210,7 @@ export class Entrypoint extends BaseEntrypoint {
 
   private actionsCache: Map<
     ActionTypes,
-    Map<unknown, Map<unknown, BaseAction<ActionQueueItem>>>
+    Map<unknown, Map<unknown, WeakMap<Services, BaseAction<ActionQueueItem>>>>
   > = new Map();
 
   // Tracks how many times resolveImports has settled with `resolved: null`
@@ -575,7 +575,10 @@ export class Entrypoint extends BaseEntrypoint {
             cached.only,
             mergedOnly
           );
-          return [isLoop ? 'loop' : 'created', cached.supersede(mergedOnly)];
+          return [
+            isLoop ? 'loop' : 'created',
+            cached.supersede(mergedOnly, services),
+          ];
         }
 
         cached.deferOnlySupersede(mergedOnly);
@@ -587,7 +590,10 @@ export class Entrypoint extends BaseEntrypoint {
         return [isLoop ? 'loop' : 'cached', cached];
       }
 
-      return [isLoop ? 'loop' : 'created', cached.supersede(mergedOnly)];
+      return [
+        isLoop ? 'loop' : 'created',
+        cached.supersede(mergedOnly, services),
+      ];
     }
 
     if (cached) {
@@ -660,7 +666,7 @@ export class Entrypoint extends BaseEntrypoint {
 
     if (cached && !cached.evaluated) {
       cached.log('is cached, but with different code');
-      cached.supersede(newEntrypoint);
+      cached.supersede(newEntrypoint, services);
     }
 
     return ['created', newEntrypoint];
@@ -704,7 +710,7 @@ export class Entrypoint extends BaseEntrypoint {
     this.resolveTasks.set(name, tracked);
   }
 
-  public applyDeferredSupersede() {
+  public applyDeferredSupersede(services: Services = this.services) {
     if (this.#supersededWith || this.#pendingOnly === null) {
       return null;
     }
@@ -718,8 +724,8 @@ export class Entrypoint extends BaseEntrypoint {
 
     this.log('apply deferred supersede (%o -> %o)', this.only, mergedOnly);
 
-    const nextEntrypoint = this.supersede(mergedOnly);
-    this.services.cache.add('entrypoints', this.name, nextEntrypoint);
+    const nextEntrypoint = this.supersede(mergedOnly, services);
+    services.cache.add('entrypoints', this.name, nextEntrypoint);
 
     return nextEntrypoint;
   }
@@ -764,7 +770,8 @@ export class Entrypoint extends BaseEntrypoint {
     actionType: TType,
     data: TAction['data'],
     abortSignal: AbortSignal | null = null,
-    actionContext: unknown = DEFAULT_ACTION_CONTEXT
+    actionContext: unknown = DEFAULT_ACTION_CONTEXT,
+    services: Services = this.services
   ): BaseAction<TAction> {
     const actionContextOwners = getActionContextOwners(actionContext);
     if (actionContextOwners && !actionContextOwners.has(this)) {
@@ -781,23 +788,28 @@ export class Entrypoint extends BaseEntrypoint {
     }
 
     const cache = contexts.get(actionContext)!;
-    const cached = cache.get(data);
+    if (!cache.has(data)) {
+      cache.set(data, new WeakMap());
+    }
+
+    const serviceScopes = cache.get(data)!;
+    const cached = serviceScopes.get(services);
     if (cached && !cached.abortSignal?.aborted) {
       return cached as BaseAction<TAction>;
     }
 
     const newAction = new BaseAction<TAction>(
       actionType as TAction['type'],
-      this.services,
+      services,
       this,
       data,
       abortSignal,
       actionContext
     );
 
-    cache.set(data, newAction);
+    serviceScopes.set(services, newAction);
 
-    this.services.eventEmitter.entrypointEvent(this.seqId, {
+    services.eventEmitter.entrypointEvent(this.seqId, {
       type: 'actionCreated',
       actionType,
       actionIdx: newAction.idx,
@@ -818,20 +830,21 @@ export class Entrypoint extends BaseEntrypoint {
   public createChild(
     name: string,
     only: string[],
-    loadedCode?: string
+    loadedCode?: string,
+    services: Services = this.services
   ): Entrypoint | 'loop' {
     this.assertNotSuperseded();
-    return Entrypoint.create(this.services, this, name, only, loadedCode, {
+    return Entrypoint.create(services, this, name, only, loadedCode, {
       graphTraversalToken: this.unknownGraphTraversalToken,
     });
   }
 
-  public createEvaluated() {
+  public createEvaluated(services: Services = this.services) {
     const evaluatedOnly = mergeOnly(this.evaluatedOnly, this.only);
     this.log('create EvaluatedEntrypoint for %o', evaluatedOnly);
 
     const evaluated = new EvaluatedEntrypoint(
-      this.services,
+      services,
       evaluatedOnly,
       this.exportsProxy,
       this.generation + 1,
@@ -923,7 +936,10 @@ export class Entrypoint extends BaseEntrypoint {
     };
   }
 
-  public setTransformResult(res: ITransformFileResult | null) {
+  public setTransformResult(
+    res: ITransformFileResult | null,
+    services: Services = this.services
+  ) {
     this.#hasTransformResult = true;
     this.#hasWywMetadata = Boolean(res?.metadata);
     this.#transformResultCode = res?.code ?? null;
@@ -931,10 +947,10 @@ export class Entrypoint extends BaseEntrypoint {
     // A completed transform releases the superseded generations that led to
     // it. A later dependency rebuild is a new lineage and must get its own
     // diagnostic budget instead of inheriting a nearly-full storm window.
-    this.services.cache.completeUnknownGraphRecovery(this.name, this);
-    resetSupersedeWindow(this.services, this.name);
+    services.cache.completeUnknownGraphRecovery(this.name, this);
+    resetSupersedeWindow(services, this.name);
 
-    this.services.eventEmitter.entrypointEvent(this.seqId, {
+    services.eventEmitter.entrypointEvent(this.seqId, {
       isNull: res === null,
       type: 'setTransformResult',
     });
@@ -957,12 +973,15 @@ export class Entrypoint extends BaseEntrypoint {
       : [...only];
   }
 
-  private supersede(newOnlyOrEntrypoint: string[] | Entrypoint): Entrypoint {
+  private supersede(
+    newOnlyOrEntrypoint: string[] | Entrypoint,
+    services: Services = this.services
+  ): Entrypoint {
     this.#pendingOnly = null;
     const widensOnly = !(newOnlyOrEntrypoint instanceof Entrypoint);
     const newEntrypoint = widensOnly
       ? new Entrypoint(
-          this.services,
+          services,
           this.parents,
           this.initialCode,
           this.name,
@@ -980,7 +999,7 @@ export class Entrypoint extends BaseEntrypoint {
         )
       : newOnlyOrEntrypoint;
 
-    this.services.eventEmitter.entrypointEvent(this.seqId, {
+    services.eventEmitter.entrypointEvent(this.seqId, {
       type: 'superseded',
       with: newEntrypoint.seqId,
     });

--- a/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
+++ b/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
@@ -1,5 +1,6 @@
 import type { Services } from '../types';
 import { createActionContext, disposeActionContext } from '../ActionContext';
+import { EventEmitter } from '../../utils/EventEmitter';
 
 import { createEntrypoint, createServices } from './entrypoint-helpers';
 
@@ -92,6 +93,46 @@ describe('createEntrypoint', () => {
       name: '/foo/bar.js',
       only: ['default', 'named'],
     });
+  });
+
+  it('uses the requesting services when widening a cached root', () => {
+    let originalEmitterClosed = false;
+    const assertOriginalEmitterOpen = () => {
+      if (originalEmitterClosed) {
+        throw new Error('stale entrypoint emitter was used');
+      }
+    };
+    services.eventEmitter = new EventEmitter(
+      assertOriginalEmitterOpen,
+      () => {
+        assertOriginalEmitterOpen();
+        return 0;
+      },
+      assertOriginalEmitterOpen
+    );
+
+    const entrypoint1 = createEntrypoint(services, '/foo/bar.js', ['default']);
+    originalEmitterClosed = true;
+
+    const nextEvents: string[] = [];
+    const nextServices: Services = {
+      ...services,
+      eventEmitter: new EventEmitter(
+        () => {},
+        () => 0,
+        (_sequenceId, _timestamp, event) => nextEvents.push(event.type)
+      ),
+    };
+    const entrypoint2 = createEntrypoint(nextServices, '/foo/bar.js', [
+      'named',
+    ]);
+
+    expect(entrypoint2).not.toBe(entrypoint1);
+    expect(entrypoint1.supersededWith).toBe(entrypoint2);
+    expect(entrypoint2.only).toEqual(['default', 'named']);
+    expect(nextEvents).toEqual(
+      expect.arrayContaining(['created', 'superseded'])
+    );
   });
 
   it('should take from cache if only is subset of cached', () => {

--- a/packages/transform/src/transform/actions/BaseAction.ts
+++ b/packages/transform/src/transform/actions/BaseAction.ts
@@ -102,18 +102,26 @@ export class BaseAction<TAction extends ActionQueueItem>
     type: TNextType,
     entrypoint: Entrypoint,
     data: TNextAction['data'],
-    abortSignal: AbortSignal | null = this.abortSignal
+    abortSignal: AbortSignal | null = this.abortSignal,
+    services?: Services
   ): Generator<
-    [TNextType, Entrypoint, TNextAction['data'], AbortSignal | null],
+    [TNextType, Entrypoint, TNextAction['data'], AbortSignal | null, Services?],
     TypeOfResult<TNextAction>,
     YieldResult
   > {
-    return (yield [
-      type,
-      entrypoint,
-      data,
-      abortSignal,
-    ]) as TypeOfResult<TNextAction>;
+    const next: [
+      TNextType,
+      Entrypoint,
+      TNextAction['data'],
+      AbortSignal | null,
+      Services?,
+    ] = [type, entrypoint, data, abortSignal];
+
+    if (services !== undefined) {
+      next.push(services);
+    }
+
+    return (yield next) as TypeOfResult<TNextAction>;
   }
 
   public onAbort(fn: () => void): () => void {

--- a/packages/transform/src/transform/actions/__tests__/actionRunner.test.ts
+++ b/packages/transform/src/transform/actions/__tests__/actionRunner.test.ts
@@ -44,6 +44,44 @@ describe('actionRunner', () => {
     expect(handlers.processEntrypoint).toHaveBeenCalled();
   });
 
+  it('separates cached nested actions by their service scope', () => {
+    const analysisServices = createServices();
+    const rootEntrypoint = createEntrypoint(services, '/foo/root.js', [
+      'default',
+    ]);
+    const analysisEntrypoint = createEntrypoint(
+      analysisServices,
+      '/foo/analysis.js',
+      ['default']
+    );
+    const captured: Services[] = [];
+    const handlers = getHandlers<'sync'>({
+      *workflow(this: IWorkflowAction) {
+        yield* this.getNext('transform', analysisEntrypoint, undefined, null);
+        yield* this.getNext(
+          'transform',
+          analysisEntrypoint,
+          undefined,
+          null,
+          analysisServices
+        );
+        return { code: '', sourceMap: null };
+      },
+      // eslint-disable-next-line require-yield
+      *transform(this: ITransformAction) {
+        captured.push(this.services);
+        return { code: '', metadata: null };
+      },
+    });
+
+    syncActionRunner(
+      rootEntrypoint.createAction('workflow', undefined, null),
+      handlers
+    );
+
+    expect(captured).toEqual([services, analysisServices]);
+  });
+
   it('should not run action if its copy was already run', async () => {
     const handler = jest.fn();
     function* handlerGenerator(

--- a/packages/transform/src/transform/actions/actionRunner.ts
+++ b/packages/transform/src/transform/actions/actionRunner.ts
@@ -61,12 +61,14 @@ export async function asyncActionRunner<TAction extends ActionQueueItem>(
       return result.value as TypeOfResult<TAction>;
     }
 
-    const [type, entrypoint, data, abortSignal] = result.value;
+    const [type, entrypoint, data, abortSignal, services = action.services] =
+      result.value;
     const nextAction = entrypoint.createAction(
       type,
       data,
       abortSignal,
-      action.actionContext
+      action.actionContext,
+      services
     );
 
     try {
@@ -108,12 +110,14 @@ export function syncActionRunner<TAction extends ActionQueueItem>(
       return result.value as TypeOfResult<TAction>;
     }
 
-    const [type, entrypoint, data, abortSignal] = result.value;
+    const [type, entrypoint, data, abortSignal, services = action.services] =
+      result.value;
     const nextAction = entrypoint.createAction(
       type,
       data,
       abortSignal,
-      action.actionContext
+      action.actionContext,
+      services
     );
 
     try {

--- a/packages/transform/src/transform/generators/__tests__/processImports.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/processImports.test.ts
@@ -52,10 +52,12 @@ describe('processImports', () => {
     syncActionRunner(action, handlers);
 
     expect(freshnessSpy).not.toHaveBeenCalled();
-    expect(createChildSpy).toHaveBeenCalledWith(depPath, [
-      '__wywPreval',
-      'value',
-    ]);
+    expect(createChildSpy).toHaveBeenCalledWith(
+      depPath,
+      ['__wywPreval', 'value'],
+      undefined,
+      services
+    );
     expect(handlers.processEntrypoint).toHaveBeenCalledTimes(1);
   });
 
@@ -207,10 +209,12 @@ describe('processImports', () => {
     syncActionRunner(action, handlers);
 
     expect(freshnessSpy).not.toHaveBeenCalled();
-    expect(createChildSpy).toHaveBeenCalledWith(depPath, [
-      '__wywPreval',
-      'value',
-    ]);
+    expect(createChildSpy).toHaveBeenCalledWith(
+      depPath,
+      ['__wywPreval', 'value'],
+      undefined,
+      services
+    );
     expect(handlers.processEntrypoint).toHaveBeenCalledTimes(1);
   });
 
@@ -258,7 +262,12 @@ describe('processImports', () => {
 
     syncActionRunner(action, handlers);
 
-    expect(createChildSpy).toHaveBeenCalledWith(depPath, ['value']);
+    expect(createChildSpy).toHaveBeenCalledWith(
+      depPath,
+      ['value'],
+      undefined,
+      services
+    );
     expect(handlers.processEntrypoint).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/transform/src/transform/generators/getExports.ts
+++ b/packages/transform/src/transform/generators/getExports.ts
@@ -3,7 +3,11 @@ import { collectOxcExportsAndImports } from '../../utils/collectOxcExportsAndImp
 import { oxcShaker } from '../../shaker';
 import type { Entrypoint } from '../Entrypoint';
 import type { IEntrypointDependency } from '../Entrypoint.types';
-import type { IGetExportsAction, SyncScenarioForAction } from '../types';
+import type {
+  IGetExportsAction,
+  Services,
+  SyncScenarioForAction,
+} from '../types';
 
 type WildcardReexport = {
   source: string;
@@ -11,7 +15,8 @@ type WildcardReexport = {
 
 export function findExportsInImports(
   entrypoint: Entrypoint,
-  imports: IEntrypointDependency[]
+  imports: IEntrypointDependency[],
+  services?: Services
 ): { entrypoint: Entrypoint; import: string }[] {
   const results: {
     entrypoint: Entrypoint;
@@ -24,7 +29,12 @@ export function findExportsInImports(
       throw new Error(`Could not resolve import ${imp.source}`);
     }
 
-    const newEntrypoint = entrypoint.createChild(resolved, []);
+    const newEntrypoint = entrypoint.createChild(
+      resolved,
+      [],
+      undefined,
+      services
+    );
 
     if (newEntrypoint === 'loop') {
       continue;
@@ -92,7 +102,8 @@ export function* getExports(
 
     const importedEntrypoints = findExportsInImports(
       entrypoint,
-      resolvedImports
+      resolvedImports,
+      this.services
     );
 
     for (const importedEntrypoint of importedEntrypoints) {

--- a/packages/transform/src/transform/generators/processEntrypoint.ts
+++ b/packages/transform/src/transform/generators/processEntrypoint.ts
@@ -41,9 +41,11 @@ export function* processEntrypoint(
 
     this.entrypoint.assertNotSuperseded();
 
-    this.entrypoint.setTransformResult(result);
+    this.entrypoint.setTransformResult(result, this.services);
 
-    const supersededWith = this.entrypoint.applyDeferredSupersede();
+    const supersededWith = this.entrypoint.applyDeferredSupersede(
+      this.services
+    );
     if (supersededWith) {
       log('processing finished, deferred only detected; schedule next attempt');
       yield* this.getNext('processEntrypoint', supersededWith, undefined, null);
@@ -102,9 +104,11 @@ export async function* processEntrypointAsync(
 
     this.entrypoint.assertNotSuperseded();
 
-    this.entrypoint.setTransformResult(result);
+    this.entrypoint.setTransformResult(result, this.services);
 
-    const supersededWith = this.entrypoint.applyDeferredSupersede();
+    const supersededWith = this.entrypoint.applyDeferredSupersede(
+      this.services
+    );
     if (supersededWith) {
       log('processing finished, deferred only detected; schedule next attempt');
       yield* this.getNext('processEntrypoint', supersededWith, undefined, null);

--- a/packages/transform/src/transform/generators/processImports.ts
+++ b/packages/transform/src/transform/generators/processImports.ts
@@ -144,11 +144,17 @@ export function* processImports(
 
     const nextEntrypoint =
       dependency.loadedCode === undefined
-        ? this.entrypoint.createChild(resolved, requiredOnly)
+        ? this.entrypoint.createChild(
+            resolved,
+            requiredOnly,
+            undefined,
+            this.services
+          )
         : this.entrypoint.createChild(
             resolved,
             requiredOnly,
-            dependency.loadedCode
+            dependency.loadedCode,
+            this.services
           );
     if (nextEntrypoint === 'loop' || nextEntrypoint.ignored) {
       continue;

--- a/packages/transform/src/transform/generators/rewriteOxcBarrelImports.ts
+++ b/packages/transform/src/transform/generators/rewriteOxcBarrelImports.ts
@@ -714,7 +714,8 @@ function* getWildcardExportDependencies(
         wildcardReexports.map((reexport) => [reexport.source, []])
       ),
     },
-    null
+    null,
+    analysisServices
   );
 
   const dependencies = new Set<string>();
@@ -753,7 +754,13 @@ function* getExportsForFile(
     undefined,
     this.entrypoint.graphTraversalToken
   );
-  return yield* this.getNext('getExports', entrypoint, undefined, null);
+  return yield* this.getNext(
+    'getExports',
+    entrypoint,
+    undefined,
+    null,
+    services
+  );
 }
 
 function* getOrBuildOxcBarrelManifest(
@@ -829,7 +836,8 @@ function* getOrBuildOxcBarrelManifest(
     {
       imports: buildImportsForResolve(analyzed),
     },
-    null
+    null,
+    analysisServices
   );
   const manifestDependencies = resolvedImports.flatMap((dependency) =>
     dependency.resolved ? [dependency.resolved] : []

--- a/packages/transform/src/transform/types.ts
+++ b/packages/transform/src/transform/types.ts
@@ -97,6 +97,7 @@ type NextParams<
   entrypoint: Entrypoint,
   data: TNextAction['data'],
   abortSignal?: AbortSignal | null,
+  services?: Services,
 ];
 
 export type YieldArg = {
@@ -150,7 +151,7 @@ export type GetNext = <
 >(
   ...args: NextParams<TType, TNextAction>
 ) => Generator<
-  [TType, Entrypoint, TNextAction['data'], AbortSignal | null],
+  NextParams<TType, TNextAction>,
   TypeOfResult<TNextAction>,
   YieldResult
 >;


### PR DESCRIPTION
Fixes #413.

## Motivation

Entrypoints can outlive the transform run that first placed them in a shared cache. Reusing such an entrypoint previously created actions with the services captured by that older run. The current file could therefore inherit an earlier importer's filename, source maps, output path, warning handler, event emitter, or cache scope, producing incorrect maps and duplicate-output conflicts.

## What changed

- Bind each root action to the services of the current `transform()` call, and make nested actions inherit their parent action's services.
- Propagate the active services through child/evaluated entrypoint creation, superseding, deferred superseding, transform-result publication, evaluator hydration, and the legacy `Module` path.
- Allow explicit nested service overrides for isolated barrel analysis, preserving its private cache and telemetry scope.
- Partition cached actions by weak `Services` identity as well as action context and data, so identical nested actions from different service scopes cannot reuse each other without retaining completed transform scopes.
- Preserve the legacy four-element action yield for callers that do not request an explicit service override.

## Test plan

- `bun test packages/transform/src`: 1,991 passed, 1 skipped, 1 todo.
- `bun run --filter @wyw-in-js/transform build:types`.
- `bun run --filter @wyw-in-js/transform lint`.
- Added regressions for cached roots, sync and async nested actions, explicit service scopes, action-cache partitioning, entrypoint lifecycle updates, isolated barrel analysis, `processImports`, and the legacy `Module` evaluator/child paths.
- End-to-end consumer typechecks/builds passed, and generated CSS matched the checked-in baselines.
