### PR TITLE
fix(turbopack-loader): emit selector list members as separate rules

### DIFF
--- a/.changeset/split-selector-lists.md
+++ b/.changeset/split-selector-lists.md
@@ -2,4 +2,6 @@
 '@wyw-in-js/turbopack-loader': patch
 ---
 
-Emit every member of a selector list as its own `:global()` rule. lightningcss resolves `:global(a), :global(b)` into `:is(a, b)`, which is not equivalent to the list: pseudo-elements are invalid inside `:is()` (every `&::before, &::after { ... }` rule was silently dropped by browsers) and `:is()` takes the specificity of its most specific member, which changed the cascade for lists with unequal members.
+Emit every member of a selector list as its own `:global()` rule. lightningcss resolves `:global(a), :global(b)` into `:is(a, b)` ([lightningcss#1032](https://github.com/parcel-bundler/lightningcss/issues/1032), [#1079](https://github.com/parcel-bundler/lightningcss/issues/1079), proposed fix in [#1231](https://github.com/parcel-bundler/lightningcss/pull/1231)), which is not equivalent to the list: pseudo-elements are invalid inside `:is()` (every `&::before, &::after { ... }` rule was silently dropped by browsers) and `:is()` takes the specificity of its most specific member, which changed the cascade for lists with unequal members.
+
+Narrowing browserslist is not a workaround: the fold happens for any target with `:is()` support (Chrome 88+). There is no toggle either, because the split output stays valid once the fold is fixed upstream, and lightningcss already merges identical adjacent rules back into a list under `minify` - returning to the list form is a size optimisation, not a correctness fix.

--- a/.changeset/split-selector-lists.md
+++ b/.changeset/split-selector-lists.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/turbopack-loader': patch
+---
+
+Emit every member of a selector list as its own `:global()` rule. lightningcss resolves `:global(a), :global(b)` into `:is(a, b)`, which is not equivalent to the list: pseudo-elements are invalid inside `:is()` (every `&::before, &::after { ... }` rule was silently dropped by browsers) and `:is()` takes the specificity of its most specific member, which changed the cascade for lists with unequal members.

--- a/packages/turbopack-loader/src/__tests__/css-modules.test.ts
+++ b/packages/turbopack-loader/src/__tests__/css-modules.test.ts
@@ -8,17 +8,25 @@ describe('makeCssModuleGlobal', () => {
   });
 
   it('emits one rule per member of a selector list', () => {
-    // lightningcss folds `:global(a), :global(b)` into `:is(a, b)`, which is
-    // invalid with pseudo-elements and takes the specificity of the most
-    // specific member; separate rules keep the source semantics
     expect(makeCssModuleGlobal('.a, .b{color:red}')).toBe(
-      ':global(.a){color:red}\n:global(.b){color:red}'
+      ':global(.a){color:red}:global(.b){color:red}'
     );
     expect(makeCssModuleGlobal('.a:before, .a:after{content:" ";c:red}')).toBe(
-      ':global(.a:before){content:" ";c:red}\n:global(.a:after){content:" ";c:red}'
+      ':global(.a:before){content:" ";c:red}:global(.a:after){content:" ";c:red}'
     );
     expect(makeCssModuleGlobal('.a, #b .c{c:red}')).toBe(
-      ':global(.a){c:red}\n:global(#b .c){c:red}'
+      ':global(.a){c:red}:global(#b .c){c:red}'
+    );
+  });
+
+  it('splits the `&:before, &:after` pair as stylis flattens it', () => {
+    expect(
+      makeCssModuleGlobal(
+        ".abc1def:before,.abc1def:after{content:' ';background:orange;animation:zoom 2.7s infinite;}"
+      )
+    ).toBe(
+      ":global(.abc1def:before){content:' ';background:orange;animation:zoom 2.7s infinite;}" +
+        ":global(.abc1def:after){content:' ';background:orange;animation:zoom 2.7s infinite;}"
     );
   });
 
@@ -28,7 +36,16 @@ describe('makeCssModuleGlobal', () => {
         '@media (min-width: 1px){.a::before, .a::after{c:red}}'
       )
     ).toBe(
-      '@media (min-width: 1px){:global(.a::before){c:red}\n:global(.a::after){c:red}}'
+      '@media (min-width: 1px){:global(.a::before){c:red}:global(.a::after){c:red}}'
+    );
+  });
+
+  it('duplicates at-rules nested in the body for every list member', () => {
+    expect(
+      makeCssModuleGlobal('.a, .b{c:red;@media (min-width: 1px){c:blue}}')
+    ).toBe(
+      ':global(.a){c:red;@media (min-width: 1px){c:blue}}' +
+        ':global(.b){c:red;@media (min-width: 1px){c:blue}}'
     );
   });
 
