### PR TITLE
fix(transform): keep answering post-eval dynamic import requests

### DIFF
--- a/.changeset/eval-broker-post-eval-dynamic-import.md
+++ b/.changeset/eval-broker-post-eval-dynamic-import.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Keep answering resolve and load requests from a fire-and-forget dynamic import after its evaluation has finished. The eval broker scoped request liveness to the entrypoint that was active when the request arrived, so a `RESOLVE` sent right before `EVAL_RESULT` and delivered in the same stdout chunk was silently dropped once the eval completed. The runner then waited for that answer forever and the next load for the same semantic session never started, which surfaced as sporadic eval timeouts on busy machines. Liveness is now scoped by the semantic session (runner, session id, request epoch, services and cache generation); the next entrypoint still invalidates stale continuations through the request epoch.

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -948,6 +948,94 @@ describe('EvalBroker', () => {
     }
   });
 
+  it('answers a post-eval dynamic import resolve delivered in one chunk with EVAL_RESULT', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const slowModule = join(root, 'slow.js');
+    const source = [
+      'export const __wywPreval = {',
+      '  value: () => {',
+      "    void import('slow');",
+      "    return 'first';",
+      '  },',
+      '};',
+    ].join('\n');
+    writeFileSync(entry, source);
+    writeFileSync(slowModule, "export const value = 'slow';");
+
+    let loads = 0;
+    let loadStarted!: () => void;
+    const loadStartedPromise = new Promise<void>((complete) => {
+      loadStarted = complete;
+    });
+    const services = createServices(root, entry, {
+      eval: {
+        customLoader: async (id) => {
+          if (id !== slowModule) return undefined;
+          loads += 1;
+          loadStarted();
+          return { code: "export const value = 'slow';" };
+        },
+      },
+    });
+    services.evalCacheKey = 'coalesced-semantics';
+    services.asyncResolve = async (what) =>
+      what === 'slow' ? slowModule : null;
+
+    const broker = new EvalBroker(services, services.asyncResolve);
+    const privateBroker = broker as unknown as {
+      onData: (runner: unknown, chunk: string) => void;
+    };
+
+    // Deliver runner stdout in coalesced chunks so the RESOLVE issued by the
+    // fire-and-forget import is processed in the same synchronous batch as
+    // EVAL_RESULT. This is what a busy CI host produces naturally.
+    const originalOnData = privateBroker.onData;
+    let coalesced = '';
+    let coalescedRunner: unknown;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    privateBroker.onData = (runner, chunk) => {
+      coalesced += chunk;
+      coalescedRunner = runner;
+      if (flushTimer) return;
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        const buffered = coalesced;
+        coalesced = '';
+        originalOnData.call(broker, coalescedRunner, buffered);
+      }, 5);
+    };
+
+    try {
+      const entrypoint = Entrypoint.createRoot(
+        services,
+        entry,
+        ['__wywPreval'],
+        source
+      );
+      expect(
+        (await broker.evaluate(entrypoint, services)).values?.get('value')
+      ).toBe('first');
+
+      // The dynamic import continuation belongs to the same semantic session
+      // and must still be served after EVAL_RESULT cleared the active
+      // entrypoint. Dropping RESOLVE_RESULT would leave the runner awaiting
+      // forever and this LOAD would never arrive.
+      const loaded = await Promise.race([
+        loadStartedPromise.then(() => true),
+        new Promise<false>((resolveTimeout) => {
+          setTimeout(() => resolveTimeout(false), 1000);
+        }),
+      ]);
+      expect(loaded).toBe(true);
+      expect(loads).toBe(1);
+    } finally {
+      if (flushTimer) clearTimeout(flushTimer);
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not let a stale same-id load block the next entrypoint session', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
     const firstEntry = join(root, 'first.js');

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -2632,6 +2632,14 @@ export class EvalBroker {
     context: EvalRequestContext | undefined
   ): boolean {
     if (!context) return true;
+    // Liveness is scoped by the semantic session (runner, session id, request
+    // epoch, services and cache generation), not by the entrypoint that was
+    // active when the request arrived. A fire-and-forget dynamic import may
+    // send RESOLVE right before EVAL_RESULT; when both land in one stdout
+    // chunk the EVAL finishes (and clears activeEntrypoint) before the async
+    // resolve completes. Dropping that RESOLVE_RESULT would leave the runner
+    // awaiting forever and block the following LOAD. The next entrypoint bumps
+    // requestEpoch, so stale continuations are still rejected there.
     return (
       context.epoch === this.requestEpoch &&
       context.cacheGeneration ===
@@ -2639,8 +2647,7 @@ export class EvalBroker {
       context.runner === this.runner &&
       context.sessionId === this.activeRunnerSessionId &&
       context.services === this.currentServices &&
-      context.inputQueue === this.runnerInputQueue &&
-      context.entrypoint === this.activeEntrypoint
+      context.inputQueue === this.runnerInputQueue
     );
   }
 


### PR DESCRIPTION
## Problem

`EvalBroker > does not carry a delayed dynamic import into the next semantic session` timed out sporadically on CI (e.g. [run 33616414238](https://github.com/wyw-in-js/wyw-in-js/actions/runs/33616414238/job/100203172308) on `main`, unrelated to the merged PR). Locally it fails ~2/25 runs on a clean `main`.

## Root cause

A fire-and-forget `import()` inside preval makes the runner send `RESOLVE` right before `EVAL_RESULT`. The broker parses runner stdout line by line, synchronously per chunk. When both messages land in one chunk, `evaluate` finishes and its `finally` clears `activeEntrypoint` before the async resolve completes. `isRequestContextActive` compared `context.entrypoint === this.activeEntrypoint`, so the `RESOLVE_RESULT` was dropped as stale. The runner awaits that answer with no timeout, the following `LOAD` for the same semantic session never starts, and the test hangs. Chunk coalescing happens more often on a busy host, hence "fails on CI, passes locally".

Forcing coalesced delivery makes the test fail 5/5; with the fix it passes 5/5.

## Origin

The `context.entrypoint === this.activeEntrypoint` check was introduced in #410 (`dfd7eeba`, "fail safely on supersede storms") together with the request-context machinery, while the test that exercises post-eval dynamic imports came from #409 (`da5e8a11`). #410's own CI and the `main` run on its merge passed by chance; the race is probabilistic (~2/25 locally).

This is a targeted fix, not a revert of #410. `activeEntrypoint` changes in three places only: the next entrypoint start also bumps `requestEpoch`, the runner reset also zeroes `activeRunnerSessionId`, and the `finally` at the end of `evaluate` clears it. The first two are still caught by the remaining checks, so the removed comparison only ever affected the post-eval window inside the same semantic session, which #409 explicitly allows. `assertNotSuperseded()` on the captured entrypoint, and using `context.entrypoint` as the publish target, stay as they were, so superseded entrypoints still cannot publish results. All eight tests added by #410 pass.

## Fix

Scope request liveness by the semantic session only: runner, session id, request epoch, services and cache generation. The entrypoint identity check was redundant for the case it was meant to guard — the next entrypoint bumps `requestEpoch` via `resetPerEntrypointState`, so stale continuations are still rejected there. `assertNotSuperseded()` on the entrypoint is unchanged.

## Test

New regression test wraps the broker's `onData` to deliver runner stdout in coalesced chunks (5 ms buffer) and asserts the dynamic import's `LOAD` still arrives after `EVAL_RESULT`. Fails without the fix, passes with it.

Full `@wyw-in-js/transform` suite: 2009 pass, 0 fail.