@@ -56,7 +73,7 @@ describe('makeCssModuleGlobal', () => {
     expect(
       makeCssModuleGlobal('.a:is(.b, .c), [data-x="y,z"], .d:hover > .e{c:red}')
     ).toBe(
-      ':global(.a:is(.b, .c)){c:red}\n:global([data-x="y,z"]){c:red}\n:global(.d:hover > .e){c:red}'
+      ':global(.a:is(.b, .c)){c:red}:global([data-x="y,z"]){c:red}:global(.d:hover > .e){c:red}'
     );
   });
 });

--- a/packages/turbopack-loader/src/__tests__/css-modules.test.ts
+++ b/packages/turbopack-loader/src/__tests__/css-modules.test.ts
@@ -7,9 +7,28 @@ describe('makeCssModuleGlobal', () => {
     );
   });
 
-  it('wraps each selector in a selector list', () => {
+  it('emits one rule per member of a selector list', () => {
+    // lightningcss folds `:global(a), :global(b)` into `:is(a, b)`, which is
+    // invalid with pseudo-elements and takes the specificity of the most
+    // specific member; separate rules keep the source semantics
     expect(makeCssModuleGlobal('.a, .b{color:red}')).toBe(
-      ':global(.a), :global(.b){color:red}'
+      ':global(.a){color:red}\n:global(.b){color:red}'
+    );
+    expect(makeCssModuleGlobal('.a:before, .a:after{content:" ";c:red}')).toBe(
+      ':global(.a:before){content:" ";c:red}\n:global(.a:after){content:" ";c:red}'
+    );
+    expect(makeCssModuleGlobal('.a, #b .c{c:red}')).toBe(
+      ':global(.a){c:red}\n:global(#b .c){c:red}'
+    );
+  });
+
+  it('splits selector lists inside @media blocks', () => {
+    expect(
+      makeCssModuleGlobal(
+        '@media (min-width: 1px){.a::before, .a::after{c:red}}'
+      )
+    ).toBe(
+      '@media (min-width: 1px){:global(.a::before){c:red}\n:global(.a::after){c:red}}'
     );
   });
 
@@ -33,9 +52,11 @@ describe('makeCssModuleGlobal', () => {
     ).toBe(':global(.a){animation: spin 1s;}@keyframes spin{from{a:0}to{a:1}}');
   });
 
-  it('handles complex selectors', () => {
+  it('does not split on commas inside functions, attributes or strings', () => {
     expect(
-      makeCssModuleGlobal('.a:hover > .b, .c[data-x="y"]{color:red}')
-    ).toBe(':global(.a:hover > .b), :global(.c[data-x="y"]){color:red}');
+      makeCssModuleGlobal('.a:is(.b, .c), [data-x="y,z"], .d:hover > .e{c:red}')
+    ).toBe(
+      ':global(.a:is(.b, .c)){c:red}\n:global([data-x="y,z"]){c:red}\n:global(.d:hover > .e){c:red}'
+    );
   });
 });

--- a/packages/turbopack-loader/src/css-modules.ts
+++ b/packages/turbopack-loader/src/css-modules.ts
@@ -138,20 +138,15 @@ function splitSelectorList(selectorText: string) {
   return parts;
 }
 
-// Each member of a selector list is emitted as its own rule. lightningcss,
-// which Turbopack uses for CSS modules, resolves a wrapped list
-// `:global(a), :global(b)` into `:is(a, b)`, and that is not equivalent to the
-// list: pseudo-elements are not allowed inside `:is()` (browsers drop the whole
-// rule, so every `&::before, &::after { }` lost its declarations), and `:is()`
-// takes the specificity of its most specific argument, so `.a, #b .c` gives
-// `.a` id-level specificity and changes the cascade. Separate rules with the
-// same body are left alone by lightningcss and keep the source semantics.
+// One rule per list member: lightningcss folds `:global(a), :global(b)` into
+// `:is(a, b)` (parcel-bundler/lightningcss#1032, #1079, proposed fix #1231).
+// No separator: the source map appended in index.ts assumes one line per rule.
 function wrapRule(selectorText: string, blockBody: string) {
   return splitSelectorList(selectorText)
     .map((s) => s.trim())
     .filter(Boolean)
     .map((selector) => `:global(${selector}){${blockBody}}`)
-    .join('\n');
+    .join('');
 }
 
 function makeCssModuleGlobalInner(css: string) {

--- a/packages/turbopack-loader/src/css-modules.ts
+++ b/packages/turbopack-loader/src/css-modules.ts
@@ -138,12 +138,20 @@ function splitSelectorList(selectorText: string) {
   return parts;
 }
 
-function wrapSelector(selectorText: string) {
-  const selectors = splitSelectorList(selectorText)
+// Each member of a selector list is emitted as its own rule. lightningcss,
+// which Turbopack uses for CSS modules, resolves a wrapped list
+// `:global(a), :global(b)` into `:is(a, b)`, and that is not equivalent to the
+// list: pseudo-elements are not allowed inside `:is()` (browsers drop the whole
+// rule, so every `&::before, &::after { }` lost its declarations), and `:is()`
+// takes the specificity of its most specific argument, so `.a, #b .c` gives
+// `.a` id-level specificity and changes the cascade. Separate rules with the
+// same body are left alone by lightningcss and keep the source semantics.
+function wrapRule(selectorText: string, blockBody: string) {
+  return splitSelectorList(selectorText)
     .map((s) => s.trim())
-    .filter(Boolean);
-
-  return selectors.map((selector) => `:global(${selector})`).join(', ');
+    .filter(Boolean)
+    .map((selector) => `:global(${selector}){${blockBody}}`)
+    .join('\n');
 }
 
 function makeCssModuleGlobalInner(css: string) {
@@ -218,7 +226,7 @@ function makeCssModuleGlobalInner(css: string) {
       }
 
       const blockBody = css.slice(openIdx + 1, blockEndIdx);
-      out += `${wrapSelector(selectorText)}{${blockBody}}`;
+      out += wrapRule(selectorText, blockBody);
       idx = blockEndIdx + 1;
     }
   }


### PR DESCRIPTION
## Motivation

Fixes #417.

The loader wraps every member of a selector list in `:global()` for its
CSS-modules output. lightningcss (Turbopack's CSS engine) resolves
`:global(a), :global(b)` into `:is(a, b)`, and that is not equivalent to the
list:

- Pseudo-elements are not allowed inside `:is()`, so every
  `&::before, &::after { ... }` block became an invalid selector that browsers
  silently drop, declarations included. No build warning, no runtime error.
- `:is()` takes the specificity of its most specific argument, so lists with
  unequal members (`.a, #b .c`, `.a:hover, .b .c .d:hover`) changed the
  cascade for the less specific ones compared to the webpack loader output.

## Summary

`makeCssModuleGlobal` (`packages/turbopack-loader/src/css-modules.ts`) now
emits one `:global(selector){body}` rule per list member instead of a wrapped
list. lightningcss leaves separate rules separate (checked with and without
`minify`), so the browser receives `.a::before{...}` and `.a::after{...}` as
two valid rules, and every member keeps its own specificity. The body is
repeated per member; that is the cost of staying equivalent without parsing
selectors (a few percent more uncompressed CSS in a typical stylesheet, much
less after compression). A heuristic that only splits pseudo-element lists was
considered and rejected because it leaves the specificity change in place.

Changeset included (`@wyw-in-js/turbopack-loader`: patch).

## Test plan

Unit tests updated in `packages/turbopack-loader/src/__tests__/css-modules.test.ts`:

- a list becomes one rule per member (plain classes, `:before, :after`, `.a, #b .c`)
- the split also happens inside `@media`
- commas inside `:is()`, attribute values and strings are not split points
- single selectors and `@keyframes` handling unchanged

```sh
cd packages/turbopack-loader && bun test src   # 15 pass
bun run lint                                   # clean
```

Verified against lightningcss 1.32.0 in CSS-modules mode: the output of
`makeCssModuleGlobal` for each case above goes through `transform()` with
`minify: true` and comes out as separate rules, no `:is()`.

End-to-end: Next.js 16.3.3 app (`withWyw`, Turbopack), cleared Turbopack
cache. Before: the served CSS contained `:is(.x:before, .x:after) {...}` for
every `&::before, &::after` rule (absent from `document.styleSheets` in the
browser, pseudo-elements unstyled) and an `:is(...)` wrapper for every other
selector list. After: each list member is its own rule, the pseudo-element
rules apply again, and no `:is()` remains in the served CSS except ones
written in the source.
